### PR TITLE
Fixes a WebPack production config reference

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -35,7 +35,7 @@ var coreConfig = {
                 exclude: [/node_modules/]
             },
             {
-                test: require.resolve('microsoft-adaptivecards'),
+                test: require.resolve('adaptivecards'),
                 use: [{ loader: 'expose-loader', options: 'AdaptiveCards' }]
             }
         ]


### PR DESCRIPTION
This fixes what currently fails `npm run build` in `adaptivecards-1.0` branch 

_Note:_ this applies to `adaptivecards-1.0` branch 