### PR TITLE
Update to use the newer style of getUserMedia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `PULL_REQUEST_TEMPLATE.md` [@corinagum](https://github.com/corinagum) in PR [#1065](https://github.com/Microsoft/BotFramework-WebChat/pull/1065)
 - Add `role === 'user'` to `fromMe` check in [#1053](https://github.com/Microsoft/BotFramework-WebChat/pull/1053)
 - Add `disabled` props to disable all controls in PR [#988](https://github.com/Microsoft/BotFramework-WebChat/pull/988)
+- Update WebRTC check by `navigator.getUserMedia` and `navigator.mediaDevices.getUserMedia`, by [@rosskyl](https://github.com/rosskyl) in [#1026](https://github.com/Microsoft/BotFramework-WebChat/pull/1026)
 
 ## [0.14.1] - 2018-07-31
 ### Added

--- a/src/CognitiveServices/SpeechRecognition.ts
+++ b/src/CognitiveServices/SpeechRecognition.ts
@@ -76,7 +76,10 @@ export class SpeechRecognizer implements Speech.ISpeechRecognizer {
             throw new Error('Error: The CognitiveServicesSpeechRecognizer requires either a subscriptionKey or a fetchCallback and fetchOnExpiryCallback.');
         }
 
-        if (window.navigator.getUserMedia) {
+        if (
+            window.navigator.getUserMedia
+            || (window.navigator.mediaDevices && window.navigator.mediaDevices.getUserMedia)
+        ) {
             this.actualRecognizer = CognitiveSpeech.CreateRecognizer(recognizerConfig, authentication);
         } else {
             console.error('This browser does not support speech recognition');


### PR DESCRIPTION
The cognitive services back end updated to use window.navigator.mediaDevices.getUserMedia but this still checks for window.navigator.getUserMedia which is undefined in Firefox even though speech works.

/* Please update CHANGELOG.md. Under [Unreleased] section, describe your changes under 80 characters */
