### PR TITLE
Speech Recognizer Result Formats

### DIFF
--- a/samples/speech/index.html
+++ b/samples/speech/index.html
@@ -23,133 +23,136 @@
   
 -->
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Bot Chat</title>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Bot Chat</title>
 
-    <link href="../../botchat.css" rel="stylesheet" />
+  <link href="../../botchat.css" rel="stylesheet" />
 
-    <style>
-      .example {
-        float: left;
-        margin-right: 20px;
-        width: 300px;
+  <style>
+    .example {
+      float: left;
+      margin-right: 20px;
+      width: 300px;
+    }
+
+    .example > h2 {
+      font-family: 'Segoe UI';
+    }
+
+    #BotChatGoesHere {
+      border: 1px solid #333;
+      float: left;
+      height: 600px;
+      position: relative;
+      width: 460px;
+    }
+  </style>
+</head>
+<body>
+  <section class="example">
+    <h2>Web Chat with speech</h2>
+    <p>
+      This sample shows the various options for enabling speech recognition and speech synthesis in the Web Chat
+    </p>
+  </section>
+
+  <div id="BotChatGoesHere"></div>
+
+  <script src="../../botchat.js"></script>
+
+  <!-- If you do not want to use Cognitive Services library, comment out the following line -->
+  <script src="../../CognitiveServices.js"></script>
+
+  <script>
+    const params = BotChat.queryParams(location.search);
+
+    const user = {
+      id: params['userid'] || 'userid',
+      name: params['username'] || 'username'
+    };
+
+    const bot = {
+      id: params['botid'] || 'botid',
+      name: params['botname'] || 'botname'
+    };
+
+    window.botchatDebug = params['debug'] && params['debug'] === 'true';
+
+    // // Option 1: No speech
+    //
+    // const speechOptions = null;
+
+    // // Option 2: Native browser speech (not supported by all browsers, no speech recognition priming support)
+    //
+    // const speechOptions = {
+    //   speechRecognizer: new BotChat.Speech.BrowserSpeechRecognizer(),
+    //   speechSynthesizer: new BotChat.Speech.BrowserSpeechSynthesizer()
+    // };
+
+    // // Option 3: Cognitive Services speech recognition using API key (cross browser, speech priming support)
+    //
+    const speechOptions = {
+      speechRecognizer: new CognitiveServices.SpeechRecognizer({
+        subscriptionKey: 'YOUR_COGNITIVE_SPEECH_API_KEY'
+        // resultForm: 'Lexical', // Use different result form (ITN is default, can use Display, Lexical or MaskedITN). See https://docs.microsoft.com/en-us/azure/cognitive-services/speech/concepts#output-format
+      }),
+      speechSynthesizer: new CognitiveServices.SpeechSynthesizer({
+        gender: CognitiveServices.SynthesisGender.Female,
+        subscriptionKey: 'YOUR_COGNITIVE_SPEECH_API_KEY',
+        voiceName: 'Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'
+      })
+    };
+
+    // // Option 4: Cognitive Services speech recognition using a token (usually generated in a secure backend using your API key)
+    //
+    // function getToken() {
+    //   // Normally this token fetch is done from your secured backend to avoid exposing the API key and this call
+    //   // would be to your backend, or to retrieve a token that was served as part of the original page.
+
+    //   return fetch(
+    //     'https://api.cognitive.microsoft.com/sts/v1.0/issueToken',
+    //     {
+    //       headers: {
+    //         'Ocp-Apim-Subscription-Key': 'YOUR_COGNITIVE_SPEECH_API_KEY'
+    //       },
+    //       method: 'POST'
+    //     }
+    //   ).then(res => res.text());
+    // }
+
+    // const speechOptions = {
+    //   speechRecognizer: new CognitiveServices.SpeechRecognizer({
+    //     fetchCallback: (authFetchEventId) => getToken(),
+    //     fetchOnExpiryCallback: (authFetchEventId) => getToken()
+    //   }),
+    //   speechSynthesizer: new BotChat.Speech.BrowserSpeechSynthesizer()
+    // };
+
+    // // Option 5: Your own custom implementations of ISpeechRecognizer and ISpeechSynthesizer
+    //
+    // const speechOptions = {
+    //   speechRecognizer: new YourOwnSpeechRecognizer(),
+    //   speechSynthesizer: new YourOwnSpeechSynthesizer()
+    // };
+
+    BotChat.App({
+      bot: bot,
+      locale: params['locale'],
+      resize: 'detect',
+      // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
+      speechOptions: speechOptions,
+      user: user,
+      // locale: 'es-es', // override locale to Spanish
+
+      directLine: {
+        domain: params['domain'],
+        secret: params['s'],
+        token: params['t'],
+        webSocket: params['webSocket'] && params['webSocket'] === 'true' // defaults to true
       }
-
-      .example > h2 {
-        font-family: 'Segoe UI';
-      }
-
-      #BotChatGoesHere {
-        border: 1px solid #333;
-        float: left;
-        height: 600px;
-        position: relative;
-        width: 460px;
-      }
-    </style>
-  </head>
-  <body>
-    <section class="example">
-      <h2>Web Chat with speech</h2>
-      <p>
-        This sample shows the various options for enabling speech recognition and speech synthesis in the Web Chat
-      </p>
-    </section>
-
-    <div id="BotChatGoesHere"></div>
-
-    <script src="../../botchat.js"></script>
-
-    <!-- If you do not want to use Cognitive Services library, comment out the following line -->
-    <script src="../../CognitiveServices.js"></script>
-
-    <script>
-      const params = BotChat.queryParams(location.search);
-
-      const user = {
-        id: params['userid'] || 'userid',
-        name: params['username'] || 'username'
-      };
-
-      const bot = {
-        id: params['botid'] || 'botid',
-        name: params['botname'] || 'botname'
-      };
-
-      window.botchatDebug = params['debug'] && params['debug'] === 'true';
-
-      // // Option 1: No speech
-      //
-      // const speechOptions = null;
-
-      // // Option 2: Native browser speech (not supported by all browsers, no speech recognition priming support)
-      //
-      // const speechOptions = {
-      //   speechRecognizer: new BotChat.Speech.BrowserSpeechRecognizer(),
-      //   speechSynthesizer: new BotChat.Speech.BrowserSpeechSynthesizer()
-      // };
-
-      // // Option 3: Cognitive Services speech recognition using API key (cross browser, speech priming support)
-      //
-      const speechOptions = {
-        speechRecognizer: new CognitiveServices.SpeechRecognizer({ subscriptionKey: 'YOUR_COGNITIVE_SPEECH_API_KEY' }),
-        speechSynthesizer: new CognitiveServices.SpeechSynthesizer({
-          gender: CognitiveServices.SynthesisGender.Female,
-          subscriptionKey: 'YOUR_COGNITIVE_SPEECH_API_KEY',
-          voiceName: 'Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'
-        })
-      };
-
-      // // Option 4: Cognitive Services speech recognition using a token (usually generated in a secure backend using your API key)
-      //
-      // function getToken() {
-      //   // Normally this token fetch is done from your secured backend to avoid exposing the API key and this call
-      //   // would be to your backend, or to retrieve a token that was served as part of the original page.
-
-      //   return fetch(
-      //     'https://api.cognitive.microsoft.com/sts/v1.0/issueToken',
-      //     {
-      //       headers: {
-      //         'Ocp-Apim-Subscription-Key': 'YOUR_COGNITIVE_SPEECH_API_KEY'
-      //       },
-      //       method: 'POST'
-      //     }
-      //   ).then(res => res.text());
-      // }
-
-      // const speechOptions = {
-      //   speechRecognizer: new CognitiveServices.SpeechRecognizer({
-      //     fetchCallback: (authFetchEventId) => getToken(),
-      //     fetchOnExpiryCallback: (authFetchEventId) => getToken()
-      //   }),
-      //   speechSynthesizer: new BotChat.Speech.BrowserSpeechSynthesizer()
-      // };
-
-      // // Option 5: Your own custom implementations of ISpeechRecognizer and ISpeechSynthesizer
-      //
-      // const speechOptions = {
-      //   speechRecognizer: new YourOwnSpeechRecognizer(),
-      //   speechSynthesizer: new YourOwnSpeechSynthesizer()
-      // };
-
-      BotChat.App({
-        bot: bot,
-        locale: params['locale'],
-        resize: 'detect',
-        // sendTyping: true,    // defaults to false. set to true to send 'typing' activities to bot (and other users) when user is typing
-        speechOptions: speechOptions,
-        user: user,
-        // locale: 'es-es', // override locale to Spanish
-
-        directLine: {
-          domain: params['domain'],
-          secret: params['s'],
-          token: params['t'],
-          webSocket: params['webSocket'] && params['webSocket'] === 'true' // defaults to true
-        }
-      }, document.getElementById('BotChatGoesHere'));
-    </script>
-  </body>
+    }, document.getElementById('BotChatGoesHere'));
+  </script>
+</body>
 </html>


### PR DESCRIPTION
This PR adds the ability to specify the result format that a developer wants from the Speech Recognizer service. Until now the result format has automatically just been ITN (Inverse Text Normalization). 

Supported result formats are now: 
* **MaskedITN** - automatically hides curse words: 
![maskeditn](https://user-images.githubusercontent.com/3891951/45061616-1aebb400-b05a-11e8-83d8-10cef801a530.PNG)

* **Lexical** - gives fully lexical representations of numbers: 
![lexical](https://user-images.githubusercontent.com/3891951/45061640-31920b00-b05a-11e8-9797-5607fa837577.PNG)

* **ITN** - gives number version of numbers: 
![itn](https://user-images.githubusercontent.com/3891951/45061661-51293380-b05a-11e8-98ad-acadd6c35222.PNG)

* **Display** - Automatically punctuates transcription: 
![image](https://user-images.githubusercontent.com/3891951/45061838-05c35500-b05b-11e8-8981-8f16c3e2f063.png)

The form still defaults to ITN, which calls the service with the "Simple" format, but using a different response form simply requires setting the resultForm property that now sits in the SpeechRecognizer interface:

```
    const speechOptions = {
      speechRecognizer: new CognitiveServices.SpeechRecognizer({
        subscriptionKey: 'YOUR_COGNITIVE_SPEECH_API_KEY',
        resultForm: 'MaskedITN'
      }),
```

This PR also adds comments in the speech sample to exemplify how to use a different result form. 
