### PR TITLE
Re-encode without BOM

### DIFF
--- a/adaptivecards-hostconfig.json
+++ b/adaptivecards-hostconfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "supportsInteractivity": true,
   "spacing": {
     "small": 4,


### PR DESCRIPTION
`adaptivecards-hostconfig.json` is encoded in UTF-8 with BOM. The BOM breaks Webpack on VSTS. JSON file should not be encoded with BOM anyway.