### PR TITLE
Fix #577 Bump package-lock.json to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/body-parser": {
@@ -492,9 +492,9 @@
       "dev": true
     },
     "botframework-directlinejs": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.9.7.tgz",
-      "integrity": "sha1-7IrFCMHTlPU2h0bKP5hqYt9hEs8="
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.9.8.tgz",
+      "integrity": "sha1-JRTGamKTFcqrSss50hHW26R28fQ="
     },
     "brace-expansion": {
       "version": "1.1.8",


### PR DESCRIPTION
Fix for #577 build break on npm 5.

Bump `package-lock.json`:

* `botframework-webchat` from `@0.10.8` to `@0.11.0`
* `botframework-directlinejs` from `@0.9.7` to `@0.9.8`

No `npm publish` is needed as `package-lock.json` won't got to npm. It should [only live on GitHub](https://docs.npmjs.com/files/package-locks).

Excerpt from the doc:

> It is highly recommended you commit the generated package lock to source control: this will allow anyone else on your team, your deployments, your CI/continuous integration, and anyone else who runs npm install in your package source to get the exact same dependency tree that you were developing on. Additionally, the diffs from these changes are human-readable and will inform you of any changes npm has made to your node_modules, so you can notice if any transitive dependencies were updated, hoisted, etc.
