### PR TITLE
Sample: IE11 compatibility

### DIFF
--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3001,14 +3001,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3023,20 +3021,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3153,8 +3148,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3166,7 +3160,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3181,7 +3174,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3189,14 +3181,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3215,7 +3205,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3296,8 +3285,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3309,7 +3297,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3431,7 +3418,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6637,6 +6623,11 @@
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
+		},
+		"url-search-params-polyfill": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz",
+			"integrity": "sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ=="
 		},
 		"use": {
 			"version": "3.1.1",

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -2205,7 +2205,7 @@
 		},
 		"css-in-js-utils": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
 			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
 			"requires": {
 				"hyphenate-style-name": "^1.0.2",
@@ -2979,8 +2979,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3001,14 +3000,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3023,20 +3020,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3153,8 +3147,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3166,7 +3159,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3181,7 +3173,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3189,14 +3180,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3215,7 +3204,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3296,8 +3284,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3309,7 +3296,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3395,8 +3381,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3432,7 +3417,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3452,7 +3436,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3496,14 +3479,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -6905,9 +6886,9 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"which": {
 			"version": "1.3.1",

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1509,7 +1509,8 @@
 		"bluebird": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+			"dev": true
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -3000,12 +3001,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3020,17 +3023,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3147,7 +3153,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3159,6 +3166,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3173,6 +3181,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3180,12 +3189,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3204,6 +3215,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3284,7 +3296,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3296,6 +3309,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3417,6 +3431,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -47,6 +47,7 @@
     "redux": "^4.0.0",
     "sanitize-html": "^1.19.0",
     "store": "^2.0.12",
+    "url-search-params-polyfill": "^5.0.0",
     "web-speech-cognitive-services": "2.1.1-master.0f7758b",
     "whatwg-fetch": "^3.0.0"
   },

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -48,7 +48,8 @@
     "redux": "^4.0.0",
     "sanitize-html": "^1.19.0",
     "store": "^2.0.12",
-    "web-speech-cognitive-services": "2.1.1-master.0f7758b"
+    "web-speech-cognitive-services": "2.1.1-master.0f7758b",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -33,7 +33,6 @@
     "@babel/runtime": "^7.0.0",
     "adaptivecards": "^1.0.0",
     "babel-runtime": "^7.0.0-beta.3",
-    "bluebird": "^3.5.2",
     "botframework-directlinejs": "0.9.18-master.3cece81",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -6,6 +6,7 @@ import 'core-js/modules/es6.array.find';
 import 'core-js/modules/es6.array.iterator';
 import 'core-js/modules/es6.object.assign';
 import 'core-js/modules/es6.math.sign';
+import 'core-js/modules/es6.number.is-finite';
 import 'core-js/modules/es6.promise';
 import 'core-js/modules/es6.string.starts-with';
 import 'core-js/modules/es6.symbol';

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -1,11 +1,18 @@
-export * from './index';
 
 // below are shims for compatibility with old browsers (IE 10 being the main culprit)
-import 'core-js/modules/es6.string.starts-with';
-import 'core-js/modules/es6.array.find';
 import 'core-js/modules/es6.array.find-index';
+import 'core-js/modules/es6.array.find';
+import 'core-js/modules/es6.array.iterator';
+import 'core-js/modules/es6.object.assign';
+import 'core-js/modules/es6.math.sign';
+import 'core-js/modules/es6.promise';
+import 'core-js/modules/es6.string.starts-with';
+import 'core-js/modules/es6.symbol';
+import 'core-js/modules/es7.array.includes';
+import 'whatwg-fetch';
 
-// Polyfill Promise if needed
-if (typeof (window as any).Promise === 'undefined') {
-  (window as any).Promise = require('bluebird');
-}
+// URLSearchParams
+
+console.log('Bundled with ES5 polyfills');
+
+export * from './index';

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -1,5 +1,6 @@
-
-// below are shims for compatibility with old browsers (IE 10 being the main culprit)
+// Polyfills for IE11 and other ES5 browsers
+// To maintain quality, we prefer polyfills without additives
+// For example, we prefer Promise implementation from "core-js" than "bluebird"
 import 'core-js/modules/es6.array.find-index';
 import 'core-js/modules/es6.array.find';
 import 'core-js/modules/es6.array.iterator';
@@ -10,9 +11,5 @@ import 'core-js/modules/es6.string.starts-with';
 import 'core-js/modules/es6.symbol';
 import 'core-js/modules/es7.array.includes';
 import 'whatwg-fetch';
-
-// URLSearchParams
-
-console.log('Bundled with ES5 polyfills');
 
 export * from './index';

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -10,6 +10,7 @@ import 'core-js/modules/es6.promise';
 import 'core-js/modules/es6.string.starts-with';
 import 'core-js/modules/es6.symbol';
 import 'core-js/modules/es7.array.includes';
+import 'url-search-params-polyfill';
 import 'whatwg-fetch';
 
 export * from './index';

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -3038,12 +3038,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3058,17 +3060,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3185,7 +3190,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3197,6 +3203,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3211,6 +3218,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3218,12 +3226,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3242,6 +3252,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3322,7 +3333,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3334,6 +3346,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3455,6 +3468,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -3017,8 +3017,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3039,14 +3038,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3061,20 +3058,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3191,8 +3185,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3204,7 +3197,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3219,7 +3211,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3227,14 +3218,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3253,7 +3242,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3334,8 +3322,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3347,7 +3334,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3433,8 +3419,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3470,7 +3455,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3490,7 +3474,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3534,14 +3517,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6146,9 +6127,9 @@
       }
     },
     "react-say": {
-      "version": "1.0.1-master.1d32161",
-      "resolved": "https://registry.npmjs.org/react-say/-/react-say-1.0.1-master.1d32161.tgz",
-      "integrity": "sha512-gLozSvs6t9BYBRB1YiStsVRn7T7wVkezBVoKvYW6wX4BUsf/DiPXxF+cBW7Je/lflghtvjrjB3CXROReBUKbAw==",
+      "version": "1.0.1-master.89c7e89",
+      "resolved": "https://registry.npmjs.org/react-say/-/react-say-1.0.1-master.89c7e89.tgz",
+      "integrity": "sha512-vfdl78EY9muCnq1iNXnJaOppk5Ej87YfsQVNsHVsILNaj+cGp58DYP/gusjLHDDn8KgABwQGimczwMPCdKsK1g==",
       "requires": {
         "classnames": "^2.2.6",
         "event-as-promise": "^1.0.3",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -66,7 +66,7 @@
     "react-dictate-button": "^1.1.3",
     "react-film": "1.0.1-master.a639199",
     "react-redux": "^5.0.7",
-    "react-say": "1.0.1-master.1d32161",
+    "react-say": "1.0.1-master.89c7e89",
     "react-scroll-to-bottom": "^1.1.0",
     "redux": "^4.0.0",
     "sanitize-html": "^1.18.2",

--- a/packages/component/src/Attachment/VideoAttachment.js
+++ b/packages/component/src/Attachment/VideoAttachment.js
@@ -1,10 +1,20 @@
+import { css } from 'glamor';
+import classNames from 'classnames';
 import React from 'react';
 
 import VideoContent from './VideoContent';
 import { withStyleSet } from '../Context';
 
+const ROOT_CSS = css({
+  display: 'flex',
+  flexDirection: 'column'
+});
+
 export default withStyleSet(({ attachment, styleSet }) =>
-  <div className={ styleSet.videoAttachment }>
+  <div className={ classNames(
+    ROOT_CSS + '',
+    styleSet.videoAttachment
+  ) }>
     <VideoContent
       alt={ attachment.name }
       src={ attachment.contentUrl }

--- a/packages/component/src/Attachment/VideoCardAttachment.js
+++ b/packages/component/src/Attachment/VideoCardAttachment.js
@@ -1,4 +1,3 @@
-import memoize from 'memoize-one';
 import React from 'react';
 
 import CommonCard from './CommonCard';

--- a/packages/component/src/Attachment/VideoContent.js
+++ b/packages/component/src/Attachment/VideoContent.js
@@ -11,9 +11,27 @@ const YOUTUBE_WWW_SHORT_DOMAIN = "www.youtu.be";
 const VIMEO_DOMAIN = "vimeo.com";
 const VIMEO_WWW_DOMAIN = "www.vimeo.com";
 
+// This is a workaround
+// - Today, there is no good URL polyfill for older browser
+// - Instead of writing a URL parser, for older browser, we will use this <a href> trick to parse the URL
+function parseURL(url) {
+  let urlLike;
+
+  if (typeof URL === 'function') {
+    urlLike = new URL(src);
+  } else {
+    urlLike = document.createElement('a');
+    urlLike.setAttribute('href', url);
+  }
+
+  const { hostname, pathname, search } = urlLike;
+
+  return { hostname, pathname, search };
+}
+
 export default props => {
   const { autoPlay, loop, poster, src } = props;
-  const { hostname, pathname, search } = new URL(src);
+  const { hostname, pathname, search } = parseURL(src);
   const lastSegment = pathname.split('/').pop();
   const searchParams = new URLSearchParams(search);
 

--- a/packages/component/src/Styles/StyleSet/VideoAttachment.js
+++ b/packages/component/src/Styles/StyleSet/VideoAttachment.js
@@ -1,6 +1,3 @@
 export default function () {
-  return {
-    display: 'flex',
-    flexDirection: 'column'
-  };
+  return {};
 }

--- a/packages/component/src/Styles/StyleSet/VideoContent.js
+++ b/packages/component/src/Styles/StyleSet/VideoContent.js
@@ -1,5 +1,8 @@
-export default function () {
+export default function ({
+  videoHeight
+}) {
   return {
+    height: videoHeight,
     width: '100%'
   };
 }

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -3949,7 +3949,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4314,7 +4315,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4362,6 +4364,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4400,11 +4403,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,1 @@
+/serve.json

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,8 +13,11 @@ This section covers samples helping you to jumpstart embedding Web Chat in your 
 For simplicity, you can use a `<script>` tag to embed Web Chat from a CDN.
 
 - [Full bundle](https://microsoft.github.io/BotFramework-WebChat/full-bundle) [(source)](https://github.com/Microsoft/BotFramework-WebChat/tree/preview/samples/full-bundle)
+- [Full bundle with polyfills for ES5 browsers](https://microsoft.github.io/BotFramework-WebChat/es5-bundle) [(source)](https://github.com/Microsoft/BotFramework-WebChat/tree/preview/samples/es5-bundle)
 - [Minimal bundle](https://microsoft.github.io/BotFramework-WebChat/minimal-bundle) [(source)](https://github.com/Microsoft/BotFramework-WebChat/tree/preview/samples/minimal-bundle)
 - [Minimal bundle with Markdown](https://microsoft.github.io/BotFramework-WebChat/minimal-bundle-with-markdown) [(source)](https://github.com/Microsoft/BotFramework-WebChat/tree/preview/samples/minimal-bundle-with-markdown)
+
+> You can look at this [sunburst chart](http://cdn.botframework.com/botframework-webchat/preview/stats.html) for better understanding on the content of various bundles.
 
 ### Thru NPM (as a React component)
 

--- a/samples/es5-bundle/index.html
+++ b/samples/es5-bundle/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Web Chat: Full-featured bundle with ES5 polyfills</title>
+    <script src="https://cdn.botframework.com/botframework-webchat/preview/botchat-es5.js"></script>
+    <style>
+      html, body { height: 100% }
+      body { margin: 0 }
+
+      #webchat,
+      #webchat > * {
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      // In this demo, we are using Direct Line token from MockBot.
+      // To talk to your bot, you should use the token exchanged using your Direct Line secret.
+      // You should never put the Direct Line secret in the browser or client app.
+      // https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication
+
+      // This code is modified to run in browser without async and Promise support
+      window.fetch('https://webchat-mockbot.azurewebsites.net/directline/token', { method: 'POST' })
+        .then(function (res) {
+          return res.json();
+        })
+        .then(function (json) {
+          const token = json.token;
+
+          window.WebChat.renderWebChat({
+            directLine: window.WebChat.createDirectLine({
+              token: token
+            })
+          }, document.getElementById('webchat'));
+
+          document.querySelector('#webchat > *').focus();
+        });
+    </script>
+  </body>
+</html>

--- a/samples/es5-bundle/serve.json
+++ b/samples/es5-bundle/serve.json
@@ -1,0 +1,7 @@
+{
+  "public": "../..",
+  "redirects": [
+    { "source": "/", "destination": "samples/es5-bundle/index.html" },
+    { "source": "/botchat-es5.js", "destination": "packages/bundle/dist/botchat-es5.js" }
+  ]
+}

--- a/samples/es5-bundle/serve.json
+++ b/samples/es5-bundle/serve.json
@@ -1,7 +1,0 @@
-{
-  "public": "../..",
-  "redirects": [
-    { "source": "/", "destination": "samples/es5-bundle/index.html" },
-    { "source": "/botchat-es5.js", "destination": "packages/bundle/dist/botchat-es5.js" }
-  ]
-}


### PR DESCRIPTION
- Remove `bluebird`
- Use `core-js` for `Promise` and other ES6/7 polyfills
- Use `url-search-params-polyfill` for `URLSearchParams`
- Use `whatwg-fetch` for `fetch`
- Custom parseURL (because there are no good `URL` polyfill)
- Fix video height in IE11