### PR TITLE
Add Dutch locale (nl-nl)

### DIFF
--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -69,6 +69,19 @@ const localizedStrings: LocalizedStrings = {
         timeSent: " в %1",
         consolePlaceholder: "Введите ваше сообщение..."
     },
+    'nl-nl': {
+        title: "Chat",
+        send: "Verstuur",
+        unknownFile: "[Bestand van het type '%1']",
+        unknownCard: "[Onbekende kaart '%1']",
+        receiptTax: "BTW",
+        receiptTotal: "Totaal",
+        messageRetry: "opnieuw",
+        messageFailed: "versturen mislukt",
+        messageSending: "versturen",
+        timeSent: " om %1",
+        consolePlaceholder: "Typ je bericht..."
+    },
     'lv-lv': {
         title: "Tērzēšana",
         send: "Sūtīt",
@@ -110,6 +123,8 @@ export const strings = (locale: string) => {
         locale = 'pl-pl';
     else if (locale.startsWith('ru'))
         locale = 'ru-ru';
+    else if (locale.startsWith('nl'))
+        locale = 'nl-nl';
     else if (locale.startsWith('lv'))
         locale = 'lv-lv';
     else if (locale.startsWith('pt'))


### PR DESCRIPTION
Add Dutch locale to Webchat.
This will also work for nl-be (Dutch - Belgium).