### PR TITLE
postinstall script should not run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "webpack": "webpack",
     "webpack-watch": "webpack --progress --watch",
     "clean": "rimraf built",
-    "postinstall": "cd test && npm install",
     "prepublish": "tsc && npm run build-css && webpack --progress --config webpack.production.config.js",
     "start": "http-server -p 8000",
     "test": "concurrently  \"node test/mock_dl/index.js\" \"mocha test\" ",


### PR DESCRIPTION
Credit @PiWiBardy for introducing this fix in PR #842. Since some part of his PR did not went thru, I am splitting his PR up into this one to get the fix in.

When installing as a dependency, `postinstall` script will be run. Since we already built everything and test files are excluded, it will fail unless the user specific `npm install botframework-webchat --ignore-scripts`.

Removing `postinstall` script to make sure user can bring in our package as a dependency.