### PR TITLE
Use rimraf package instead of rm -rf commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "scripts": {
     "build-test": "tsc -p ./test/mock_dl && tsc -p ./test",
     "build-test-watch": "concurrently \"tsc -w -p ./test/mock_dl\" \"tsc -w -p ./test\"",
-    "build-css": "node-sass ./src/scss/ -o . && rm -rf ./includes/",
+    "build-css": "node-sass ./src/scss/ -o . && rimraf ./includes/",
     "build-css-watch": "node-sass ./src/scss/ -o . -w",
     "build": "tsc && npm run build-css && webpack --progress",
     "watch": "npm-run-all -p -r -l tsc-watch webpack-watch build-css-watch",
     "tsc-watch": "tsc -w",
     "webpack-watch": "webpack --progress --watch",
-    "clean": "rm -rf built",
+    "clean": "rimraf built",
     "prepublish": "tsc && npm run build-css && webpack --progress --config webpack.production.config.js",
     "start": "http-server -p 8000",
     "test": "concurrently  \"node test/mock_dl/index.js\" \"mocha test\" "
@@ -34,6 +34,7 @@
     "react-redux": "^5.0.3",
     "redux": "^3.6.0",
     "redux-observable": "^0.13.0",
+    "rimraf": "^2.6.1",
     "rxjs": "^5.3.0",
     "tslib": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-redux": "^5.0.3",
     "redux": "^3.6.0",
     "redux-observable": "^0.13.0",
-    "rimraf": "^2.6.1",
     "rxjs": "^5.3.0",
     "tslib": "^1.6.0",
     "typescript": "2.3"
@@ -71,6 +70,7 @@
     "nodemon": "^1.11.0",
     "npm-run-all": "^3.1.2",
     "remote": "^0.2.6",
+    "rimraf": "^2.6.1",
     "source-map-loader": "^0.2.1",
     "typescript": "2.2.2",
     "vo": "^4.0.2",


### PR DESCRIPTION
Update the build-css and clean commands to be cross-platform capable rather than UNIX specific. Changed to use "rimraf" rather than "rm -rf".