### PR TITLE
Don't render tax or total if not present

### DIFF
--- a/src/Attachment.tsx
+++ b/src/Attachment.tsx
@@ -138,14 +138,20 @@ export const AttachmentView = (props: {
                             </tr>) }
                         </tbody>
                         <tfoot>
-                            <tr>
-                                <td>{ props.format.strings.receiptTax }</td>
-                                <td>{ attachment.content.tax }</td>
-                            </tr>
-                            <tr className="total">
-                                <td>{ props.format.strings.receiptTotal }</td>
-                                <td>{ attachment.content.total }</td>
-                            </tr>
+                            { renderIfNonempty(
+                                attachment.content.tax,
+                                tax => <tr>
+                                    <td>{ props.format.strings.receiptTax }</td>
+                                    <td>{ attachment.content.tax }</td>
+                                </tr>)
+                            }
+                            { renderIfNonempty(
+                                attachment.content.total,
+                                total => <tr className="total">
+                                    <td>{ props.format.strings.receiptTotal }</td>
+                                    <td>{ attachment.content.total }</td>
+                                </tr>)
+                            }
                         </tfoot>
                     </table>
                 </div>


### PR DESCRIPTION
Closes #239 by not rendering the tax or total rows if not present. 

Example:
![screen shot 2017-01-06 at 4 17 11 pm](https://cloud.githubusercontent.com/assets/87996/21737516/6c21297c-d42e-11e6-841c-6193684a3a62.png)
