### PR TITLE
Added tag propperty to query string

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,8 @@
             
             var bot = {
                 id: params['botid'] || 'botid',
-                name: params["botname"] || 'botname'
+                name: params["botname"] || 'botname',
+                tag: params['tag']
             };
 
             BotChat.App({

--- a/src/BotConnection.ts
+++ b/src/BotConnection.ts
@@ -123,7 +123,8 @@ export type Attachment = Media | HeroCard | Thumbnail | Signin | Receipt | Audio
 export interface User {
     id: string,
     name?: string,
-    iconUrl?: string
+    iconUrl?: string,
+    tag?: string
 }
 
 export interface IActivity {

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -70,6 +70,14 @@ export class Chat extends React.Component<ChatProps, {}> {
         this.props.selectedActivity.next({ activity });
     }
 
+    private sendTag(props: ChatProps) {
+        if ( typeof props.bot.tag != 'undefined' && props.bot.tag != '') {
+            sendMessage(this.store, props.bot.tag);
+            props.bot.tag = null;
+        }
+        
+    }
+
     componentDidMount() {
         let props = this.props;
 
@@ -107,6 +115,8 @@ export class Chat extends React.Component<ChatProps, {}> {
         this.storeUnsubscribe = this.store.subscribe(() =>
             this.forceUpdate()
         );
+
+        this.sendTag(props);
     }
 
     componentWillUnmount() {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -33,6 +33,7 @@ export class DirectLine implements IBotConnection {
     private conversationId: string;
     private secret: string;
     private token: string;
+    private tag: string;
     private watermark = '';
     private streamUrl: string;
 


### PR DESCRIPTION
Hi,

In order use one bot on multiple websites, I need the bot to know from what site he was called. This way the bot does not need to ask the user this information.

The easiest way I found was to add a "tag" parameter to the URL querystring and have the WebChat UI send the string in this tag to the bot as soon as the connection is made. It is then up to the bot implementation to act upon this first message properly.

I am sending this pull request because I think more users could benefit from this change and the changes are minimal.

Example usage: http://localhost:8000/?s=[bot secret]&tag=makemeasandwhich

Please do let me know if you need more information or want something refactored?

Best regards,

Jhon