### PR TITLE
Hide post back activities by flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Bump `botframework-directlinejs` to `0.9.17` in PR [#1131](https://github.com/Microsoft/BotFramework-WebChat/pull/1131)
 - Fix `historyRef` cannot be focused because it is unmounted in Emulator, in PR [#1157](https://github.com/Microsoft/BotFramework-WebChat/pull/1157)
+- Fix for Chatdown that activities sent by the user are not displayed, in PR [#1162](https://github.com/Microsoft/BotFramework-WebChat/pull/1162)
 
 ## [0.14.2] - 2018-08-16
 ### Added

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -370,7 +370,10 @@ export const sendPostBack = (botConnection: IBotConnection, text: string, value:
         text,
         value,
         from,
-        locale
+        locale,
+        channelData: {
+            postback: true
+        }
     })
     .subscribe(
         id => konsole.log('success sending postBack', id),

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -333,7 +333,8 @@ export const history: Reducer<HistoryState> = (
     konsole.log('history action', action);
     switch (action.type) {
         case 'Receive_Sent_Message': {
-            if (!action.activity.channelData || !action.activity.channelData.clientActivityId) {
+            // if (!action.activity.channelData || !action.activity.channelData.clientActivityId) {
+            if (action.activity.channelData && action.activity.channelData.postBack) {
                 // only postBack messages don't have clientActivityId, and these shouldn't be added to the history
                 return state;
             }


### PR DESCRIPTION
We were using `channelData.clientActivityId` to hide post back.

But in Chatdown, the transcript generated does not have `clientActivityId`, which is normal.

In Web Chat, we should change it to be a `postBack` flag to hide activities sent by the user instead.