### PR TITLE
Inline TS sources and enable sourcemap for uglify

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "botchat-fullwindow.css",
     "botchat.css",
     "botchat.js",
-    "CognitiveServices.js"
+    "botchat.js.map",
+    "CognitiveServices.js",
+    "CognitiveServices.js.map"
   ]
 }

--- a/test/mock_dl/index.ts
+++ b/test/mock_dl/index.ts
@@ -347,6 +347,9 @@ app.get('/', function (req, res) {
 app.get('/botchat.js', function (req, res) {
     res.sendFile(path.join(__dirname + "/../../botchat.js"));
 });
+app.get('/botchat.js.map', function (req, res) {
+    res.sendFile(path.join(__dirname + "/../../botchat.js.map"));
+});
 app.get('/botchat.css', function (req, res) {
     res.sendFile(path.join(__dirname + "/../../botchat.css"));
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "noImplicitAny": true,
         "outDir": "./built/",
         "target": "es5",
-        "sourceMap": true
+        "sourceMap": true,
+        "inlineSources": true
     },
     "files": [
         "src/adaptivecards-hostconfig.d.ts",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -18,7 +18,8 @@ var coreConfig = {
         new webpack.optimize.UglifyJsPlugin({
             compressor: {
                 warnings: false
-            }
+            },
+            sourceMap: true
         }),
         new webpack.optimize.OccurrenceOrderPlugin(),
     ],
@@ -26,7 +27,10 @@ var coreConfig = {
     module: {
         rules: [
             // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { test: /\.tsx?$/, loader: "awesome-typescript-loader" },
+            {
+                test: /\.tsx?$/,
+                loader: "awesome-typescript-loader"
+            },
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
             {
                 enforce: "pre",


### PR DESCRIPTION
Credit @PiWiBardy on #842 for the effort to introduce source map into our package. Instead of taking his in (which inline TS into `BotChat.js` and bloated it up), I am making a new one and credit him here.

* Uglify should not remove sourcemap references
* Include `BotChat.js.map` and `CognitiveServices.js.map`
  * We will publish them to CDN
  * We are not inlining sourcemap in `*.js` because it will bloat `BotChat.js` to > 5 MB (from ~500 KB)
* Inline sources in JS files compiled from TS, namely, `built/*.js.map` will inline TS source code
