### PR TITLE
Masking password input with backchannel event

### DIFF
--- a/src/ActivityView.tsx
+++ b/src/ActivityView.tsx
@@ -67,7 +67,7 @@ export class ActivityView extends React.Component<ActivityViewProps, {}> {
                 return (
                     <div>
                         <FormattedText
-                            text={ activity.text }
+                            text={ activity.inputHint === 'password' ? '•'.repeat(activity.text.length) : activity.text }
                             format={ activity.textFormat }
                             onImageLoad={ props.onImageLoad }
                         />

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
 import { Activity, IBotConnection, User, DirectLine, DirectLineOptions, CardActionTypes } from 'botframework-directlinejs';
-import { createStore, ChatActions, sendMessage } from './Store';
+import { createStore, ChatActions, ShellAction, sendMessage } from './Store';
 import { Provider } from 'react-redux';
 import { SpeechOptions } from './SpeechOptions';
 import { Speech } from './SpeechModule';
@@ -101,6 +101,12 @@ export class Chat extends React.Component<ChatProps, {}> {
     private handleIncomingActivity(activity: Activity) {
         let state = this.store.getState();
         switch (activity.type) {
+            case "event":
+                if (activity.name === 'inputTypeChange') {
+                    this.store.dispatch<ShellAction>({ type: 'Change_Input_Type', inputType: activity.value });
+                }
+            break;
+
             case "message":
                 this.store.dispatch<ChatActions>({ type: activity.from.id === state.connection.user.id ? 'Receive_Sent_Message' : 'Receive_Message', activity });
                 break;

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -5,17 +5,18 @@ import { classList } from './Chat';
 import { Dispatch, connect } from 'react-redux';
 import { Strings } from './Strings';
 import { Speech } from './SpeechModule'
-import { ChatActions, ListeningState, sendMessage, sendFiles } from './Store';
+import { ChatActions, InputTypes, ListeningState, sendMessage, sendFiles } from './Store';
 
 interface Props {
     inputText: string,
+    inputType: InputTypes;
     strings: Strings,
     listeningState: ListeningState,
     showUploadButton: boolean
 
     onChangeText: (inputText: string) => void
 
-    sendMessage: (inputText: string) => void,
+    sendMessage: (inputText: string, messageType: string) => void,
     sendFiles: (files: FileList) => void,
     stopListening: () => void,
     startListening: () => void
@@ -31,7 +32,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
 
     private sendMessage() {
         if (this.props.inputText.trim().length > 0) {
-            this.props.sendMessage(this.props.inputText);
+            this.props.sendMessage(this.props.inputText, this.props.inputType);
         }
     }
 
@@ -141,7 +142,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                 }
                 <div className="wc-textbox">
                     <input
-                        type="text"
+                        type={this.props.inputType}
                         className="wc-shellinput"
                         ref={ input => this.textInput = input }
                         autoFocus
@@ -190,6 +191,7 @@ export const Shell = connect(
     (state: ChatState) => ({
         // passed down to ShellContainer
         inputText: state.shell.input,
+        inputType: state.shell.inputType,
         showUploadButton: state.format.showUploadButton,
         strings: state.format.strings,
         // only used to create helper functions below
@@ -207,13 +209,16 @@ export const Shell = connect(
     }, (stateProps: any, dispatchProps: any, ownProps: any): Props => ({
         // from stateProps
         inputText: stateProps.inputText,
+        inputType: stateProps.inputType,
         showUploadButton: stateProps.showUploadButton,
         strings: stateProps.strings,
         listeningState: stateProps.listeningState,
         // from dispatchProps
         onChangeText: dispatchProps.onChangeText,
         // helper functions
-        sendMessage: (text: string) => dispatchProps.sendMessage(text, stateProps.user, stateProps.locale),
+        sendMessage:
+            (text: string, messageType: string) =>
+                dispatchProps.sendMessage(text, stateProps.user, stateProps.locale, messageType),
         sendFiles: (files: FileList) => dispatchProps.sendFiles(files, stateProps.user, stateProps.locale),
         startListening: () => dispatchProps.startListening(),
         stopListening: () => dispatchProps.stopListening()

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -591,6 +591,7 @@
             margin: 11px;
         }
 
+        input[type=password],
         input[type=text],
         textarea {
             border: none;


### PR DESCRIPTION
If you send the following event to WebChat through the backchannel, the input box will become a password input until you send a message.

Event:
```ts
{
    name: 'inputTypeChange',
    type: 'event',
    value: 'password'
}
```
Demo:
![demo](https://user-images.githubusercontent.com/20838344/39816081-d7764a00-53a2-11e8-8356-68536b80106e.gif)
