### PR TITLE
Add listenFor speech recognizer hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `listenFor` speech recognizer hint for both Cognitive Services and Web Speech API
+
 ### Changed
 - Fix [#870](https://github.com/Microsoft/BotFramework-WebChat/issues/870) not to show empty bubble, in [#917](https://github.com/Microsoft/BotFramework-WebChat/pull/917)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4143,6 +4143,11 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jspeech": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jspeech/-/jspeech-0.1.1.tgz",
+      "integrity": "sha1-n+wcnRGeFJBajeqCpQWvBs+Sg1k="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bluebird": "^3.5.1",
     "botframework-directlinejs": "0.9.13",
     "core-js": "2.4.1",
+    "jspeech": "^0.1.1",
     "markdown-it": "8.3.1",
     "microsoft-speech-browser-sdk": "0.0.12",
     "react": "15.6.1",

--- a/src/CognitiveServices/SpeechRecognition.ts
+++ b/src/CognitiveServices/SpeechRecognition.ts
@@ -2,6 +2,16 @@ import { Speech, Func, Action } from '../SpeechModule'
 import * as konsole from '../Konsole';
 import * as CognitiveSpeech from 'microsoft-speech-browser-sdk/Speech.Browser.Sdk'
 
+export interface ISpeechContextDgiGroup {
+    Type: string;
+    Hints?: { ReferenceGrammar: string };
+    Items?: { Text: string }[];
+}
+
+export interface ISpeechContext {
+    dgi: { Groups: ISpeechContextDgiGroup[] };
+}
+
 export interface ICognitiveServicesSpeechRecognizerProperties {
     locale?: string,
     subscriptionKey?: string,
@@ -123,7 +133,7 @@ export class SpeechRecognizer implements Speech.ISpeechRecognizer {
             }
         }
 
-        const speechContext = { dgi: { Groups: [] } };
+        const speechContext: ISpeechContext = { dgi: { Groups: [] } };
 
         if (this.referenceGrammarId) {
             speechContext.dgi.Groups.push({

--- a/src/SpeechModule.ts
+++ b/src/SpeechModule.ts
@@ -1,3 +1,6 @@
+/// <reference path="types/jspeech.d.ts"/>
+import jspeech from 'jspeech';
+
 export type Action = () => void
 
 export type Func<T, TResult> = (item: T) => TResult;
@@ -5,6 +8,10 @@ export type Func<T, TResult> = (item: T) => TResult;
 interface EventEmitter {
     addEventListener(name: string, listener: (event: Event) => void): void
     removeEventListener(name: string, listener: (event: Event) => void): void
+}
+
+function prefixFallback(type: string, prefixes = ['moz', 'ms', 'webkit']): any {
+    return ['', ...prefixes].reduce((found, prefix) => found || (<any>window)[prefix + type], null);
 }
 
 function waitEvent(emitter: EventEmitter, name: string): Promise<Event> {
@@ -41,6 +48,7 @@ export module Speech {
         onRecognitionFailed: Action;
 
         warmup(): void;
+        setGrammars(grammars?: string[]): void;
         startRecognizing(): Promise<void>;
         stopRecognizing(): Promise<void>;
         speechIsAvailable(): boolean;
@@ -60,6 +68,7 @@ export module Speech {
 
         public static async startRecognizing(
             locale: string = 'en-US',
+            grammars?: string[],
             onIntermediateResult: Func<string, void> = null,
             onFinalResult: Func<string, void> = null,
             onAudioStreamStarted: Action = null,
@@ -73,6 +82,8 @@ export module Speech {
                 await SpeechRecognizer.instance.stopRecognizing();
                 SpeechRecognizer.instance.locale = locale; // to do this could invalidate warmup.
             }
+
+            SpeechRecognizer.instance.setGrammars(grammars);
 
             if (SpeechRecognizer.alreadyRecognizing()) {
                 await SpeechRecognizer.stopRecognizing();
@@ -213,6 +224,27 @@ export module Speech {
             } else {
                 return Promise.resolve();
             }
+        }
+
+        public setGrammars(grammars: string[] = []) {
+            const list = new (prefixFallback('SpeechGrammarList'));
+
+            if (!list) {
+                if (grammars.length) {
+                    console.warn('This browser does not support speech grammar list');
+                }
+
+                return;
+            } else if (!grammars.length) {
+                return;
+            }
+
+            const grammar = jspeech('listenfor');
+
+            grammar.public.rule('hint', grammars.join(' | '));
+
+            list.addFromString(grammar.stringify());
+            this.recognizer.grammars = list;
         }
     }
 

--- a/src/SpeechModule.ts
+++ b/src/SpeechModule.ts
@@ -1,4 +1,4 @@
-/// <reference path="types/jspeech.d.ts"/>
+/// <reference path="types/JSpeech.d.ts"/>
 import jspeech from 'jspeech';
 
 export type Action = () => void

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -628,18 +628,28 @@ const stopListeningEpic: Epic<ChatActions, ChatState> = (action$, store) =>
 const startListeningEpic: Epic<ChatActions, ChatState> = (action$, store) =>
     action$.ofType('Listening_Starting')
     .do(async (action : ShellAction) => {
-        var locale = store.getState().format.locale;
-        var onIntermediateResult = (srText : string) => { store.dispatch({ type: 'Update_Input', input: srText, source:"speech" })};
-        var onFinalResult = (srText : string) => {
-                srText = srText.replace(/^[.\s]+|[.\s]+$/g, "");
-                onIntermediateResult(srText);
-                store.dispatch({ type: 'Listening_Stopping' });
-                store.dispatch(sendMessage(srText, store.getState().connection.user, locale));
-            };
-        var onAudioStreamStart = () => { store.dispatch({ type: 'Listening_Start' }) };
-        var onRecognitionFailed = () => { store.dispatch({ type: 'Listening_Stopping' })};
+        const { history: { activities }, format: { locale } } = store.getState();
+        const lastActivity = activities[activities.length - 1];
+        // TODO: Bump DirectLineJS version to support "listenFor" grammars
+        const grammars: string[] = lastActivity && (lastActivity as any).listenFor;
+        const onIntermediateResult = (srText : string) => { store.dispatch({ type: 'Update_Input', input: srText, source: 'speech' })};
+        const onFinalResult = (srText : string) => {
+            srText = srText.replace(/^[.\s]+|[.\s]+$/g, "");
+            onIntermediateResult(srText);
+            store.dispatch({ type: 'Listening_Stopping' });
+            store.dispatch(sendMessage(srText, store.getState().connection.user, locale));
+        };
+        const onAudioStreamStart = () => { store.dispatch({ type: 'Listening_Start' }) };
+        const onRecognitionFailed = () => { store.dispatch({ type: 'Listening_Stopping' })};
 
-        await Speech.SpeechRecognizer.startRecognizing(locale, onIntermediateResult, onFinalResult, onAudioStreamStart, onRecognitionFailed);
+        await Speech.SpeechRecognizer.startRecognizing(
+            locale,
+            grammars,
+            onIntermediateResult,
+            onFinalResult,
+            onAudioStreamStart,
+            onRecognitionFailed
+        );
     })
     .map(_ => nullAction)
 

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -629,9 +629,9 @@ const startListeningEpic: Epic<ChatActions, ChatState> = (action$, store) =>
     action$.ofType('Listening_Starting')
     .do(async (action : ShellAction) => {
         const { history: { activities }, format: { locale } } = store.getState();
-        const lastActivity = activities[activities.length - 1];
+        const lastMessageActivity = [...activities].reverse().find(activity => activity.type === 'message');
         // TODO: Bump DirectLineJS version to support "listenFor" grammars
-        const grammars: string[] = lastActivity && (lastActivity as any).listenFor;
+        const grammars: string[] = lastMessageActivity && (lastMessageActivity as any).listenFor;
         const onIntermediateResult = (srText : string) => { store.dispatch({ type: 'Update_Input', input: srText, source: 'speech' })};
         const onFinalResult = (srText : string) => {
             srText = srText.replace(/^[.\s]+|[.\s]+$/g, "");

--- a/src/types/JSpeech.d.ts
+++ b/src/types/JSpeech.d.ts
@@ -5,7 +5,7 @@ declare module 'jspeech' {
   }
 
   interface Rule {
-    rule: function(name, rule);
+    rule: (name, rule) => void;
   }
 
   export default function (name: string): JSpeech;

--- a/src/types/JSpeech.d.ts
+++ b/src/types/JSpeech.d.ts
@@ -1,0 +1,12 @@
+declare module 'jspeech' {
+  interface JSpeech implements Rule {
+    public: Rule;
+    stringify(): string;
+  }
+
+  interface Rule {
+    rule: function(name, rule);
+  }
+
+  export default function (name: string): JSpeech;
+}

--- a/test/commands_map.ts
+++ b/test/commands_map.ts
@@ -833,8 +833,7 @@ var commands_map: CommandValuesMap = {
 };
 
 //use this to run only specified tests
-var testOnly = ['speech listen-for'];    //["carousel", "herocard"];
-// var testOnly = [];    //["carousel", "herocard"];
+var testOnly = [];    //["carousel", "herocard"];
 
 if (testOnly && testOnly.length > 0) {
     for (var key in commands_map) if (testOnly.indexOf(key) < 0) delete commands_map[key];

--- a/test/commands_map.ts
+++ b/test/commands_map.ts
@@ -691,7 +691,6 @@ var commands_map: CommandValuesMap = {
                 .wait(1000);
         },
         client: function () {
-            debugger;
             return (((document.querySelector('.wc-shellinput') as HTMLInputElement).placeholder === 'Listening...'));
         }
     },
@@ -715,6 +714,21 @@ var commands_map: CommandValuesMap = {
         },
         client: function () {
             return (((document.querySelector('.wc-shellinput') as HTMLInputElement).placeholder === 'Type your message...'));
+        }
+    },
+    "speech listen-for": {
+        do: function (nightmare) {
+            nightmare.click('.wc-mic').wait(1000);
+        },
+        client: function () {
+            return JSON.stringify(window['debugSpeechRecognizer'].grammars) === JSON.stringify(['San Francisco', 'Seattle']);
+        },
+        server: function (res, sendActivity, json) {
+            sendActivity(res, {
+                type: 'message',
+                text: 'Where do you live?',
+                listenFor: ['San Francisco', 'Seattle']
+            } as any);
         }
     },
     "focus on type": {
@@ -819,7 +833,8 @@ var commands_map: CommandValuesMap = {
 };
 
 //use this to run only specified tests
-var testOnly = [];    //["carousel", "herocard"];
+var testOnly = ['speech listen-for'];    //["carousel", "herocard"];
+// var testOnly = [];    //["carousel", "herocard"];
 
 if (testOnly && testOnly.length > 0) {
     for (var key in commands_map) if (testOnly.indexOf(key) < 0) delete commands_map[key];

--- a/test/mock_speech/index.ts
+++ b/test/mock_speech/index.ts
@@ -13,6 +13,7 @@ interface ISpeechRecognizer {
     onRecognitionFailed: Action;
 
     warmup(): void;
+    setGrammars(grammars?: string[]);
     startRecognizing(): Promise<void>;
     stopRecognizing(): Promise<void>;
     speechIsAvailable() : boolean;
@@ -24,6 +25,7 @@ interface ISpeechSynthesizer {
 }
 
 class MockSpeechRecognizer implements ISpeechRecognizer {
+    grammars: string[];
     locale: string = "en-US";
     isStreamingToService: boolean = false;
     referenceGrammarId: string = "mock";
@@ -34,13 +36,20 @@ class MockSpeechRecognizer implements ISpeechRecognizer {
     onRecognitionFailed: Action = null;
 
     warmup(): void { }
+
+    setGrammars(grammars?: string[]) {
+        this.grammars = grammars;
+    }
+
     async startRecognizing(): Promise<void> {
         // This will advance to Listening_Start state from Listening_Starting
         if (this.onAudioStreamingToService) {
             this.onAudioStreamingToService();
         }
     }
+
     async stopRecognizing(): Promise<void> {}
+
     speechIsAvailable(): boolean {
         return true;
     }

--- a/test/test.html
+++ b/test/test.html
@@ -89,7 +89,7 @@
             showUploadButton: params['showUploadButton'] !== 'false',
             speechOptions: params['speech'] === 'enabled/ui' ?
               {
-                speechRecognizer: new MockSpeechRecognizer(),
+                speechRecognizer: (window['debugSpeechRecognizer'] = new MockSpeechRecognizer()),
                 speechSynthesizer: new MockSpeechSynthesizer()
               }
             : params['speech'] === 'browser' ?


### PR DESCRIPTION
`listenFor` is a hint for speech recognizer, suggesting possible wordings to improve accuracy. We support this feature for both Cognitive Services and Web Speech API + JSRF.

Note: DirectLineJS currently do not support `listenFor`.