### PR TITLE
Update rxjs to 5.4.3 to avoid TypeScript issues with strict generic checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-redux": "5.0.5",
     "redux": "3.7.2",
     "redux-observable": "0.13.0",
-    "rxjs": "5.3.3",
+    "rxjs": "5.4.3",
     "tslib": "1.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
See: https://github.com/ReactiveX/rxjs/issues/2705

Basically any project using TypeScript 2.4+ consuming bot-webchat would require `noStrictNullChecks` to avoid compilation issues since bot-webchat uses a older version rxjs. Updating rxjs to 5.4.3 should be non breaking change and would also avoid this issue in consuming projects.