### PR TITLE
Bump to microsoft-speech-browser-sdk@0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update dependencies
   - [`adaptivecards@1.0.0-beta9`](https://www.npmjs.com/package/adaptivecards), in [PR #849](https://github.com/Microsoft/BotFramework-WebChat/pull/849)
   - [`http-server@0.10.0`](https://www.npmjs.com/package/http-server), in [PR #829](https://github.com/Microsoft/BotFramework-WebChat/pull/829)
+  - [`microsoft-speech-browser-sdk@0.0.12`](https://www.npmjs.com/package/microsoft-speech-browser-sdk), in [PR #XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
   - [`node-sass@4.7.2`](https://www.npmjs.com/package/node-sass), in [PR #873](https://github.com/Microsoft/BotFramework-WebChat/pull/873)
 - Fix: Safari on Mac speech synthesis by prefixing `AudioContext`, by [@DerPate2010](https://github.com/DerPate2010) in [PR #865](https://github.com/Microsoft/BotFramework-WebChat/pull/865)
 - Fix: clicking microphone button too fast should not fail, by [@shahidkhuram](https://github.com/shahidkhuram) in [PR #657](#657) and [PR #881](https://github.com/Microsoft/BotFramework-WebChat/pull/881)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update dependencies
   - [`adaptivecards@1.0.0-beta9`](https://www.npmjs.com/package/adaptivecards), in [PR #849](https://github.com/Microsoft/BotFramework-WebChat/pull/849)
   - [`http-server@0.10.0`](https://www.npmjs.com/package/http-server), in [PR #829](https://github.com/Microsoft/BotFramework-WebChat/pull/829)
-  - [`microsoft-speech-browser-sdk@0.0.12`](https://www.npmjs.com/package/microsoft-speech-browser-sdk), in [PR #XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+  - [`microsoft-speech-browser-sdk@0.0.12`](https://www.npmjs.com/package/microsoft-speech-browser-sdk), in [PR #888](https://github.com/Microsoft/BotFramework-WebChat/pull/888)
   - [`node-sass@4.7.2`](https://www.npmjs.com/package/node-sass), in [PR #873](https://github.com/Microsoft/BotFramework-WebChat/pull/873)
 - Fix: Safari on Mac speech synthesis by prefixing `AudioContext`, by [@DerPate2010](https://github.com/DerPate2010) in [PR #865](https://github.com/Microsoft/BotFramework-WebChat/pull/865)
 - Fix: clicking microphone button too fast should not fail, by [@shahidkhuram](https://github.com/shahidkhuram) in [PR #657](#657) and [PR #881](https://github.com/Microsoft/BotFramework-WebChat/pull/881)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3976,9 +3976,9 @@
       }
     },
     "microsoft-speech-browser-sdk": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.1.tgz",
-      "integrity": "sha1-+n2NE9t6nGjRz+6YqWCrqHuBpiI="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.12.tgz",
+      "integrity": "sha512-JYIR/WpaCyV1wk+4ff3kSJMqJFehbeApzG9CJxR+mN3z+4hFKGB/D5GaFsdN5WtRvnrekzUYSOv2nljMQb3Nwg=="
     },
     "miller-rabin": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "botframework-directlinejs": "0.9.13",
     "core-js": "2.4.1",
     "markdown-it": "8.3.1",
-    "microsoft-speech-browser-sdk": "0.0.1",
+    "microsoft-speech-browser-sdk": "0.0.12",
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-redux": "5.0.5",

--- a/test/mock_dl/index.ts
+++ b/test/mock_dl/index.ts
@@ -350,6 +350,12 @@ app.get('/botchat.js', function (req, res) {
 app.get('/botchat.js.map', function (req, res) {
     res.sendFile(path.join(__dirname + "/../../botchat.js.map"));
 });
+app.get('/CognitiveServices.js', function (req, res) {
+    res.sendFile(path.join(__dirname + "/../../CognitiveServices.js"));
+});
+app.get('/CognitiveServices.js.map', function (req, res) {
+    res.sendFile(path.join(__dirname + "/../../CognitiveServices.js.map"));
+});
 app.get('/botchat.css', function (req, res) {
     res.sendFile(path.join(__dirname + "/../../botchat.css"));
 });

--- a/test/test.html
+++ b/test/test.html
@@ -52,6 +52,7 @@
 
     <script src="botchat.js"></script>
     <script src="mock_speech.js"></script>
+    <script src="CognitiveServices.js"></script>
 
     <script type="text/babel">
       const params = BotChat.queryParams(location.search);
@@ -86,13 +87,22 @@
             resize: 'window',
             sendTyping: false, //set to true to send 'typing' activities to bot (and other users) when user is typing
             showUploadButton: params['showUploadButton'] !== 'false',
-            speechOptions: params['speech'] !== 'enabled/ui' ?
-              null
-            :
+            speechOptions: params['speech'] === 'enabled/ui' ?
               {
                 speechRecognizer: new MockSpeechRecognizer(),
                 speechSynthesizer: new MockSpeechSynthesizer()
-              },
+              }
+            : params['speech'] ?
+              {
+                speechRecognizer: new CognitiveServices.SpeechRecognizer({ subscriptionKey: params['speech'] }),
+                speechSynthesizer: new CognitiveServices.SpeechSynthesizer({
+                  gender: CognitiveServices.SynthesisGender.Female,
+                  subscriptionKey: params['speech'],
+                  voiceName: 'Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'
+                })
+              }
+            :
+              null,
             user: {
               id: params['userid'] || 'userid',
               name: params['username'] || 'username'


### PR DESCRIPTION
We were using `microsoft-speech-browser-sdk@0.0.1` which is 10 months old.

This PR will also enable Bing Speech using MOCK_DL server by hitting http://localhost:3000/?domain=http://localhost:3000/mock&speech=YOUR_BING_SPEECH_API.

