### PR TITLE
Use webchat.js as bundle name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is how how you can add Web Chat control to you website:
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <script>
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ secret: 'YOUR_BOT_SECRET_FROM_AZURE_PORTAL' })
@@ -50,7 +50,7 @@ You can use the full, typical webchat package that contains the most typically u
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <script>
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECREET' })
@@ -78,7 +78,7 @@ See a working sample with minimal Web Chat bundle [here](https://github.com/Micr
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-minimal.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-minimal.js"></script>
     <script>
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECRET' })

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -23,7 +23,7 @@ If you need to do some simple styling, you can set them thru `styleOptions`. Sty
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <script>
       const styleOptions = {
         bubbleBackground: 'rgba(0, 0, 255, .1)',
@@ -56,7 +56,7 @@ For deeper styling, you can also modify the style set manually by setting the CS
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <script>
       // "styleSet" is a set of CSS rules which are generated from "styleOptions"
       const styleSet = window.WebChat.createStyleSet({
@@ -92,7 +92,7 @@ The latest Web Chat support avatar, you can customize them using `botAvatarIniti
 <html>
   <body>
     <div id="webchat"></div>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <script>
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ secret: 'YOUR_BOT_SECRET' }),

--- a/packages/bundle/webpack.config.js
+++ b/packages/bundle/webpack.config.js
@@ -3,9 +3,9 @@ const Visualizer = require('webpack-visualizer-plugin');
 
 module.exports = {
   entry: {
-    'botchat': './lib/index.js',
-    'botchat-es5': './lib/index-es5.js',
-    'botchat-minimal': './lib/index-minimal.js'
+    'webchat': './lib/index.js',
+    'webchat-es5': './lib/index-es5.js',
+    'webchat-minimal': './lib/index-minimal.js'
   },
   output: {
     filename: '[name].js',

--- a/samples/activity-decorator-button/index.html
+++ b/samples/activity-decorator-button/index.html
@@ -10,7 +10,12 @@
     <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
     <script src="https://unpkg.com/glamor@2.20.40/umd/index.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/activity-decorator-highlight/index.html
+++ b/samples/activity-decorator-highlight/index.html
@@ -10,7 +10,12 @@
     <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
     <script src="https://unpkg.com/glamor@2.20.40/umd/index.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/avatar-initials/index.html
+++ b/samples/avatar-initials/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Avatar with initials</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/custom-attachment-github-repository/index.html
+++ b/samples/custom-attachment-github-repository/index.html
@@ -9,7 +9,12 @@
     <script src="https://unpkg.com/react@16.5.0/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/custom-redux-store/index.html
+++ b/samples/custom-redux-store/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Custom Redux store</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js"
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/custom-style-options/index.html
+++ b/samples/custom-style-options/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Custom style options</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/custom-style-set/index.html
+++ b/samples/custom-style-set/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Custom style set</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/es5-bundle/index.html
+++ b/samples/es5-bundle/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Full-featured bundle with ES5 polyfills</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-es5.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat-es5.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat-es5.js".
+      Or locked down on a specific version "/4.1.0/webchat-es5.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-es5.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/full-bundle/README.md
+++ b/samples/full-bundle/README.md
@@ -40,10 +40,14 @@ The `index.html` page has two main goals.
 ```diff
 …
 <head>
-+ <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
++ <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
 </head>
 …
 ```
+
+> For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+> When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+> Or locked down on a specific version "/4.1.0/webchat.js".
 
 Next, the code to render Web Chat must be added to the body. Note that MockBot uses **tokens** rather than the **Direct Line secret**.
 > It is **never recommended** to put the Direct Line secret in the browser or client app. To learn more about secrets and tokens for Direct Line, visit [this tutorial on authentication](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication).
@@ -104,7 +108,7 @@ Here is the finished `index.html`:
 <html lang="en-US">
   <head>
     <title>Web Chat: Full-featured bundle</title>
-+   <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
++   <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
    <style>
 +    html, body { height: 100% }
 +    body { margin: 0 }

--- a/samples/full-bundle/index.html
+++ b/samples/full-bundle/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Full-featured bundle</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/integrate-with-react/README.md
+++ b/samples/integrate-with-react/README.md
@@ -43,10 +43,14 @@ We'll start by adding React and Babel to the head our template, based off of the
 + <script src="https://unpkg.com/react@16.5.0/umd/react.development.js"></script>
 + <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
 + <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
-  <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+  <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
 </head>
 …
 ```
+
+> For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+> When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+> Or locked down on a specific version "/4.1.0/webchat.js".
 
 The core of this code both creates and renders the React component that displays Web Chat.
 
@@ -82,7 +86,7 @@ Here is the finished `index.html`:
 +   <script src="https://unpkg.com/react@16.5.0/umd/react.development.js"></script>
 +   <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
 +   <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/integrate-with-react/index.html
+++ b/samples/integrate-with-react/index.html
@@ -8,7 +8,12 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
     <script src="https://unpkg.com/react@16.5.0/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/minimal-bundle-with-markdown/index.html
+++ b/samples/minimal-bundle-with-markdown/index.html
@@ -7,10 +7,16 @@
       - Adaptive Cards
       - Cognitive Services Bing Speech
       - Markdown-It
+      - sanitize-html
 
       And then, we bring Markdown-It back to the project.
     -->
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-minimal.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat-minimal.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat-minimal.js".
+      Or locked down on a specific version "/4.1.0/webchat-minimal.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-minimal.js"></script>
     <script src="https://unpkg.com/markdown-it@8.4.2/dist/markdown-it.min.js"></script>
     <style>
       html, body { height: 100% }

--- a/samples/minimal-bundle/README.md
+++ b/samples/minimal-bundle/README.md
@@ -41,11 +41,15 @@ The only change needed in this sample is to change the Web Chat CDN from the ful
 ```diff
 …
 <head>
-- <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
-+ <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-minimal.js"></script>
+- <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
++ <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-minimal.js"></script>
 </head>
 …
 ```
+
+> For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+> When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+> Or locked down on a specific version "/4.1.0/webchat.js".
 
 ## Completed code
 
@@ -56,8 +60,8 @@ Here is the finished `index.html`:
 <html lang="en-US">
   <head>
     <title>Web Chat: Minimal bundle</title>
-- <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
-+   <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-minimal.js"></script>
+- <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
++   <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-minimal.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/minimal-bundle/index.html
+++ b/samples/minimal-bundle/index.html
@@ -3,15 +3,21 @@
   <head>
     <title>Web Chat: Minimal bundle</title>
     <!--
-      We are using a "core" build, which does not contain:
+      We are using a "minimal" build, which does not contain:
       - Adaptive Cards
       - Cognitive Services Bing Speech
       - Markdown-It
+      - sanitize-html
 
       However, it contains:
       - Direct Line JS
     -->
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat-minimal.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat-minimal.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat-minimal.js".
+      Or locked down on a specific version "/4.1.0/webchat-minimal.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-minimal.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/presentation-mode/index.html
+++ b/samples/presentation-mode/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Presentation mode</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/speech-browser/README.md
+++ b/samples/speech-browser/README.md
@@ -56,7 +56,7 @@ Here is the finished `index.html`:
 <html lang="en-US">
   <head>
     <title>Web Chat: Browser-supported speech</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/speech-browser/index.html
+++ b/samples/speech-browser/index.html
@@ -6,7 +6,12 @@
        Speech functionality is a core feature in Web Chat and does not require the full bundle.
        You can use either the core bundle or full bundle, depending on your other bot specifications.
     -->
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/speech-browser/serve.json
+++ b/samples/speech-browser/serve.json
@@ -2,6 +2,6 @@
   "public": "../../",
   "rewrites": [
     { "source": "/", "destination": "samples/speech-browser/index.html" },
-    { "source": "/botchat-minimal.js", "destination": "packages/bundle/dist/botchat-minimal.js" }
+    { "source": "/webchat-minimal.js", "destination": "packages/bundle/dist/webchat-minimal.js" }
   ]
 }

--- a/samples/speech-cognitive-services-bing-speech-react/index.html
+++ b/samples/speech-cognitive-services-bing-speech-react/index.html
@@ -9,7 +9,12 @@
     <script src="https://unpkg.com/react@16.5.0/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@16.5.0/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/react-redux@5.0.7/dist/react-redux.min.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/speech-cognitive-services-bing-speech/README.md
+++ b/samples/speech-cognitive-services-bing-speech/README.md
@@ -26,11 +26,10 @@ A simple web page with a maximized and full-featured Web Chat embed from a CDN, 
 The `index.html` page has one main goal:
 - To enable cognitive services to provide speech-to-text ability
 
-We'll start by using the [full-bundle CDN sample](./../full-bundle/README.md) as our Web Chat template.
+We'll start by using the [full-bundle CDN sample](../full-bundle/README.md) as our Web Chat template.
 > Cognitive Services Bing Speech package is only available in the Web Chat full bundle
 
 > **Retrieving the subscription key in the URL and fetching a token is for demonstration purposes only.** In a published bot, the secret should be stored on the server and generate a token to avoid exposing the secret. For more information, visit the [websocket protocol documenation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/api-reference-rest/websocketprotocol#authorization) for Cognitive Services.
-
 
 First, the app must retrieve the __speech cognitive services subscription key__ when running this bot. Add the `URLSearchParams` method to retrieve the key from the URL.
 
@@ -51,13 +50,15 @@ Next, the bot needs to fetch a **token** using the subscription key when the pre
 + const TOKEN_RENEWAL_INTERVAL = 300000;
 + let accessTokenPromise;
 + let lastFetch = 0;
-
++
 + const fetchToken = () => {
 + const now = Date.now();
++
 + if (!accessTokenPromise || now - lastFetch > TOKEN_RENEWAL_INTERVAL) {
 +   console.log(`Cognitive Services: Issuing new token using subscription key`);
-
++
 +   lastFetch = now;
++
 +   accessTokenPromise = fetch(
 +   'https://api.cognitive.microsoft.com/sts/v1.0/issueToken',
 +   {
@@ -70,8 +71,10 @@ Next, the bot needs to fetch a **token** using the subscription key when the pre
 +    return Promise.reject(err);
 +  });
 + }
++
 + return accessTokenPromise;
 };
+
 window.WebChat.renderWebChat({
 …
 ```
@@ -97,7 +100,7 @@ Here is the finished `index.html`:
 <html lang="en-US">
   <head>
     <title>Web Chat: Cognitive Services Bing Speech using JavaScript</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/speech-cognitive-services-bing-speech/index.html
+++ b/samples/speech-cognitive-services-bing-speech/index.html
@@ -3,7 +3,12 @@
   <head>
     <title>Web Chat: Cognitive Services Bing Speech using JavaScript</title>
     <!-- Cognitive Services Bing Speech adapter is only available in full bundle -->
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }

--- a/samples/timestamp-grouping/index.html
+++ b/samples/timestamp-grouping/index.html
@@ -2,7 +2,12 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Configurable timestamp grouping</title>
-    <script src="https://cdn.botframework.com/botframework-webchat/master/botchat.js"></script>
+    <!--
+      For demonstration purpose, we are using development branch of Web Chat at "/master/webchat.js".
+      When you are using Web Chat for production, you should use the latest stable at "/latest/webchat.js".
+      Or locked down on a specific version "/4.1.0/webchat.js".
+    -->
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body {

--- a/serve.json
+++ b/serve.json
@@ -1,8 +1,8 @@
 {
   "redirects": [
     { "source": "/", "destination": "samples/full-bundle/index.html" },
-    { "source": "/botchat.js", "destination": "packages/bundle/dist/botchat.js" },
-    { "source": "/botchat-es5.js", "destination": "packages/bundle/dist/botchat-es5.js" },
-    { "source": "/botchat-minimal.js", "destination": "packages/bundle/dist/botchat-minimal.js" }
+    { "source": "/webchat.js", "destination": "packages/bundle/dist/webchat.js" },
+    { "source": "/webchat-es5.js", "destination": "packages/bundle/dist/webchat-es5.js" },
+    { "source": "/webchat-minimal.js", "destination": "packages/bundle/dist/webchat-minimal.js" }
   ]
 }


### PR DESCRIPTION
To prevent colliding with Web Chat v3, which use `botchat-*.js` as bundle name.