### PR TITLE
Add null check to ResizeDetector

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -58,7 +58,7 @@ export class Chat extends React.Component<ChatProps, {}> {
     private store = createStore();
 
     private botConnection: IBotConnection;
-    
+
     private activitySubscription: Subscription;
     private connectionStatusSubscription: Subscription;
     private selectedActivitySubscription: Subscription;
@@ -79,7 +79,7 @@ export class Chat extends React.Component<ChatProps, {}> {
         if (props.formatOptions)
             this.store.dispatch<ChatActions>({ type: 'Set_Format_Options', options: props.formatOptions });
         if (props.sendTyping)
-            this.store.dispatch<ChatActions>({ type: 'Set_Send_Typing', sendTyping: props.sendTyping });        
+            this.store.dispatch<ChatActions>({ type: 'Set_Send_Typing', sendTyping: props.sendTyping });
     }
 
     private handleIncomingActivity(activity: Activity) {
@@ -273,5 +273,8 @@ const ResizeDetector = (props: {
     // adapted to React from https://github.com/developit/simple-element-resize-detector
     <iframe
         style={ { position: 'absolute', left: '0', top: '-100%', width: '100%', height: '100%', margin: '1px 0 0', border: 'none', opacity: 0, visibility: 'hidden', pointerEvents: 'none' } }
-        ref={ frame => frame.contentWindow.onresize = props.onresize }
+        ref={ frame => {
+            if (frame)
+                frame.contentWindow.onresize = props.onresize;
+        } }
     />;


### PR DESCRIPTION
In the emulator I'm seeing null-ref exceptions from the WebChat control coming from the ResizeDetector. The reason is: sometimes the value of `frame` is null in the iframe's `ref` handler. I can only speculate the reason, but once this happens, the emulator stops functioning. This null check makes the emulator work correctly.