### PR TITLE
Subtitle + buttons on receipt card

### DIFF
--- a/botchat.css
+++ b/botchat.css
@@ -279,6 +279,14 @@
         max-width: 50px;
     }
 
+    .wc-card.receipt div.title {
+        font-weight: bolder;
+    }
+
+    .wc-card.receipt div.subtitle {
+        font-weight: lighter;
+    }
+
     .wc-card.receipt tbody tr, .wc-card.receipt tfoot tr {
         border-top: 1px solid #d2dde5;
     }

--- a/src/Attachment.tsx
+++ b/src/Attachment.tsx
@@ -175,7 +175,18 @@ export const AttachmentView = (props: {
                             <tr key={'item' + i}>
                                 <td>
                                     { item.image && <Media src={ item.image.url } onLoad={ props.onImageLoad } /> }
-                                    <span>{ item.title }</span>
+                                    { renderIfNonempty(
+                                        item.title,
+                                        title => <div className="title">
+                                            { item.title }
+                                        </div>)
+                                    }
+                                    { renderIfNonempty(
+                                        item.subtitle,
+                                        subtitle => <div className="subtitle">
+                                            { item.subtitle }
+                                        </div>)
+                                    }
                                 </td>
                                 <td>{ item.price }</td>
                             </tr>) }
@@ -197,6 +208,7 @@ export const AttachmentView = (props: {
                             }
                         </tfoot>
                     </table>
+                    { buttons(attachment.content.buttons, props.onClickButton) }
                 </div>
             );
 


### PR DESCRIPTION
- Adds button support for the receipt card
- Adds a subtitle for items in the receipt card
- Styles title/subtitle differently in the receipt card

Theoretically closes #235, but not entirely, as I can't figure out a way to render item descriptions without bloating the content of the card. Image below:

![screen shot 2017-01-17 at 4 36 30 pm](https://cloud.githubusercontent.com/assets/87996/22046450/9051881e-dcd5-11e6-8654-1d01d394652b.png)
