### PR TITLE
Fixing code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Include `botchat.css` and `botchat.js` in your website, for example,
     <script src="https://cdn.botframework.com/botframework-webchat/latest/botchat.js"></script>
     <script>
       BotChat.App({
-        directLine: { secret: direct_line_secret },
+        directLine: { token: direct_line_secret },
         user: { id: 'userid' },
         bot: { id: 'botid' },
         resize: 'detect'


### PR DESCRIPTION
Fixing code snippet under "Easy: In your non-React website, run Web Chat inline" section. Replaced "secret" with "token" as writing it as "secret" never works.

