### PR TITLE
Updating brand color for more contrast ratio

### DIFF
--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -10,7 +10,7 @@
     }
 
     .wc-app button {
-        background-color: $c06;
+        background-color: $c_brand;
         border: 1px solid $c05;
         border-radius: 1px;
         color: $c01;
@@ -253,7 +253,7 @@
 
     .wc-message-from {
         clear: both;
-        color: $c_textLight;
+        color: $c_timestamp;
         font-size: 11px;
         margin-top: 5px;
     }
@@ -623,45 +623,55 @@
                 width: 26px;
             }
         }
+    .wc-send {
+        right: 0;
+    }
 
-        .wc-textbox {
-            bottom: 0;
-            left: 48px;
-            right: 49px;
+    .wc-send.hidden {
+        visibility: hidden
+    }
 
-            input {
-                background-color: transparent;
-            }
-        }
+    .wc-textbox {
+        bottom: 0;
+        left: 48px;
+        right: 49px;
 
-        .wc-mic,
-        .wc-send {
+        input {
             background-color: transparent;
-            border: 0;
-            padding: 0;
-            right: 0;
+        }
+    }
 
-            &.hidden {
-                visibility: hidden;
-            }
+    .wc-mic,
+    .wc-send {
+        background-color: transparent;
+        border: 0;
+        padding: 0;
+        right: 0;
+
+        &.hidden {
+            visibility: hidden;
+        }
+    }
+
+    .wc-send {
+        svg {
+            height: 18px;
+            width: 27px;
+        }
+    }
+
+    .wc-mic {
+        &.active path#micFilling {
+            fill:rgb(78, 55, 135)
         }
 
-        .wc-send {
-            svg {
-                height: 18px;
-                width: 27px;
-            }
+        &.inactive path#micFilling {
+            visibility: hidden;
         }
+    }
 
-        .wc-mic {
-            &.active path#micFilling {
-                fill:rgb(78, 55, 135)
-            }
-
-            &.inactive path#micFilling {
-                visibility: hidden;
-            }
-        }
+    .wc-console.has-text .wc-send svg {
+        fill: $c07;
     }
 
 /* animation */
@@ -758,11 +768,11 @@
         }
 
         &:hover {
-            @include link-and-svg-arrow($c07, 1);
+            @include link-and-svg-arrow($c_brand, 1);
         }
 
         &:active {
-            @include link-and-svg-arrow($c06, 1);
+            @include link-and-svg-arrow($c_brand, 0.8);
         }
     }
 

--- a/src/scss/includes/colors.scss
+++ b/src/scss/includes/colors.scss
@@ -5,13 +5,13 @@ $c02: rgba(0, 0, 0, 0.2);
 $c03: #8a8a8a;
 $c04: #999999;
 $c05: #cccccc;
-$c06: #0063b1;
-$c07: #3a96dd;
+$c07: #0078d7;
 $c08: #808c95;
 $c09: #eceff1;
 $c10: #dbdee1;
 $c11: #d2dde5;
 $c12: #ffa333;
+$c13: #767676; // used for timestamp under chat bubbles
 
 $c_brand: $c07;
 $c_shadow: $c02;
@@ -19,5 +19,6 @@ $c_chrome: $c10;
 $c_textHeading: $c08;
 $c_textLight: $c04;
 
-$c_messageFromMe: $c07;
+$c_messageFromMe: $c_brand;
 $c_messageFromThem: $c09;
+$c_timestamp: $c13;

--- a/src/scss/includes/colors.scss
+++ b/src/scss/includes/colors.scss
@@ -5,13 +5,13 @@ $c02: rgba(0, 0, 0, 0.2);
 $c03: #8a8a8a;
 $c04: #999999;
 $c05: #cccccc;
+$c06: #767676; // used for timestamp under chat bubbles
 $c07: #0078d7;
 $c08: #808c95;
 $c09: #eceff1;
 $c10: #dbdee1;
 $c11: #d2dde5;
 $c12: #ffa333;
-$c13: #767676; // used for timestamp under chat bubbles
 
 $c_brand: $c07;
 $c_shadow: $c02;
@@ -21,4 +21,4 @@ $c_textLight: $c04;
 
 $c_messageFromMe: $c_brand;
 $c_messageFromThem: $c09;
-$c_timestamp: $c13;
+$c_timestamp: $c06;


### PR DESCRIPTION
# Updating brand color

To match 4.5:1 contrast ratio, the following colors were updated:

* Update brand color
* Update timestamp color
* Remove `$c06` because it was not longer used

![image](https://user-images.githubusercontent.com/1622400/31689585-be2d4016-b344-11e7-9e7b-5443dda82cb6.png)
