### PR TITLE
Fixed domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
             const botConnection = new BotChat.DirectLine({
                 secret: params['s'],
                 token: params['t']
-                }, params["domain"]
+                }, params["domain"] //the domain should be the DL url https://directline.botframework.com/v3/directline
             );
 
             const user = {
@@ -47,7 +47,7 @@
                 botConnection,
                 user,
                 bot,
-//              allowMessagesFrom: ['http://localhost:8080']
+//              allowMessagesFrom: ['https://directline.botframework.com/v3/directline'] 
             }, document.getElementById("BotChatGoesHere"));
         </script>
     </body>


### PR DESCRIPTION
The Direct Line URL is more leading than the localhost one.
When I had to implement my custom webchat I found the 'domain' and 'allowMessagesFrom' fields quite confusing. It took me a while until I realized that the DL url should be placed there. And since most of us don't have the possibility to run DL locally it would be better for everyone if it just had the right one to begin with.