### PR TITLE
Prefer user ID from Direct Line token

### DIFF
--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -35,9 +35,6 @@ import shallowEquals from './Utils/shallowEquals';
 const EMPTY_ARRAY = [];
 const NULL_FUNCTION = () => ({});
 
-const DEFAULT_USER_ID = 'default-user';
-const DEFAULT_USERNAME = 'user';
-
 const DISPATCHERS = {
   markActivity,
   postActivity,
@@ -179,17 +176,17 @@ class Composer extends React.Component {
 
   componentWillMount() {
     const { props } = this;
-    const { directLine, userID, username } = props;
+    const { directLine, userID } = props;
 
     this.setLanguageFromProps(props);
     this.setSendTypingFromProps(props);
 
-    props.dispatch(createConnectAction({ directLine, userID, username }));
+    props.dispatch(createConnectAction({ directLine, userID }));
   }
 
   componentDidUpdate(prevProps) {
     const { props } = this;
-    const { directLine, locale, sendTyping, userID, username } = props;
+    const { directLine, locale, sendTyping, userID } = props;
 
     if (prevProps.locale !== locale) {
       this.setLanguageFromProps(props);
@@ -202,11 +199,10 @@ class Composer extends React.Component {
     if (
       prevProps.directLine !== directLine
       || prevProps.userID !== userID
-      || prevProps.username !== username
     ) {
       // TODO: [P3] disconnect() is an async call (pending -> fulfilled), we need to wait, or change it to reconnect()
       props.dispatch(disconnect());
-      props.dispatch(createConnectAction({ directLine, userID, username }));
+      props.dispatch(createConnectAction({ directLine, userID }));
     }
   }
 
@@ -297,11 +293,6 @@ Composer.propTypes = {
   userAvatarInitials: PropTypes.string,
   userID: PropTypes.string,
   webSpeechPonyfillFactory: PropTypes.func
-};
-
-Composer.defaultProps = {
-  userID: DEFAULT_USER_ID,
-  username: DEFAULT_USERNAME
 };
 
 // TODO: [P3] Should we hide the knowledge of Redux?

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1505,6 +1505,11 @@
 				"node-int64": "^0.4.0"
 			}
 		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+		},
 		"buffer-from": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -2195,6 +2200,14 @@
 				"jsbn": "~0.1.0"
 			}
 		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+			"integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"electron-to-chromium": {
 			"version": "1.3.52",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
@@ -2690,8 +2703,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2712,14 +2724,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2734,20 +2744,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2864,8 +2871,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2877,7 +2883,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2892,7 +2897,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2900,14 +2904,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2926,7 +2928,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3007,8 +3008,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3020,7 +3020,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3106,8 +3105,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3143,7 +3141,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3163,7 +3160,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3207,14 +3203,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4853,6 +4847,29 @@
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 			"dev": true
 		},
+		"jsonwebtoken": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+			"integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+			"requires": {
+				"jws": "^3.1.5",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4863,6 +4880,25 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
+			}
+		},
+		"jwa": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+			"integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.10",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+			"integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+			"requires": {
+				"jwa": "^1.1.5",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"kind-of": {
@@ -4944,6 +4980,41 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true,
 			"optional": true
+		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -6005,8 +6076,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0-rc.2",
     "event-as-promise": "^1.0.3",
+    "jsonwebtoken": "^8.3.0",
     "redux": "^4.0.0",
     "redux-promise-middleware": "^5.1.1",
     "redux-saga": "^0.16.0",

--- a/packages/core/src/actions/connect.js
+++ b/packages/core/src/actions/connect.js
@@ -7,10 +7,10 @@ const CONNECT_PENDING = `${ CONNECT }_PENDING`;
 const CONNECT_REJECTED = `${ CONNECT }_REJECTED`;
 const CONNECT_FULFILLED = `${ CONNECT }_FULFILLED`;
 
-export default function ({ directLine, userID, username }) {
+export default function ({ directLine, userID }) {
   return {
     type: CONNECT,
-    payload: { directLine, userID, username }
+    payload: { directLine, userID }
   };
 }
 

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -7,6 +7,8 @@ import {
   take,
 } from 'redux-saga/effects';
 
+import { decode } from 'jsonwebtoken';
+
 import callUntil from './effects/callUntil';
 import forever from './effects/forever';
 
@@ -36,6 +38,17 @@ const ENDED = 5;
 export default function* () {
   for (;;) {
     const { payload: { directLine, userID, username } } = yield take(CONNECT);
+    const { token } = directLine;
+    const { user: userIDFromToken } = decode(token) || {};
+
+    if (userIDFromToken) {
+      if (userID && userID !== userIDFromToken) {
+        console.warn('Web Chat: user ID is both specified in the Direct Line token and passed in, will use the user ID from the token.');
+      }
+
+      userID = userIDFromToken;
+    }
+
     const connectTask = yield fork(connectSaga, directLine, userID, username);
 
     yield take(DISCONNECT);

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -35,9 +35,11 @@ const ONLINE = 2;
 // const FAILED_TO_CONNECT = 4;
 const ENDED = 5;
 
+const DEFAULT_USER_ID = 'default-user';
+
 export default function* () {
   for (;;) {
-    const { payload: { directLine, userID, username } } = yield take(CONNECT);
+    const { payload: { directLine, userID } } = yield take(CONNECT);
     const { token } = directLine;
     const { user: userIDFromToken } = decode(token) || {};
 
@@ -47,17 +49,20 @@ export default function* () {
       }
 
       userID = userIDFromToken;
+    } else if (!userID) {
+      // Only specify "default-user" if not found from token and not passed in
+      userID = DEFAULT_USER_ID;
     }
 
-    const connectTask = yield fork(connectSaga, directLine, userID, username);
+    const connectTask = yield fork(connectSaga, directLine, userID);
 
     yield take(DISCONNECT);
     yield call(disconnectSaga, connectTask, directLine);
   }
 }
 
-function* connectSaga(directLine, userID, username) {
-  const meta = { userID, username };
+function* connectSaga(directLine, userID) {
+  const meta = { userID };
 
   yield put({ type: CONNECT_PENDING, meta });
 

--- a/packages/core/src/sagas/effects/whileConnected.js
+++ b/packages/core/src/sagas/effects/whileConnected.js
@@ -11,8 +11,8 @@ import { DISCONNECT_FULFILLED } from '../../actions/disconnect';
 export default function (fn) {
   return call(function* () {
     for (;;) {
-      const { meta: { userID, username }, payload: { directLine } } = yield take(CONNECT_FULFILLED);
-      const task = yield fork(fn, directLine, userID, username);
+      const { meta: { userID }, payload: { directLine } } = yield take(CONNECT_FULFILLED);
+      const task = yield fork(fn, directLine, userID);
 
       yield take(DISCONNECT_FULFILLED);
       yield cancel(task);

--- a/packages/core/tests/connectionStatus.test.js
+++ b/packages/core/tests/connectionStatus.test.js
@@ -11,8 +11,7 @@ test('Connection status', async () => {
     type: START_CONNECTION,
     payload: {
       directLine,
-      userID: 'default-user',
-      username: 'WC'
+      userID: 'default-user'
     }
   });
 

--- a/packages/core/tests/createFacility.js
+++ b/packages/core/tests/createFacility.js
@@ -4,7 +4,6 @@ import { START_CONNECTION } from '../src/actions/startConnection';
 import createStore from '../src/createStore';
 
 const DEFAULT_USER_ID = 'default-user';
-const DEFAULT_USERNAME = 'John Doe';
 
 jest.mock('../src/util/getTimestamp', () => {
   let now = 946684800000; // '2000-01-01T00:00:00.000Z'
@@ -48,8 +47,7 @@ export default async function ({
       type: START_CONNECTION,
       payload: {
         directLine,
-        userID: DEFAULT_USER_ID,
-        username: DEFAULT_USERNAME
+        userID: DEFAULT_USER_ID
       }
     });
 

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -57,8 +57,8 @@ export default class extends React.Component {
     super(props);
 
     this.handleBotAvatarInitialsChange = this.handleBotAvatarInitialsChange.bind(this);
-    this.handleGroupTimestampChange = this.handleGroupTimestampChange.bind(this);
     this.handleDisabledChange = this.handleDisabledChange.bind(this);
+    this.handleGroupTimestampChange = this.handleGroupTimestampChange.bind(this);
     this.handleHideSendBoxChange = this.handleHideSendBoxChange.bind(this);
     this.handleLanguageChange = this.handleLanguageChange.bind(this);
     this.handleReliabilityChange = this.handleReliabilityChange.bind(this);
@@ -77,7 +77,7 @@ export default class extends React.Component {
     const directLineToken = params.get('t');
     const domain = params.get('domain');
     const speech = params.get('speech');
-    const userID = params.get('u') || 'default-user';
+    const userID = params.get('u');
     const webSocket = params.get('websocket');
 
     if (speech === 'cs') {
@@ -161,7 +161,7 @@ export default class extends React.Component {
 
   handleUseEmulatorCoreClick() {
     window.sessionStorage.removeItem('REDUX_STORE');
-    window.location.href = '?domain=http://localhost:5000/v3/directline&websocket=0';
+    window.location.href = '?domain=http://localhost:5000/v3/directline&websocket=0&u=default-user';
   }
 
   handleUserAvatarInitialsChange({ target: { value } }) {
@@ -176,15 +176,13 @@ export default class extends React.Component {
         throw new Error(`Server returned ${ directLineTokenRes.status } while requesting for Direct Line token`);
       }
 
-      // TODO: [P4] We should use JWT to get user ID so it don't introduce inconsistencies
-      const { userID, token } = await directLineTokenRes.json();
+      const { token } = await directLineTokenRes.json();
 
       window.sessionStorage.removeItem('REDUX_STORE');
       window.location.href = '/?' + new URLSearchParams({
         speech: 'cs',
         websocket: 'true',
-        t: token,
-        u: userID || ''
+        t: token
       }).toString();
     } catch (err) {
       console.log(err);

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -215,7 +215,6 @@ export default class extends React.Component {
           styleSet={ styleSet }
           userAvatarInitials={ state.userAvatarInitials }
           userID={ state.userID }
-          username="User 1"
           webSpeechPonyfillFactory={ this.webSpeechPonyfillFactory }
         />
         <div className="button-bar">

--- a/packages/playground/src/SpeechOnlyButton/index.js
+++ b/packages/playground/src/SpeechOnlyButton/index.js
@@ -31,8 +31,7 @@ export default class SpeechOnlyButton extends React.Component {
         },
         webSocket: false
       }),
-      userID: 'default-user',
-      username: 'User-1'
+      userID: 'default-user'
     }));
   }
 

--- a/samples/backend-cli/src/index.ts
+++ b/samples/backend-cli/src/index.ts
@@ -86,8 +86,7 @@ function main() {
       },
       webSocket: false
     }),
-    userID: 'default-user',
-    username: 'User-1'
+    userID: 'default-user'
   }));
 
   rl.on('line', line => {


### PR DESCRIPTION
- JWT generated from Direct Line will now contains "user" field, indicating the user ID associated with this token. More details can be found in this [article](https://blog.botframework.com/2018/09/01/using-webchat-with-azure-bot-services-authentication/)
   - If user ID is available from JWT, we should use it because it's more authoritative (not to mention its security nature)
      - JWT is from the hosted page, given it's developed by the same developer, it should be secure enough to trust the embedded user ID without verifying it
   - If there is a conflict between `props.userID` vs. user ID in JWT, we will prefer the one from JWT and give a warning
- Also, we are removing `username` because it was not used
   - For avatar initials, we are using values from `botAvatarInitials` and `userAvatarInitials`

(@mingweiw Web Chat will now prefer the user ID in JWT, than the one the user passed in. This is done automatically)