### PR TITLE
Removed the article before the timesent

### DIFF
--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -225,7 +225,7 @@ const localizedStrings: LocalizedStrings = {
         messageRetry: "riprova",
         messageFailed: "impossibile inviare",
         messageSending: "invio",
-        timeSent: " il %1",
+        timeSent: " %1",
         consolePlaceholder: "Scrivi il tuo messaggio...",
         listeningIndicator: "Ascoltando..."
     },


### PR DESCRIPTION
#763 the article "il" in italian doesn't work for time. It should be "alle" or "all'" depending on the time, better to just remove it.