### PR TITLE
Fix activity without "from"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       - `webpack@4.24.0`
       - `webpack-command@0.4.2`
 
+### Fixed
+- Fix [#1397](https://github.com/Microsoft/BotFramework-WebChat/issues/1397/) by patching activities without `from` field, in PR [#1405](https://github.com/Microsoft/BotFramework-WebChat/pull/1405)
+
 ## [4.1.0] - 2018-10-31
 ### Added
 - Initial release of Web Chat v4

--- a/packages/core/src/sagas/incomingActivitySaga.js
+++ b/packages/core/src/sagas/incomingActivitySaga.js
@@ -25,11 +25,15 @@ export default function* () {
       activity = { ...activity };
 
       // Patch activity.from.role to make sure its either "bot", "user", or "channel"
-      if (!activity.from.role) {
+      if (!activity.from) {
+        activity.from = { role: 'channel' };
+      } else if (!activity.from.role) {
         if (activity.from.id === userID) {
           activity.from.role = 'user';
-        } else {
+        } else if (activity.from.id) {
           activity.from.role = 'bot';
+        } else {
+          activity.from.role = 'channel';
         }
       }
 
@@ -39,7 +43,11 @@ export default function* () {
       const activities = yield select(({ activities }) => activities);
       const lastMessageActivity = last(activities, ({ type }) => type === 'message');
 
-      if (lastMessageActivity.from.role === 'bot') {
+      if (
+        lastMessageActivity
+        && lastMessageActivity.from
+        && lastMessageActivity.from.role === 'bot'
+      ) {
         const { suggestedActions: { actions } = {} } = lastMessageActivity;
 
         yield put(setSuggestedActions(actions));


### PR DESCRIPTION
> Will fix #1397.

### Changes

- Patch `activity.from.role`
   - `"user"` if `from.id` is user ID, otherwise,
   - `"bot"` if `from.id` is anything otherwise,
   - `"channel"`, because either `from` or `from.id` was not defined (e.g. in `ConversationUpdate` activity)
- Should not set suggested actions if there are nothing on the transcript