### PR TITLE
Fix #287 Put input[type="file"] outside of label

### DIFF
--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -113,23 +113,24 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
             <div className={ className }>
                 <label
                     className="wc-upload"
+                    htmlFor="wc-upload-input"
                     onKeyPress={ evt => this.handleUploadButtonKeyPress(evt) }
                     tabIndex={ 0 }
                 >
                     <svg>
                         <path d="M19.96 4.79m-2 0a2 2 0 0 1 4 0 2 2 0 0 1-4 0zM8.32 4.19L2.5 15.53 22.45 15.53 17.46 8.56 14.42 11.18 8.32 4.19ZM1.04 1L1.04 17 24.96 17 24.96 1 1.04 1ZM1.03 0L24.96 0C25.54 0 26 0.45 26 0.99L26 17.01C26 17.55 25.53 18 24.96 18L1.03 18C0.46 18 0 17.55 0 17.01L0 0.99C0 0.45 0.47 0 1.03 0Z" />
                     </svg>
-                    <input
-                        id="wc-upload-input"
-                        tabIndex={ -1 }
-                        type="file"
-                        ref={ input => this.fileInput = input }
-                        multiple
-                        onChange={ () => this.onChangeFile() }
-                        aria-label={ this.props.strings.uploadFile }
-                        role="button"
-                    />
                 </label>
+                <input
+                    id="wc-upload-input"
+                    tabIndex={ -1 }
+                    type="file"
+                    ref={ input => this.fileInput = input }
+                    multiple
+                    onChange={ () => this.onChangeFile() }
+                    aria-label={ this.props.strings.uploadFile }
+                    role="button"
+                />
                 <div className="wc-textbox">
                     <input
                         type="text"

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -608,21 +608,21 @@
             cursor: pointer;
             position: relative;
 
-            input[type="file"] {
-                font-size: 0;
-                height: 0;
-                left: 0;
-                opacity: 0;
-                outline: 0;
-                position: absolute;
-                top: 0;
-                width: 0;
-            }
-
             svg {
                 height: 18px;
                 width: 26px;
             }
+        }
+
+        #wc-upload-input {
+            font-size: 0;
+            height: 0;
+            left: 0;
+            opacity: 0;
+            outline: 0;
+            position: absolute;
+            top: 0;
+            width: 0;
         }
 
         .wc-send {


### PR DESCRIPTION
Fix #287

Edge 14 fail to close file upload dialog when `<input type="file">` is inside `<label>`.