### PR TITLE
Move @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "author": "Microsoft Corp",
   "license": "MIT",
   "dependencies": {
-    "@types/react": "15.0.38",
     "botframework-directlinejs": "0.9.13",
     "core-js": "2.4.1",
     "markdown-it": "8.3.1",
@@ -44,6 +43,7 @@
     "tslib": "1.7.1"
   },
   "devDependencies": {
+    "@types/react": "15.0.38",
     "@types/chai": "3.4.34",
     "@types/chai-subset": "1.0.29",
     "@types/deep-freeze": "0.0.29",


### PR DESCRIPTION
Prevents compile error when using different version of react