### PR TITLE
Showing successive messages from the same chat-end as a single message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.13.1] - 2018-04-21
+### Added
+- Show successive messages from the same chat-end as a single message
+
 ## [0.12.1] - 2018-04-16
 ### Added
 - Add `listenFor` speech recognizer hint for both Cognitive Services and Web Speech API

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build-test": "cd test && npm run build",
     "build-test-watch": "concurrently \"tsc -w -p ./test/mock_dl\" \"tsc -w -p ./test\"",
     "build-css": "node-sass ./src/scss/ -o . && rimraf ./includes/",
+    "build-css-watch": "node-sass -w ./src/scss/ -o . && rimraf ./includes/",
     "build-ac-config": "ac-scss2json ./src/scss/includes/adaptive-card-config.scss > adaptivecards-hostconfig.json",
     "build-all-style": "npm run build-css && npm run build-ac-config && webpack",
     "build": "npm run build-css && tsc && webpack --progress",

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -16,23 +16,26 @@ import { getTabIndex } from './getTabIndex';
 
 export interface ChatProps {
     adaptiveCardsHostConfig: any,
-    chatTitle?: boolean | string,
-    user: User,
     bot: User,
     botConnection?: IBotConnection,
+    chatTitle?: boolean | string,
     directLine?: DirectLineOptions,
-    speechOptions?: SpeechOptions,
+    formatOptions?: FormatOptions,
     locale?: string,
+    resize?: 'none' | 'window' | 'detect'
     selectedActivity?: BehaviorSubject<ActivityOrID>,
     sendTyping?: boolean,
     showUploadButton?: boolean,
-    formatOptions?: FormatOptions,
-    resize?: 'none' | 'window' | 'detect'
+    speechOptions?: SpeechOptions,
+    activityMergeWindowSizeInMillis?: number,
+    user: User,
 }
 
 import { History } from './History';
 import { MessagePane } from './MessagePane';
 import { Shell, ShellFunctions } from './Shell';
+
+const DEFAULT_ACTIVITY_MERGE_WINDOW_SIZE_IN_MILLIS = 5000;
 
 export class Chat extends React.Component<ChatProps, {}> {
 
@@ -257,6 +260,7 @@ export class Chat extends React.Component<ChatProps, {}> {
 
     render() {
         const state = this.store.getState();
+        const activityMergeWindowSizeInMillis = this.props.activityMergeWindowSizeInMillis || DEFAULT_ACTIVITY_MERGE_WINDOW_SIZE_IN_MILLIS;
         konsole.log("BotChat.Chat state", state);
 
         // only render real stuff after we know our dimensions
@@ -275,6 +279,7 @@ export class Chat extends React.Component<ChatProps, {}> {
                     }
                     <MessagePane>
                         <History
+                            activityMergeWindowSizeInMillis={activityMergeWindowSizeInMillis}
                             onCardAction={ this._handleCardAction }
                             ref={ this._saveHistoryRef }
                         />

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -181,6 +181,61 @@
 
 /* messages */
 
+    .wc-message-first {
+
+        .wc-message-from-bot {
+
+            .wc-message-content {
+                border-bottom-left-radius: 6px;
+            }
+        }
+
+        .wc-message-from-me {
+
+            .wc-message-content {
+                border-bottom-right-radius: 6px;
+            }
+        }
+    }
+
+    .wc-message-last {
+        margin-top: -8px;
+
+        .wc-message-from-bot {
+
+            .wc-message-content {
+                border-top-left-radius: 6px;
+            }
+        }
+
+        .wc-message-from-me {
+
+            .wc-message-content {
+                border-top-right-radius: 6px;
+            }
+        }
+    }
+
+    .wc-message-middle {
+        margin-top: -8px;
+
+        .wc-message-from-bot {
+
+            .wc-message-content {
+                border-bottom-left-radius: 6px;
+                border-top-left-radius: 6px;
+            }
+        }
+
+        .wc-message-from-me {
+
+            .wc-message-content {
+                border-bottom-right-radius: 6px;
+                border-top-right-radius: 6px;
+            }
+        }
+    }
+
     .wc-message-wrapper {
         animation: animationFrames 2s;
         animation-iteration-count: 1;
@@ -214,15 +269,15 @@
     }
 
     .wc-message svg.wc-message-callout {
+        bottom: 0px;
         height: 22px;
         position: absolute;
         stroke: none;
-        top: 12px;
         width: 6px;
     }
 
     .wc-message-content {
-        border-radius: 2px;
+        border-radius: 12px;
         box-shadow: 0px 1px 1px 0px $c_shadow;
         padding: 8px;
         word-break: break-word;


### PR DESCRIPTION
@billba @compulim @danmarshall  This PR attempts to give a better look for rendered messages. Successive messages from the same chat-end will show up as a single message like popular messaging platforms (Skype, Facebook messenger etc...).

The difference:
![diff](https://user-images.githubusercontent.com/20838344/39081357-9e1e8bea-4548-11e8-8db8-d255a72926c0.png)

Also it has a configurable time window value to show messages separately if their time difference exceeds that value (default 5000 ms):
![timeout](https://user-images.githubusercontent.com/20838344/39081358-ab606c1a-4548-11e8-8ac7-bd1e8ae3aec9.png)
