### PR TITLE
Preview

### DIFF
--- a/packages/component/src/Localization/ja-JP.js
+++ b/packages/component/src/Localization/ja-JP.js
@@ -1,3 +1,24 @@
+function xMinutesAgo(date) {
+  const now = Date.now();
+  const deltaInMs = now - new Date(date).getTime();
+  const deltaInMinutes = Math.floor(deltaInMs / 60000);
+  const deltaInHours = Math.floor(deltaInMs / 3600000);
+
+  if (deltaInMinutes < 1) {
+    return 'たった今';
+  } else if (deltaInHours < 1) {
+    return `${ deltaInMinutes } 分前`;
+  } else if (deltaInHours < 5) {
+    return `${ deltaInHours } 時間前`;
+  } else if (deltaInHours <= 24) {
+    return `今日`;
+  } else if (deltaInHours <= 48) {
+    return `昨日`;
+  } else {
+    return new Intl.DateTimeFormat('ja-JP').format(date);
+  }
+}
+
 export default {
   'Chat': 'チャット',
   'Listening': '聴いてます',
@@ -8,5 +29,5 @@ export default {
   'Type your message': 'メッセージを入力してください',
   'Total': '合計',
   'VAT': '消費税',
-  'Send': '送信'
-}
+  'Send': '送信',
+  'X minutes ago': xMinutesAgo}

--- a/packages/component/src/localize.test.js
+++ b/packages/component/src/localize.test.js
@@ -1,0 +1,50 @@
+import Localization, { localize } from './Localization/Localize';
+
+test('Japanese timestamp localization now', () => {
+    const expected = 'たった今';
+    testJapaneseTime(Date.now()- 1000, expected);
+    testJapaneseTime(Date.now()- 30000, expected);
+    testJapaneseTime(Date.now()- 50000, expected);
+    testJapaneseTime(Date.now()- 59999, expected);
+});
+
+test('Japanese timestamp localization within 1 hour', () => {
+    testJapaneseTime(Date.now()- 61000, '1 分前');
+    testJapaneseTime(Date.now()- 120001, '2 分前');
+    testJapaneseTime(Date.now()- 3540000, '59 分前');
+});
+
+test('Japanese timestamp localization within 5 hours', () => {
+    const oneHour = 3600000;
+    testJapaneseTime(Date.now()- oneHour, '1 時間前');
+    testJapaneseTime(Date.now()- (oneHour * 2), '2 時間前');
+    testJapaneseTime(Date.now()- (oneHour * 4), '4 時間前');
+});
+
+test('Japanese timestamp localization today', () => {
+    const oneHour = 3600000;
+    testJapaneseTime(Date.now()- (oneHour * 5), '今日');
+    testJapaneseTime(Date.now()- (oneHour * 6), '今日');
+    testJapaneseTime(Date.now()- (oneHour * 23), '今日');
+});
+
+test('Japanese timestamp localization yesterday', ()=> {
+    const oneHour = 3600000;
+    testJapaneseTime(Date.now()- (oneHour * 25), '昨日');
+    testJapaneseTime(Date.now()- (oneHour * 36), '昨日');
+    testJapaneseTime(Date.now()- (oneHour * 47), '昨日');
+    testJapaneseTime(Date.now()- (oneHour * 48), '昨日');
+
+});
+
+test('Japanese timestamp localization longer than yesterday', ()=> {
+    const oneHour = 3600000;
+    const formatter = new Intl.DateTimeFormat('ja-JP').format;
+    testJapaneseTime(Date.now()- (oneHour * 49), formatter(Date.now()- (oneHour * 49)));
+    testJapaneseTime(Date.now()- (oneHour * 120), formatter(Date.now()- (oneHour * 120)));
+});
+
+function testJapaneseTime(testDate, expectedResult){
+    const result = localize('X minutes ago', 'ja-JP', testDate);
+    expect(result).toEqual(expectedResult);
+}


### PR DESCRIPTION
The Japanese localization was missing the 'x minutes ago' feature.
I added unit tests for only for the `X minutes ago` localization for Japanese under `localize.test.js`.