### PR TITLE
Update readme

### DIFF
--- a/src/Attachment.tsx
+++ b/src/Attachment.tsx
@@ -305,7 +305,7 @@ export const AttachmentView = (props: {
 
         case "audio/mpeg":
         case "audio/mp4":
-            return <Media type='video' src={ attachment.contentUrl } onLoad={ props.onImageLoad } />;
+            return <Media type='audio' src={ attachment.contentUrl } />;
 
         case "video/mp4":
             return <Media type='video' poster={ attachment.thumbnailUrl } src={ attachment.contentUrl } onLoad={ props.onImageLoad } />;

--- a/src/Attachment.tsx
+++ b/src/Attachment.tsx
@@ -305,10 +305,10 @@ export const AttachmentView = (props: {
 
         case "audio/mpeg":
         case "audio/mp4":
-            return <Media type='audio' src={ attachment.contentUrl } />;
+            return <Media type='video' src={ attachment.contentUrl } onLoad={ props.onImageLoad } />;
 
         case "video/mp4":
-            return <Media type='video' src={ attachment.contentUrl } onLoad={ props.onImageLoad } />;
+            return <Media type='video' poster={ attachment.thumbnailUrl } src={ attachment.contentUrl } onLoad={ props.onImageLoad } />;
 
         default:
             return <Unknown format={ props.format } contentType={ (attachment as any).contentType } contentUrl={ (attachment as any).contentUrl } name={ (attachment as any).name } />;

--- a/test/README.md
+++ b/test/README.md
@@ -66,7 +66,9 @@ The mock server will now automatically serve dummy data to the web chat instance
 * Always run __"npm run build-test"__ prior to any testing processes.
 * Keep in mind that if mock server and [Nightmare.js](http://www.Nightmare.js.org/) / [Mocha.js](https://mochajs.org/) tests are both running separately, the mock server will occupy one terminal (process), tests will run from another terminal (process). If the mock server is interrupted, closed, killed, or force closed, the tests will fail intermediately.
 > * __"npm run build-test-watch"__ will monitor file-system changes to perform automatic rebuilds, but the watch system will occupy a separate process thread on its own.
-> * While running [Nightmare.js](http://www.Nightmare.js.org/), press **Ctrl + C** to cancel it at any time during the process.
+* While running [Nightmare.js](http://www.Nightmare.js.org/), press **Ctrl + C** to cancel it at any time during the process.
+* While running [Nightmare.js](http://www.Nightmare.js.org/), make sure you do not have other processes or browser tabs / windows / processes are opening the same __localhost:3000__ url, otherwise tests will run into state of confusion by not knowing which browser instance to interact with. It will lead to inconsistent test results or test failures.
+* Due to browser resource management constrains, while running [Nightmare.js] (http://www.Nightmare.js.org/) please do not minimize your browser window. It will pause browser activities, which would lead to test failures as well.
 
 ## Example - Write a "Hello World" test 
 

--- a/test/README.md
+++ b/test/README.md
@@ -66,9 +66,7 @@ The mock server will now automatically serve dummy data to the web chat instance
 * Always run __"npm run build-test"__ prior to any testing processes.
 * Keep in mind that if mock server and [Nightmare.js](http://www.Nightmare.js.org/) / [Mocha.js](https://mochajs.org/) tests are both running separately, the mock server will occupy one terminal (process), tests will run from another terminal (process). If the mock server is interrupted, closed, killed, or force closed, the tests will fail intermediately.
 > * __"npm run build-test-watch"__ will monitor file-system changes to perform automatic rebuilds, but the watch system will occupy a separate process thread on its own.
-* While running [Nightmare.js](http://www.Nightmare.js.org/), press **Ctrl + C** to cancel it at any time during the process.
-* While running [Nightmare.js](http://www.Nightmare.js.org/), make sure you do not have other processes or browser tabs / windows / processes are opening the same __localhost:3000__ url, otherwise tests will run into state of confusion by not knowing which browser instance to interact with. It will lead to inconsistent test results or test failures.
-* Due to browser resource management constrains, while running [Nightmare.js] (http://www.Nightmare.js.org/) please do not minimize your browser window. It will pause browser activities, which would lead to test failures as well.
+> * While running [Nightmare.js](http://www.Nightmare.js.org/), press **Ctrl + C** to cancel it at any time during the process.
 
 ## Example - Write a "Hello World" test 
 

--- a/test/commands_map.ts
+++ b/test/commands_map.ts
@@ -201,6 +201,22 @@ var commands_map: CommandValuesMap = {
             sendActivity(res, server_content.receipt_card);
         }
     },
+    "video": {
+        client: function () {
+            return true;
+        },
+        server: function (res, sendActivity) {
+            sendActivity(res, server_content.video );
+        }
+    },
+    "videocard": {
+        client: function () {
+            return true;
+        },
+        server: function (res, sendActivity) {
+            sendActivity(res, server_content.video_card );
+        }
+    },
     "card Weather": {
         client: function () {
             var source = document.querySelectorAll('img')[0].src;

--- a/test/mock_dl/index.ts
+++ b/test/mock_dl/index.ts
@@ -27,7 +27,7 @@ const simpleCard = {
 };
 
 const get_token = (req: express.Request) =>
-    (req.headers["authorization"] || "works/all").split(" ")[1];
+    (req.header("authorization") || "works/all").split(" ")[1];
 
 const sendExpiredToken = (res: express.Response) => {
     res.status(403).send({ error: { code: "TokenExpired" } });

--- a/test/server_content.ts
+++ b/test/server_content.ts
@@ -312,3 +312,48 @@ export var receipt_card: dl.Message = {
     attachmentLayout: "carousel",
     attachments: [receipt_attach]
 }
+
+export var video: dl.Message = {
+    type: "message",
+    from: bot,
+    timestamp: new Date().toUTCString(),
+    channelId: "webchat",
+    text: "",
+    attachments: [
+        {
+            contentType: "video/mp4",
+            contentUrl: "https://testbot.botframework.com/media/thenewmicrosoftsurfacebook.mp4",
+            name: "The New Microsoft Surface Book",
+            thumbnailUrl: "https://testbot.botframework.com/media/surface_thumb.jpg"
+        }
+    ]
+}
+
+export var video_card: dl.Message = {
+    type: "message",
+    from: bot,
+    timestamp: new Date().toUTCString(),
+    channelId: "webchat",
+    text: "",
+    attachments: [
+        {
+            contentType: "application/vnd.microsoft.card.video",
+            content: {
+                title: "Microsoft Band",
+                subtitle: "Large Video",
+                text: "No Image, No Buttons, Autostart, Autoloop, Sharable",
+                image: {
+                    url: "https://testbot.botframework.com/media/ms-band1.jpg"
+                },
+                media: [
+                    {
+                        url: "https://testbot.botframework.com/media/thenewmicrosoftband2_mid.mp4"
+                    }
+                ],
+                shareable: true,
+                autoloop: true,
+                autostart: true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Request from @reyesrico . A tip or warning to user who are seeing test failures due to:

1) conflict tabs/windows/processes racing condition to the mock server on port 3000. It will result inconstant test results or test failures.

2) while running electron, minimize the window would cause browser process kick into pause state, hence, interrupt the test process, will always return false.