### PR TITLE
Auto scroll on click of message action in history to view the new incoming message

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -132,6 +132,13 @@ export class Chat extends React.Component<ChatProps, {}> {
         if (historyDOM) {
             historyDOM.focus();
         }
+        // After user click on any message action in the history
+        // Auto scroll down to view the new incoming message.
+        this.autoScroll();
+    }
+
+    private autoScroll() {
+        this.historyRef.componentDidUpdate(this.historyRef.props, this.historyRef.state, this.historyRef.context);
     }
 
     private handleKeyDownCapture(evt: React.KeyboardEvent<HTMLDivElement>) {


### PR DESCRIPTION
Hi,
I have fixed the "No Auto scroll" issue #1031 
This fix will make the chat auto scroll to view the new incoming message.

I am new to this architecture and would love some suggestions if this is not the right way to fix this issue.
