### PR TITLE
Add `type="button"` to `<button>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#894](https://github.com/Microsoft/BotFramework-WebChat/issues/894): Chrome not speaking malformed SSML on Adaptive Cards `speak` property, in [PR #895](https://github.com/Microsoft/BotFramework-WebChat/pull/895)
 - Fix [#866](https://github.com/Microsoft/BotFramework-WebChat/issues/866): unmount should not throw exception, in [PR #884](https://github.com/Microsoft/BotFramework-WebChat/pull/884)
 - Cleanup: `dependencies` and `devDependencies` in both `package.json` and `test/package.json` is much cleaner and independent of each other, in [PR #893](https://github.com/Microsoft/BotFramework-WebChat/pull/893)
-- Fix [#906](https://github.com/Microsoft/BotFramework-WebChat/issues/906): Add type="button" to `<button>`, in [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- Fix [#906](https://github.com/Microsoft/BotFramework-WebChat/issues/906): Add type="button" to `<button>`, in [#910](https://github.com/Microsoft/BotFramework-WebChat/pull/910)
 
 ### Removed
 - Deprecated `props.formatOptions.showHeader`, [use `props.chatTitle` instead](#formatoptionsshowheader-is-deprecated-use-chattitle-instead), in [PR #875](https://github.com/Microsoft/BotFramework-WebChat/pull/875)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#894](https://github.com/Microsoft/BotFramework-WebChat/issues/894): Chrome not speaking malformed SSML on Adaptive Cards `speak` property, in [PR #895](https://github.com/Microsoft/BotFramework-WebChat/pull/895)
 - Fix [#866](https://github.com/Microsoft/BotFramework-WebChat/issues/866): unmount should not throw exception, in [PR #884](https://github.com/Microsoft/BotFramework-WebChat/pull/884)
 - Cleanup: `dependencies` and `devDependencies` in both `package.json` and `test/package.json` is much cleaner and independent of each other, in [PR #893](https://github.com/Microsoft/BotFramework-WebChat/pull/893)
+- Fix [#906](https://github.com/Microsoft/BotFramework-WebChat/issues/906): Add type="button" to `<button>`, in [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Removed
 - Deprecated `props.formatOptions.showHeader`, [use `props.chatTitle` instead](#formatoptionsshowheader-is-deprecated-use-chattitle-instead), in [PR #875](https://github.com/Microsoft/BotFramework-WebChat/pull/875)

--- a/src/HScroll.tsx
+++ b/src/HScroll.tsx
@@ -143,7 +143,12 @@ export class HScroll extends React.Component<HScrollProps, {}> {
     render() {
         return (
             <div>
-                <button ref={ button => this.prevButton = button } className="scroll previous" disabled>
+                <button
+                    className="scroll previous"
+                    disabled
+                    ref={ button => this.prevButton = button }
+                    type="button"
+                >
                     <svg>
                         <path d={ this.props.prevSvgPathData }/>
                     </svg>
@@ -153,7 +158,12 @@ export class HScroll extends React.Component<HScrollProps, {}> {
                         { this.props.children }
                     </div>
                 </div>
-                <button ref={ button => this.nextButton = button } className="scroll next" disabled>
+                <button
+                    className="scroll next"
+                    disabled
+                    ref={ button => this.nextButton = button }
+                    type="button"
+                >
                     <svg>
                         <path d={ this.props.nextSvgPathData }/>
                     </svg>

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -161,6 +161,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                     role="button"
                     onKeyPress={ evt => this.handleSendButtonKeyPress(evt) }
                     tabIndex={ 0 }
+                    type="button"
                 >
                     <svg>
                         <path d="M26.79 9.38A0.31 0.31 0 0 0 26.79 8.79L0.41 0.02C0.36 0 0.34 0 0.32 0 0.14 0 0 0.13 0 0.29 0 0.33 0.01 0.37 0.03 0.41L3.44 9.08 0.03 17.76A0.29 0.29 0 0 0 0.01 17.8 0.28 0.28 0 0 0 0.01 17.86C0.01 18.02 0.14 18.16 0.3 18.16A0.3 0.3 0 0 0 0.41 18.14L26.79 9.38ZM0.81 0.79L24.84 8.79 3.98 8.79 0.81 0.79ZM3.98 9.37L24.84 9.37 0.81 17.37 3.98 9.37Z" />
@@ -172,6 +173,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                     aria-label={ this.props.strings.speak }
                     role="button"
                     tabIndex={ 0 }
+                    type="button"
                 >
                    <svg width="28" height="22" viewBox="0 0 58 58" >
                         <path d="M 44 28 C 43.448 28 43 28.447 43 29 L 43 35 C 43 42.72 36.72 49 29 49 C 21.28 49 15 42.72 15 35 L 15 29 C 15 28.447 14.552 28 14 28 C 13.448 28 13 28.447 13 29 L 13 35 C 13 43.485 19.644 50.429 28 50.949 L 28 56 L 23 56 C 22.448 56 22 56.447 22 57 C 22 57.553 22.448 58 23 58 L 35 58 C 35.552 58 36 57.553 36 57 C 36 56.447 35.552 56 35 56 L 30 56 L 30 50.949 C 38.356 50.429 45 43.484 45 35 L 45 29 C 45 28.447 44.552 28 44 28 Z"/>


### PR DESCRIPTION
Fix #906.

We should add `type="button"` to indicate buttons are just clickable button but not submit button. Submit buttons are automatically triggered by the browser when the user press ENTER on any <input> on the page.