### PR TITLE
Enable override locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,6 @@ You can alter or add localized strings in [/src/Strings.ts](src/Strings.ts):
 * Add logic to map the requested locale to the supported locale in `strings`
 * Please help the community by submitting a [pull request](https://github.com/Microsoft/BotFramework-WebChat/pulls).
 
-You can specify locale to use in your website depends on your usage:
-
-* IFRAME: append `&locale=en-us` in query string
-* Inline JavaScript: add `{ locale: 'en-us' }` to options in `BotChat.App()` call
-* React: add `locale="en-us"` as a props to `<Chat>` component
-
 ### Behaviors
 
 Behavioral customization will require changing the TypeScript files in `/src`. A full description of the architecture of Web Chat is beyond the scope of this document, but here are a few starters:

--- a/README.md
+++ b/README.md
@@ -166,11 +166,17 @@ Web Chat strives to use responsive design when possible. As part of this, Web Ch
 
 ### Strings
 
-You can alter or add localized strings in `/src/Strings.ts`:
+You can alter or add localized strings in [/src/Strings.ts](src/Strings.ts):
 
 * Add one or more locales (with associated localized strings) to `localizedStrings`
 * Add logic to map the requested locale to the supported locale in `strings`
 * Please help the community by submitting a [pull request](https://github.com/Microsoft/BotFramework-WebChat/pulls).
+
+You can specify locale to use in your website depends on your usage:
+
+* IFRAME: append `&locale=en-us` in query string
+* Inline JavaScript: add `{ locale: 'en-us' }` to options in `BotChat.App()` call
+* React: add `locale="en-us"` as a props to `<Chat>` component
 
 ### Behaviors
 

--- a/samples/backchannel/index.html
+++ b/samples/backchannel/index.html
@@ -83,8 +83,8 @@
       BotChat.App({
         bot: bot,
         botConnection: botConnection,
-        user: user,
         // locale: 'es-es', // override locale to Spanish
+        user: user
       }, document.getElementById('BotChatGoesHere'));
 
       botConnection.activity$

--- a/samples/backchannel/index.html
+++ b/samples/backchannel/index.html
@@ -83,7 +83,7 @@
       BotChat.App({
         bot: bot,
         botConnection: botConnection,
-        user: user
+        user: user,
         // locale: 'es-es', // override locale to Spanish
       }, document.getElementById('BotChatGoesHere'));
 

--- a/samples/backchannel/index.html
+++ b/samples/backchannel/index.html
@@ -84,6 +84,7 @@
         bot: bot,
         botConnection: botConnection,
         user: user
+        // locale: 'es-es', // override locale to Spanish
       }, document.getElementById('BotChatGoesHere'));
 
       botConnection.activity$

--- a/samples/fullwindow/index.html
+++ b/samples/fullwindow/index.html
@@ -55,6 +55,7 @@
         resize: 'window',
         // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
         user: user,
+        // locale: 'es-es', // override locale to Spanish
 
         directLine: {
           secret: params['s'],

--- a/samples/sidebar/index.html
+++ b/samples/sidebar/index.html
@@ -101,7 +101,7 @@
         resize: 'detect',
         // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
         user: user,
-        locale: 'es-es', // override locale to Spanish
+        // locale: 'es-es', // override locale to Spanish
 
         directLine: {
           domain: params['domain'],

--- a/samples/sidebar/index.html
+++ b/samples/sidebar/index.html
@@ -101,6 +101,7 @@
         resize: 'detect',
         // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
         user: user,
+        locale: 'es-es', // override locale to Spanish
 
         directLine: {
           domain: params['domain'],

--- a/samples/speech/index.html
+++ b/samples/speech/index.html
@@ -138,6 +138,7 @@
         // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
         speechOptions: speechOptions,
         user: user,
+        // locale: 'es-es', // override locale to Spanish
 
         directLine: {
           domain: params['domain'],


### PR DESCRIPTION
Locale was grabbed from `navigator`. Instructions added on how to override default locale.