### PR TITLE
Bump to 0.12.1-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.0] - 2018-03-21
 ### Added
 - [#754](https://github.com/Microsoft/BotFramework-WebChat/issues/754) Customizable chat title thru `props.chatTitle`, either `true`/`false` or a string, by [@shade33](https://github.com/shade33) in [PR #810](https://github.com/Microsoft/BotFramework-WebChat/pull/810) and [PR #875](https://github.com/Microsoft/BotFramework-WebChat/pull/875)
 - [#798](https://github.com/Microsoft/BotFramework-WebChat/issues/798) Options to show/hide upload button thru `props.showUploadButton`, in [PR #883](https://github.com/Microsoft/BotFramework-WebChat/pull/883)
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `nl-nl`, by [Mick Vleeshouwer](https://github.com/iMicknl) in [PR #821](https://github.com/Microsoft/BotFramework-WebChat/pull/821)
   - `pl-pl`, by [Peter Blazejewicz](https://github.com/peterblazejewicz) in [PR #813](https://github.com/Microsoft/BotFramework-WebChat/pull/813)
   - `zh-hans`, by [@Antimoney](https://github.com/Antimoney) in [PR #822](https://github.com/Microsoft/BotFramework-WebChat/pull/822) and [PR #823](https://github.com/Microsoft/BotFramework-WebChat/pull/823)
-- Promise polyfill with [bluebird](https://www.npmjs.com/package/bluebird) if needed in [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- Promise polyfill with [bluebird](https://www.npmjs.com/package/bluebird) if needed in [#911](https://github.com/Microsoft/BotFramework-WebChat/pull/911)
 
 ### Changed
 - Update dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat",
-  "version": "0.12.0",
+  "version": "0.12.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat",
-  "version": "0.12.0",
+  "version": "0.12.1-pre",
   "description": "Embeddable web chat control for the Microsoft Bot Framework",
   "main": "built/BotChat.js",
   "types": "built/BotChat.d.ts",


### PR DESCRIPTION
`@0.12.0` is out on [NPM](https://www.npmjs.com/package/botframework-webchat) and GitHub [Releases](https://github.com/Microsoft/BotFramework-WebChat/releases/tag/v0.12.0).

It's time to prepare for the next release. Bumping version to `@0.12.1-pre` to mark our starting point.