### PR TITLE
Lerna version should use exact version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get install jq
   - npx version-from-git --travis
   - git checkout -b temp-ci
-  - lerna version --force-publish --no-git-tag-version --no-push --yes `cat package.json | jq -r .version`
+  - lerna version --exact --force-publish --no-git-tag-version --no-push --yes `cat package.json | jq -r .version`
 
 install:
   - npm run bootstrap


### PR DESCRIPTION
If `--exact` is not specified:
- `bundle` depends on `component@^4.0.0-preview.newer` and `core@^4.0.0-preview.newer`
- But since both are caret-ed version
- NPM will prefer version with `latest` tag, which means `@4.0.0-preview.veryold` instead