### PR TITLE
Fix error when spamming browser speech recognition button

### DIFF
--- a/src/CognitiveServices/SpeechRecognition.ts
+++ b/src/CognitiveServices/SpeechRecognition.ts
@@ -132,7 +132,7 @@ export class SpeechRecognizer implements Speech.ISpeechRecognizer {
             });
         }
 
-        this.actualRecognizer.Recognize(eventhandler, speechContext);
+        return this.actualRecognizer.Recognize(eventhandler, speechContext);
     }
 
     public speechIsAvailable(){
@@ -143,7 +143,10 @@ export class SpeechRecognizer implements Speech.ISpeechRecognizer {
         if (this.actualRecognizer != null) {
             this.actualRecognizer.AudioSource.TurnOff();
         }
+
         this.isStreamingToService = false;
+
+        return Promise.resolve();
     }
 
     private log(message: string) {


### PR DESCRIPTION
When ending a speech recognition session, we need to wait until `webkitSpeechRecognition.onend` event. If we call `webkitSpeechRecognition.start()` before the `onend` event, we will receive "already started" error.

Credit @shahidkhuram for the original PR #657. We prefer observing `onend` event, than waiting for an arbitrary 500ms.