### PR TITLE
Add sample for user ID and more validation logics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Code is instrumented using [`istanbul`](https://npmjs.com/package/istanbul)
    - Test report is hosted on [Coveralls](https://coveralls.io/github/compulim/BotFramework-WebChat)
 - Add French localization, by [@tao1](https://github.com/tao1) in PR [#1327](https://github.com/Microsoft/BotFramework-WebChat/pull/1327)
+- Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344), by updating `README.md` and adding validation logic for `userID` props, in [#1447](https://github.com/Microsoft/BotFramework-WebChat/pull/1447)
+   - If `userID` props present and also embedded in Direct Line token, will use the one from Direct Line token
+   - If `userID` props present, they must be string and not prefixed with `dl_`, to avoid confusion between `userID` props and Direct Line embedded user ID (which is forgery-proof)
+   - If `userID` props does not pass the validation test or not specified, Web Chat will use `default-user` instead
 
 ### Changed
 - Core: Saga will run after custom middleware, in [#1331](https://github.com/Microsoft/BotFramework-WebChat/pull/1331)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Here is how how you can add Web Chat control to you website:
 </html>
 ```
 
+> If `userID` is not specified, it will be default to `default-user`. Multiple users sharing the same user ID is not recommended, their user state will be shared.
+
 ![Screenshot of Web Chat](https://raw.githubusercontent.com/Microsoft/BotFramework-WebChat/master/doc/webchat-screenshot.png)
 
 ## Integrate with JavaScript

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Here is how how you can add Web Chat control to you website:
     <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <script>
       window.WebChat.renderWebChat({
-        directLine: window.WebChat.createDirectLine({ secret: 'YOUR_BOT_SECRET_FROM_AZURE_PORTAL' })
+        directLine: window.WebChat.createDirectLine({ secret: 'YOUR_BOT_SECRET_FROM_AZURE_PORTAL' }),
+        userID: 'YOUR_USER_ID'
       }, document.getElementById('webchat'));
     </script>
   </body>
@@ -54,7 +55,8 @@ You can use the full, typical webchat package that contains the most typically u
     <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <script>
       window.WebChat.renderWebChat({
-        directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECREET' })
+        directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECRET' }),
+        userID: 'YOUR_USER_ID'
       }, document.getElementById('webchat'));
     </script>
   </body>
@@ -82,7 +84,8 @@ See a working sample with minimal Web Chat bundle [here](https://github.com/Micr
     <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat-minimal.js"></script>
     <script>
       window.WebChat.renderWebChat({
-        directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECRET' })
+        directLine: window.WebChat.createDirectLine({ token: 'YOUR_BOT_SECRET' }),
+        userID: 'YOUR_USER_ID'
       }, document.getElementById('webchat'));
     </script>
   </body>
@@ -109,7 +112,7 @@ export default class extends React.Component {
 
   render() {
     return (
-      <ReactWebChat directLine={ this.directLine } />
+      <ReactWebChat directLine={ this.directLine } userID="YOUR_USER_ID" />
       element
     );
   }

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -49,7 +49,15 @@ export default function* () {
       }
 
       userID = userIDFromToken;
-    } else if (!userID) {
+    } else if (userID) {
+      if (typeof userID !== 'string') {
+        console.warn('Web Chat: user ID must be a string.');
+        userID = DEFAULT_USER_ID;
+      } else if (/^dl_/.test(userID)) {
+        console.warn('Web Chat: user ID prefixed with "dl_" is reserved and must be embedded into the Direct Line token to prevent forgery.');
+        userID = DEFAULT_USER_ID;
+      }
+    } else {
       // Only specify "default-user" if not found from token and not passed in
       userID = DEFAULT_USER_ID;
     }


### PR DESCRIPTION
## Background

If user ID is not specified, default will be `default-user`.

Although conversation is identified/partitioned by conversation ID, user state use user ID. That means, multiple conversations with same user ID will share same user state.

In README.md, we didn't spec out how to specify `userID`. This PR will add the documentation and more checks to make sure the `userID` passed is okay:

- `userID` can be specified by props or embedded in Direct Line token.
   - If the `userID` is both specified and embedded, we prefer the embedded one from Direct Line token.
- `userID` must be a string.
- `userID` passed from props cannot prefix with `dl_`.
   - Embedded user ID is always prefixed with `dl_`, and this user ID is "forgery-proof". This checks reduces the confusion between a forgery-proof user ID and a non-forgery-proof one.

## Changelog

### Added

- Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344), by updating `README.md` and adding validation logic for `userID` props, in [#1447](https://github.com/Microsoft/BotFramework-WebChat/pull/1447)
   - If `userID` props present and also embedded in Direct Line token, will use the one from Direct Line token
   - If `userID` props present, they must be string and not prefixed with `dl_`, to avoid confusion between `userID` props and Direct Line embedded user ID (which is forgery-proof)
   - If `userID` props does not pass the validation test or not specified, Web Chat will use `default-user` instead