### PR TITLE
Mocha done() should be called with an Error object

### DIFF
--- a/test/uitest.js
+++ b/test/uitest.js
@@ -69,7 +69,7 @@ describe('nightmare UI tests', function () {
 			return result;
 		}
 
-		//Testing devices and commands 
+		//Testing devices and commands
 		function* testAllCommands() {
 			let success = true;
 
@@ -104,7 +104,12 @@ describe('nightmare UI tests', function () {
 		}
 
 		vo(testAllCommands)(function (err, success) {
-			done(!success);
+			// When test failed, err is string instead of Error
+			if (err || !success) {
+				done(new Error(err || 'one or more tests failed'));
+			} else {
+				done();
+			}
 		});
 	});
 });


### PR DESCRIPTION
When test failed, currently, Mocha will complain `Error: done() invoked with non-Error: true`. We should return an Error object for that.

![image](https://user-images.githubusercontent.com/1622400/30141111-e6854e0a-932d-11e7-908f-e1a39eed8e98.png)
