### PR TITLE
[DRAFT] Prime code_challenge in OAuth card

### DIFF
--- a/packages/component/.babelrc
+++ b/packages/component/.babelrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
-    "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-transform-runtime"
   ],
   "presets": [
     "@babel/preset-typescript",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -833,6 +833,52 @@
         "regenerator-transform": "^0.12.4"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
+      "integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+          "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz",
+          "integrity": "sha512-pb1I05sZEKiSlMUV9UReaqsCPUpgbHHHu2n1piRm7JkuBkm6QxcaIzKu6FMnMtCbih/cEYTR+RGYYC96Yk9HAg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.51.tgz",
@@ -970,6 +1016,21 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.51",
         "@babel/plugin-transform-typescript": "7.0.0-beta.51"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "@babel/template": {
@@ -3038,14 +3099,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3060,20 +3119,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3190,8 +3246,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3203,7 +3258,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3218,7 +3272,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3226,14 +3279,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3252,7 +3303,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3333,8 +3383,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3346,7 +3395,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3468,7 +3516,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -41,6 +41,7 @@
     "@babel/cli": "^7.0.0-beta.51",
     "@babel/core": "^7.0.0-beta.51",
     "@babel/plugin-proposal-class-properties": "^7.0.0-beta.56",
+    "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.0.0-beta.51",
     "@babel/preset-react": "^7.0.0-beta.51",
     "@babel/preset-typescript": "^7.0.0-beta.51",
@@ -57,6 +58,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.1.2",
     "adaptivecards": "^1.0.0",
     "botframework-webchat-core": "^0.0.0-0",
     "bytes": "^3.0.0",

--- a/packages/component/src/Attachment/OAuthCardAttachment.js
+++ b/packages/component/src/Attachment/OAuthCardAttachment.js
@@ -12,7 +12,10 @@ export default class extends React.Component {
       const builder = new AdaptiveCardBuilder(adaptiveCards);
 
       builder.addCommonHeaders(content);
-      builder.addButtons(content.buttons, true);
+
+      // "signin" button should be converted to "openUrl" with corresponding "?code_challenge" via saga in "botframework-webchat-core"
+      // Thus, if we see "signin" button, they are not converted and not ready for the user to click on
+      builder.addButtons(content.buttons.filter(({ type }) => type !== 'signin'));
 
       return builder.card;
     });

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -83,30 +83,6 @@ function createCardActionLogic({ directLine, dispatch }) {
           window.open(value);
           break;
 
-        case 'signin':
-          // TODO: [P3] We should prime the URL into the OAuthCard directly, instead of calling getSessionId on-demand
-          //       This is to eliminate the delay between window.open() and location.href call
-
-          const popup = window.open();
-
-          if (directLine.getSessionId)  {
-            const subscription = directLine.getSessionId().subscribe(sessionId => {
-              popup.location.href = `${ value }${ encodeURIComponent(`&code_challenge=${ sessionId }`) }`;
-
-              // HACK: Sometimes, the call complete asynchronously and we cannot unsubscribe
-              //       Need to wait some short time here to make sure the subscription variable has setup
-              setImmediate(() => subscription.unsubscribe());
-            }, error => {
-              // TODO: [P3] Let the user know something failed and we cannot proceed
-              //       This is as-of v3 now
-              console.error(error);
-            });
-          } else {
-            popup.location.href = value;
-          }
-
-          break;
-
         default:
           console.error(`Web Chat: received unknown card action "${ type }"`);
           break;

--- a/packages/component/src/Utils/AdaptiveCardBuilder.ts
+++ b/packages/component/src/Utils/AdaptiveCardBuilder.ts
@@ -19,17 +19,8 @@ export interface BotFrameworkCardAction extends CardAction {
   __isBotFrameworkCardAction: boolean;
 }
 
-function addCardAction(cardAction: CardAction, includesOAuthButtons?: boolean) {
+function addCardAction(cardAction: CardAction) {
   if (cardAction.type === 'imBack' || cardAction.type === 'postBack') {
-    const action = new SubmitAction();
-    const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...cardAction };
-
-    action.data = botFrameworkCardAction;
-    action.title = cardAction.title;
-
-    return action;
-  } else if (cardAction.type === 'signin' && includesOAuthButtons) {
-    // Create a button specific for OAuthCard 'signin' actions (cardAction.type == signin and button action is Action.Submit)
     const action = new SubmitAction();
     const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...cardAction };
 
@@ -91,9 +82,9 @@ export class AdaptiveCardBuilder {
     }
   }
 
-  addButtons(cardActions: CardAction[], includesOAuthButtons?: boolean) {
+  addButtons(cardActions: CardAction[]) {
     cardActions && cardActions.forEach(cardAction => {
-      this.card.addAction(addCardAction(cardAction, includesOAuthButtons));
+      this.card.addAction(addCardAction(cardAction));
     });
   }
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2690,8 +2690,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2712,14 +2711,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2734,20 +2731,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2864,8 +2858,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2877,7 +2870,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2892,7 +2884,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2900,14 +2891,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2926,7 +2915,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3007,8 +2995,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3020,7 +3007,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3106,8 +3092,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3143,7 +3128,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3163,7 +3147,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3207,14 +3190,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -6135,9 +6116,9 @@
 			"dev": true
 		},
 		"simple-update-in": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.3.0.tgz",
-			"integrity": "sha512-XQdzyPAjHeqcBDJfUBKgfnurtE9Z/PC7Jh73DAiNlS4vMkdVTrtNpg5GJEGSDOtJ5LPQdZ/BWTx5GNzsP89mlA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.3.1.tgz",
+			"integrity": "sha512-liUwgR6yIHGkazvU8wMZxEfxCvssH9FvzlTnRXPcVgLMU0iFVmMgs7yBxRXHvDfazfylpPfY+7lcvbsIVgMWOg=="
 		},
 		"slash": {
 			"version": "1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,6 @@
     "redux": "^4.0.0",
     "redux-promise-middleware": "^5.1.1",
     "redux-saga": "^0.16.0",
-    "simple-update-in": "^1.3.0"
+    "simple-update-in": "^1.3.1"
   }
 }

--- a/packages/core/src/reducers/activities.js
+++ b/packages/core/src/reducers/activities.js
@@ -29,11 +29,12 @@ function upsertActivityWithSort(activities, nextActivity) {
   } = nextActivity;
 
   const nextTimestamp = Date.parse(nextActivity.timestamp);
-  const nextActivities = activities.filter(({ channelData: { clientActivityID } = {}, from, type }) =>
+  const nextActivities = activities.filter(({ channelData: { clientActivityID } = {}, from, id, type }) =>
     // We will remove all "typing" and "sending messages" activities
     // "clientActivityID" is unique and used to track if the message has been sent and echoed back from the server
     !(
-      (type === 'typing' && from.id === nextFromID)
+      id === nextActivity.id
+      || (type === 'typing' && from.id === nextFromID)
       || (nextClientActivityID && clientActivityID === nextClientActivityID)
     )
   );
@@ -80,10 +81,7 @@ export default function (state = DEFAULT_STATE, { meta, payload, type }) {
       break;
 
     case UPSERT_ACTIVITY:
-      // UpdateActivity is not supported right now because we ignore duplicated activity ID
-      if (!~state.findIndex(({ id }) => id === payload.activity.id)) {
-        state = upsertActivityWithSort(state, payload.activity);
-      }
+      state = upsertActivityWithSort(state, payload.activity);
 
       break;
 

--- a/packages/core/src/sagas.js
+++ b/packages/core/src/sagas.js
@@ -6,6 +6,7 @@ import connectSaga from './sagas/connectSaga';
 import incomingActivitySaga from './sagas/incomingActivitySaga';
 import incomingTypingSaga from './sagas/incomingTypingSaga';
 import markActivityForSpeakSaga from './sagas/markActivityForSpeakSaga';
+import patchOAuthAttachmentSaga from './sagas/patchOAuthAttachmentSaga';
 import postActivitySaga from './sagas/postActivitySaga';
 import sendFilesToPostActivitySaga from './sagas/sendFilesToPostActivitySaga';
 import sendMessageToPostActivitySaga from './sagas/sendMessageToPostActivitySaga';
@@ -23,6 +24,7 @@ export default function* () {
   yield fork(incomingActivitySaga);
   yield fork(incomingTypingSaga);
   yield fork(markActivityForSpeakSaga);
+  yield fork(patchOAuthAttachmentSaga);
   yield fork(postActivitySaga);
   yield fork(sendFilesToPostActivitySaga);
   yield fork(sendMessageToPostActivitySaga);

--- a/packages/core/src/sagas/patchOAuthAttachmentSaga.js
+++ b/packages/core/src/sagas/patchOAuthAttachmentSaga.js
@@ -1,0 +1,63 @@
+import {
+  call,
+  put,
+  takeLatest
+} from 'redux-saga/effects';
+
+import updateIn from 'simple-update-in';
+import whileConnected from './effects/whileConnected';
+
+import upsertActivity, { UPSERT_ACTIVITY } from '../actions/upsertActivity';
+
+function observableToPromise(observable) {
+  return new Promise((resolve, reject) => {
+    const subscription = observable.subscribe(result => {
+      // HACK: Sometimes, the call complete asynchronously and we cannot unsubscribe
+      //       Need to wait some short time here to make sure the subscription variable has setup
+      setImmediate(() => subscription.unsubscribe());
+      resolve(result);
+    }, reject);
+  });
+}
+
+async function getSessionId(directLine) {
+  try {
+    return directLine.getSessionId ? await observableToPromise(directLine.getSessionId()) : Promise.resolve();
+  } catch (err) {
+    return Promise.resolve();
+  }
+}
+
+export default function* () {
+  yield whileConnected(function* (directLine) {
+    // We fetch session ID asynchronously to make sure if the call is slower than the first UPSERT_ACTIVITY, we won't miss the first few activites.
+    const sessionIdPromise = getSessionId(directLine);
+
+    // In this saga, we are going to patch OAuth card to prime the "&code_challenge" into the card.
+    // We moved the code from UI to here because it makes sense to prime it nomatter what UI the dev is using.
+    yield takeLatest(UPSERT_ACTIVITY, function* ({ payload: { activity } }) {
+      const sessionId = yield call(() => sessionIdPromise);
+      const nextActivity = updateIn(
+        activity,
+        [
+          'attachments',
+          attachment => attachment && attachment.contentType === 'application/vnd.microsoft.card.oauth',
+          'content',
+          'buttons',
+          button => button.type === 'signin'
+        ],
+        button => ({
+          ...button,
+          // After the conversion, we will change it to "openUrl"
+          // This will also make sure this loop is not called indefinitely
+          type: 'openUrl',
+          value: sessionId ? `${ button.value }&code_challenge=${ sessionId }` : button.value
+        })
+      );
+
+      if (activity !== nextActivity) {
+        yield put(upsertActivity(nextActivity));
+      }
+    });
+  });
+}


### PR DESCRIPTION
> This is marked as DRAFT. Please do not start code reviewing as the code may change significantly over time. I will assign reviewers once this PR is out of draft state.

- Prime `&code_challenge=SESSION_ID` in Redux store, instead of UI
   - It makes sense to patch the OAuth card before it reach the UI
   - The old approach, on slow network, will cause a popup to show up without loading anything (we call `window.open` and set `window.location` at different time, span across an async network call)
   - User who use Redux store only (e.g. speech-only button) will have benefits
- In addition, it will enable us to ponyfill `window.open` much easier
   - Ponyfilling `window.open` is important for Emulator and other PWA environment
- We cannot prime it for too long, the session ID only last for about an hour
   - We should only prime the URL when the activity arrive
   - And always get a new session ID (we could cache for 5 minutes, but cache hit is not very likely)