### PR TITLE
Better error handling in WebChat for getSessionId call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Translations
+  - `pt-BR`, by [Diego Castro](https://github.com/dfdcastro) in [PR #1074](https://github.com/Microsoft/BotFramework-WebChat/pull/1074)
 
 ## [0.14.2] - 2018-08-16
 ### Added

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -349,7 +349,6 @@ export const doCardAction = (
                     loginWindow.location.href = text + param;
                 }, error => {
                     konsole.log('failed to get sessionId', error);
-                    loginWindow.location.href = text;
                 });
             } else {
                 loginWindow.location.href = text;

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -342,9 +342,14 @@ export const doCardAction = (
             if (botConnection.getSessionId)  {
                 botConnection.getSessionId().subscribe(sessionId => {
                     konsole.log('received sessionId: ' + sessionId);
-                    loginWindow.location.href = text + encodeURIComponent('&code_challenge=' + sessionId);
+                    let param = '';
+                    if (sessionId && sessionId.length > 0) {
+                        param = encodeURIComponent('&code_challenge=' + sessionId);
+                    }
+                    loginWindow.location.href = text + param;
                 }, error => {
                     konsole.log('failed to get sessionId', error);
+                    loginWindow.location.href = text;
                 });
             } else {
                 loginWindow.location.href = text;

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -188,8 +188,8 @@ const localizedStrings: LocalizedStrings = {
         timeSent: ' às %1',
         consolePlaceholder: 'Digite sua mensagem...',
         listeningIndicator: 'Ouvindo...',
-        uploadFile: '',
-        speak: ''
+        uploadFile: 'Subir arquivo',
+        speak: 'Falar'
     },
     'fr-fr': {
         title: 'Chat',


### PR DESCRIPTION
Added more error handling and checks for when getSessionId either returns nothing or has an error of some sort. Without this, WebChat seemed to get in a bad state after this call.