### PR TITLE
Do not send empty dgi.Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fix [#963](https://github.com/Microsoft/BotFramework-WebChat/issues/963) not to send empty `dgi.Groups` to Cognitive Services, in [#965](https://github.com/Microsoft/BotFramework-WebChat/pull/965)
 
 ## [0.13.0] - 2018-04-26
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6410,6 +6410,11 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-update-in": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.2.0.tgz",
+      "integrity": "sha512-a6s2H/Px+TXHlJG6FvBpVQU4qnz2BFjMzPfuzdqnGabKUntbIeRknTasCwlWKrXhD1QBSPZ9XoiGF8EpRLjpiQ=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "redux": "3.7.2",
     "redux-observable": "0.13.0",
     "rxjs": "5.4.3",
+    "simple-update-in": "^1.2.0",
     "tslib": "1.7.1"
   },
   "devDependencies": {

--- a/src/CognitiveServices/SpeechRecognition.ts
+++ b/src/CognitiveServices/SpeechRecognition.ts
@@ -1,6 +1,7 @@
 import { Speech, Func, Action } from '../SpeechModule'
 import * as konsole from '../Konsole';
 import * as CognitiveSpeech from 'microsoft-speech-browser-sdk/Speech.Browser.Sdk'
+import updateIn from 'simple-update-in';
 
 export interface ISpeechContextDgiGroup {
     Type: string;
@@ -133,23 +134,23 @@ export class SpeechRecognizer implements Speech.ISpeechRecognizer {
             }
         }
 
-        const speechContext: ISpeechContext = { dgi: { Groups: [] } };
+        let speechContext: ISpeechContext;
 
         if (this.referenceGrammarId) {
-            speechContext.dgi.Groups.push({
+            speechContext = updateIn(speechContext, ['dgi', 'Groups'], (groups: any[] = []) => [...groups, {
                 Type: 'Generic',
                 Hints: { ReferenceGrammar: this.referenceGrammarId }
-            });
+            }]);
         }
 
         if (this.grammars) {
-            speechContext.dgi.Groups.push({
+            speechContext = updateIn(speechContext, ['dgi', 'Groups'], (groups: any[] = []) => [...groups, {
                 Type: 'Generic',
                 Items: this.grammars.map(grammar => ({ Text: grammar }))
-            });
+            }]);
         }
 
-        return this.actualRecognizer.Recognize(eventhandler, JSON.stringify(speechContext));
+        return this.actualRecognizer.Recognize(eventhandler, speechContext && JSON.stringify(speechContext));
     }
 
     public speechIsAvailable(){

--- a/src/simple-update-in.d.ts
+++ b/src/simple-update-in.d.ts
@@ -1,0 +1,3 @@
+declare module 'simple-update-in' {
+  export default function<T, U> (obj: T, patches: string[], patch: (value: U) => U): T;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     },
     "files": [
         "src/adaptivecards-hostconfig.d.ts",
-        "src/BotChat.ts"
+        "src/BotChat.ts",
+        "src/simple-update-in.d.ts"
     ]
 }


### PR DESCRIPTION
Few changes ago, we updated our Cognitive Services code to support grammar list. That fix broke Cognitive Services because we sent an empty `speechContext.dgi.Groups` and the server responded `InternalServerError` when parsing an empty array.

On our side, we will fix the code not to send `speechContext` when it is not needed.