### PR TITLE
Customizable title

### DIFF
--- a/src/BotChat.ts
+++ b/src/BotChat.ts
@@ -4,7 +4,6 @@ export * from 'botframework-directlinejs';
 export { queryParams } from './Attachment';
 export { SpeechOptions } from './SpeechOptions'
 export { Speech } from './SpeechModule'
-import { FormatOptions } from './Types';
 // below are shims for compatibility with old browsers (IE 10 being the main culprit)
 import 'core-js/modules/es6.string.starts-with';
 import 'core-js/modules/es6.array.find';

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Deprecations
+
+## "formatOptions.showHeader" is deprecated, use "chatTitle" instead
+
+`formatOptions` is a prop that contains `showHeader` only. The `showHeader` is a boolean flag that show/hide the chat title.
+
+Customizable chat title is a [popular](https://github.com/Microsoft/BotFramework-WebChat/issues/754) [ask](https://github.com/Microsoft/BotFramework-WebChat/pull/810), thus, we added it. But instead of using the original `showHeader`, which literally means a boolean. We added `chatTitle` instead. Since `formatOptions` contains only one option `showHeader`, we are deprecating `formatOptions` together.
+
+You can set `chatTitle` to `true` (a default localized chat title), `false` (hide chat title), or a string of your preferred chat title.

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -75,7 +75,7 @@ export class Chat extends React.Component<ChatProps, {}> {
         let { chatTitle } = props;
 
         if (props.formatOptions) {
-            console.warn('DEPRECATED: "formatOptions.showHeader" is deprecated, use "chatTitle" instead. See https://github.com/Microsoft/BotFramework-WebChat/blob/master/CHANGELOG.md#formatoptions-showheader-is-deprecated-use-chattitle-instead.');
+            console.warn('DEPRECATED: "formatOptions.showHeader" is deprecated, use "chatTitle" instead. See https://github.com/Microsoft/BotFramework-WebChat/blob/master/CHANGELOG.md#formatoptionsshowheader-is-deprecated-use-chattitle-instead.');
 
             if (typeof props.formatOptions.showHeader !== 'undefined' && typeof props.chatTitle === 'undefined') {
                 chatTitle = props.formatOptions.showHeader;

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -74,6 +74,14 @@ export class Chat extends React.Component<ChatProps, {}> {
         this.store.dispatch<ChatActions>({ type: 'Toggle_Upload_Button', showUploadButton: props.showUploadButton });
 
         if (props.formatOptions) {
+            if (typeof props.formatOptions.showHeader !== 'undefined') {
+                console.warn('DEPRECATED: "formatOptions.showHeader" is deprecated, use "formatOptions.title" instead');
+
+                if (typeof props.formatOptions.title === 'undefined') {
+                    props.formatOptions.title = props.formatOptions.showHeader;
+                }
+            }
+
             this.store.dispatch<ChatActions>({ type: 'Set_Format_Options', options: props.formatOptions });
         }
 
@@ -243,9 +251,9 @@ export class Chat extends React.Component<ChatProps, {}> {
 
         // only render real stuff after we know our dimensions
         let header: JSX.Element;
-        if (state.format.options.showHeader) header =
+        if (state.format.options.title) header =
             <div className="wc-header">
-                <span>{ state.format.strings.title }</span>
+                <span>{ typeof state.format.options.title === 'string' ? state.format.options.title : state.format.strings.title }</span>
             </div>;
 
         let resize: JSX.Element;

--- a/src/History.tsx
+++ b/src/History.tsx
@@ -157,7 +157,7 @@ export class HistoryView extends React.Component<HistoryProps, {}> {
             }
         }
 
-        const groupsClassName = classList('wc-message-groups', !this.props.format.options.showHeader && 'no-header');
+        const groupsClassName = classList('wc-message-groups', !this.props.format.options.title && 'no-header');
 
         return (
             <div

--- a/src/History.tsx
+++ b/src/History.tsx
@@ -157,7 +157,7 @@ export class HistoryView extends React.Component<HistoryProps, {}> {
             }
         }
 
-        const groupsClassName = classList('wc-message-groups', !this.props.format.options.title && 'no-header');
+        const groupsClassName = classList('wc-message-groups', !this.props.format.chatTitle && 'no-header');
 
         return (
             <div

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -176,7 +176,7 @@ export const format: Reducer<FormatState> = (
     state: FormatState = {
         locale: 'en-us',
         options: {
-            showHeader: true
+            title: true
         },
         showUploadButton: true,
         strings: defaultStrings,

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -2,7 +2,7 @@ import { Activity, ConnectionStatus, IBotConnection, Media, MediaType, Message, 
 import { strings, defaultStrings, Strings } from './Strings';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Speech } from './SpeechModule';
-import { ActivityOrID, FormatOptions } from './Types';
+import { ActivityOrID } from './Types';
 import { HostConfig } from 'adaptivecards';
 import * as konsole from './Konsole';
 
@@ -151,16 +151,16 @@ export const shell: Reducer<ShellState> = (
 }
 
 export interface FormatState {
+    chatTitle: boolean | string,
     locale: string,
-    options: FormatOptions,
     showUploadButton: boolean,
     strings: Strings,
     carouselMargin: number
 }
 
 export type FormatAction = {
-    type: 'Set_Format_Options',
-    options: FormatOptions,
+    type: 'Set_Chat_Title',
+    chatTitle: boolean | string
 } | {
     type: 'Set_Locale',
     locale: string
@@ -174,10 +174,8 @@ export type FormatAction = {
 
 export const format: Reducer<FormatState> = (
     state: FormatState = {
+        chatTitle: true,
         locale: 'en-us',
-        options: {
-            title: true
-        },
         showUploadButton: true,
         strings: defaultStrings,
         carouselMargin: undefined
@@ -185,13 +183,10 @@ export const format: Reducer<FormatState> = (
     action: FormatAction
 ) => {
     switch (action.type) {
-        case 'Set_Format_Options':
+        case 'Set_Chat_Title':
             return {
                 ...state,
-                options: {
-                    ...state.options,
-                    ...action.options
-                }
+                chatTitle: typeof action.chatTitle === 'undefined' ? true : action.chatTitle
             };
         case 'Set_Locale':
             return {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,7 +1,8 @@
 import { Activity } from 'botframework-directlinejs';
 
 export interface FormatOptions {
-    showHeader?: boolean
+    showHeader?: boolean // DEPRECATED: Use "title" instead
+    title?: boolean | string
 }
 
 export type ActivityOrID = {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,7 +2,6 @@ import { Activity } from 'botframework-directlinejs';
 
 export interface FormatOptions {
     showHeader?: boolean // DEPRECATED: Use "title" instead
-    title?: boolean | string
 }
 
 export type ActivityOrID = {

--- a/test/commands_map.ts
+++ b/test/commands_map.ts
@@ -47,27 +47,33 @@ var commands_map: CommandValuesMap = {
             return top === 0;
         }
     },
-    "options.showHeader=default": {
-        client: function () {
-            var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
-            return top > 0;
-        }
-    },
     "options.title=false": {
-        urlAppend: { "formatOptions": { title: false } },
+        urlAppend: { title: false },
         client: function () {
             var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
             return top === 0;
         }
     },
-    "options.title=default": {
+    "options.title=undefined": {
         client: function () {
             var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
             return top > 0;
         }
     },
     "options.title=custom": {
-        urlAppend: { "formatOptions": { title: 'Hello, World!' } },
+        urlAppend: { title: 'Hello, World!' },
+        client: function () {
+            var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
+            var text = document.querySelector('.wc-header').textContent;
+            return top > 0 && text === 'Hello, World!';
+        }
+    },
+    "set title on-the-fly": {
+        do: function (nightmare) {
+            nightmare.evaluate(() => {
+                window['WebChatTest'].setChatTitle('Hello, World!');
+            });
+        },
         client: function () {
             var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
             var text = document.querySelector('.wc-header').textContent;

--- a/test/commands_map.ts
+++ b/test/commands_map.ts
@@ -53,6 +53,27 @@ var commands_map: CommandValuesMap = {
             return top > 0;
         }
     },
+    "options.title=false": {
+        urlAppend: { "formatOptions": { title: false } },
+        client: function () {
+            var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
+            return top === 0;
+        }
+    },
+    "options.title=default": {
+        client: function () {
+            var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
+            return top > 0;
+        }
+    },
+    "options.title=custom": {
+        urlAppend: { "formatOptions": { title: 'Hello, World!' } },
+        client: function () {
+            var top = document.querySelector('.wc-message-groups').getClientRects()[0].top;
+            var text = document.querySelector('.wc-header').textContent;
+            return top > 0 && text === 'Hello, World!';
+        }
+    },
     "animation": {
         client: function () {
             var source = document.querySelectorAll('img')[0].src;

--- a/test/test.html
+++ b/test/test.html
@@ -74,6 +74,7 @@
               id: params['botid'] || 'botid',
               name: params['botname'] || 'botname'
             },
+            chatTitle: params['title'] !== 'false' && params['title'],
             directLine: {
               domain: params['domain'],
               secret: params['s'],
@@ -113,6 +114,7 @@
                 }
               }));
             },
+            setChatTitle: chatTitle => this.setState(() => ({ chatTitle })),
             toggleUploadButton: show => {
               this.setState(state => ({
                 showUploadButton: typeof show === 'boolean' ? show : !state.showUploadButton
@@ -127,6 +129,7 @@
               <BotChat.Chat
                 adaptiveCardsHostConfig={ this.state.adaptiveCardsHostConfig }
                 bot={ this.state.bot }
+                chatTitle={ this.state.chatTitle }
                 directLine={ this.state.directLine }
                 formatOptions={ this.state.formatOptions }
                 locale={ this.state.locale }


### PR DESCRIPTION
Credit @shade33 for the original PR #810.

Instead of having two props `showHeader?: boolean` and `title?: string`. We prefer a single one named `title?: boolean | string`.

Rule for `title`:
- `undefined` or `true` is passed, we will show the header with default text (locale-sensitive)
- `false` (or falsy except `undefined`) is passed, we will remove the header
- a string is passed, we will show the header with the text

A deprecation warning on `formatOptions` and `showHeader` is added.