### PR TITLE
Bump react-scripts@2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added/Changed/Removed
 - Added something, by [@johndoe](https://github.com/johndoe), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
+### Changed (for dependency bumps)
+- `core`: Bumps to [`abc@1.2.3`](https://npmjs.com/package/abc/), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+
 ### Fixed
 - Fix [#XXX](https://github.com/Microsoft/BotFramework-WebChat/issues/XXX). Patched something, by [@johndoe](https://github.com/johndoe) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 -->
 
 ## [Unreleased]
 ### Added
-- Bumps [`botframework-directlinejs`](https://github.com/Microsoft/BotFramework-DirectLineJS/) dependency in playground package to `0.10.0`, in PR [#1511](https://github.com/Microsoft/BotFramework-WebChat/pull/1511)
 - Fix [#1383](https://github.com/Microsoft/BotFramework-WebChat/issues/1383). Added options to hide upload button, by [@compulim](https://github.com/compulim) in PR [#1491](https://github.com/Microsoft/BotFramework-WebChat/pull/1491)
 - Added support of avatar image, thru `styleOptions.botAvatarImage` and `styleOptions.userAvatarImage`, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)
 
 ### Changed
 - Moved `botAvatarImage` and `userAvatarImage` to `styleOptions.botAvatarImage` and `styleOptions.userAvatarImage` respectively, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)
 - Fix string interpolation error in Russian localization and fallback for browsers without Intl support by [@odysseus1973](https://github.com/odysseus1973) in PR [#1509](https://github.com/Microsoft/BotFramework-WebChat/pull/1509)
+- `playground`: Bumps to [`botframework-directlinejs@0.10.0`](https://github.com/Microsoft/BotFramework-DirectLineJS/), in PR [#1511](https://github.com/Microsoft/BotFramework-WebChat/pull/1511)
+- `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3624,12 +3624,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3644,17 +3646,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3771,7 +3776,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3783,6 +3789,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3797,6 +3804,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3804,12 +3812,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3828,6 +3838,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3908,7 +3919,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3920,6 +3932,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4041,6 +4054,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -5557,11 +5557,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5574,15 +5576,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5685,7 +5690,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5695,6 +5701,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5707,17 +5714,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5734,6 +5744,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5806,7 +5817,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5816,6 +5828,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5921,6 +5934,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -4,10 +4,1087 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.0.tgz",
+			"integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/helpers": "^7.1.0",
+				"@babel/parser": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^3.1.0",
+				"json5": "^0.5.0",
+				"lodash": "^4.17.10",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+			"integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+			"requires": {
+				"@babel/types": "^7.2.2",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"esutils": "^2.0.0"
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
+			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.2.2",
+				"@babel/types": "^7.2.2",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+		},
+		"@babel/helper-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"requires": {
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
+			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.2.3",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"requires": {
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.2.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
+			"integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+			"requires": {
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.2.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+			"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
+			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/plugin-syntax-class-properties": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-decorators": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
+			"integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/plugin-syntax-decorators": "^7.1.0"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-json-strings": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
+			"integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.2.0"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
+			"integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-decorators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+			"integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+			"integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-flow": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz",
+			"integrity": "sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
+			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
+			"integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
+			"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
+			"integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
+			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-flow-strip-types": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
+			"integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
+			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
+			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
+			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
+			"integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
+			"integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
+			"requires": {
+				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-constant-elements": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
+			"integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.2.0.tgz",
+			"integrity": "sha512-h/fZRel5wAfCqcKgq3OhbmYaReo7KkoJBpt8XnvpS7wqaNMqtw5xhxutzcm35iMUWucfAdT/nvGTsWln0JTg2Q==",
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-self": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"requires": {
+				"regenerator-transform": "^0.13.3"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
+			"integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+			"integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz",
+			"integrity": "sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-typescript": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
+			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.2.3.tgz",
+			"integrity": "sha512-AuHzW7a9rbv5WXmvGaPX7wADxFkZIqKlbBh1dmZUQp4iwiPpkE/Qnrji6SC4UQCQzvWY/cpHET29eUhXS9cLPw==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-json-strings": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-transform-arrow-functions": "^7.2.0",
+				"@babel/plugin-transform-async-to-generator": "^7.2.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+				"@babel/plugin-transform-block-scoping": "^7.2.0",
+				"@babel/plugin-transform-classes": "^7.2.0",
+				"@babel/plugin-transform-computed-properties": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.2.0",
+				"@babel/plugin-transform-dotall-regex": "^7.2.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+				"@babel/plugin-transform-for-of": "^7.2.0",
+				"@babel/plugin-transform-function-name": "^7.2.0",
+				"@babel/plugin-transform-literals": "^7.2.0",
+				"@babel/plugin-transform-modules-amd": "^7.2.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.2.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.2.0",
+				"@babel/plugin-transform-modules-umd": "^7.2.0",
+				"@babel/plugin-transform-new-target": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.2.0",
+				"@babel/plugin-transform-parameters": "^7.2.0",
+				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-sticky-regex": "^7.2.0",
+				"@babel/plugin-transform-template-literals": "^7.2.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+				"@babel/plugin-transform-unicode-regex": "^7.2.0",
+				"browserslist": "^4.3.4",
+				"invariant": "^2.2.2",
+				"js-levenshtein": "^1.1.3",
+				"semver": "^5.3.0"
+			}
+		},
+		"@babel/preset-react": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
+			"integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-typescript": "^7.1.0"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+			"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+			"requires": {
+				"regenerator-runtime": "^0.12.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+				}
+			}
+		},
+		"@babel/template": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+			"integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@csstools/convert-colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+		},
+		"@svgr/core": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
+			"integrity": "sha512-2i1cUbjpKt1KcIP05e10vkmu9Aedp32EFqVcSQ08onbB8lVxJqMPci3Hr54aI14S9cLg4JdcpO0D35HHUtT8oQ==",
+			"requires": {
+				"camelcase": "^5.0.0",
+				"cosmiconfig": "^5.0.6",
+				"h2x-core": "^1.1.0",
+				"h2x-plugin-jsx": "^1.1.0",
+				"merge-deep": "^3.0.2",
+				"prettier": "^1.14.2",
+				"svgo": "^1.0.5"
+			}
+		},
+		"@svgr/webpack": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-2.4.1.tgz",
+			"integrity": "sha512-sMHYq0zbMtSHcc9kVfkYI2zrl88u4mKGyQLgKt7r+ul5nITcncm/EPBhzEUrJY5izdlaU6EvyH8zOhZnfaSmOA==",
+			"requires": {
+				"@babel/core": "^7.0.1",
+				"@babel/plugin-transform-react-constant-elements": "^7.0.0",
+				"@babel/preset-env": "^7.0.0",
+				"@babel/preset-react": "^7.0.0",
+				"@svgr/core": "^2.4.1",
+				"loader-utils": "^1.1.0"
+			}
+		},
+		"@types/q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+			"integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+		},
+		"@types/tapable": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
+			"integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ=="
+		},
+		"@webassemblyjs/ast": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.6.tgz",
+			"integrity": "sha512-8nkZS48EVsMUU0v6F1LCIOw4RYWLm2plMtbhFTjNgeXmsTNLuU3xTRtnljt9BFQB+iPbLRobkNrCWftWnNC7wQ==",
+			"requires": {
+				"@webassemblyjs/helper-module-context": "1.7.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+				"@webassemblyjs/wast-parser": "1.7.6",
+				"mamacro": "^0.0.3"
+			}
+		},
+		"@webassemblyjs/floating-point-hex-parser": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.6.tgz",
+			"integrity": "sha512-VBOZvaOyBSkPZdIt5VBMg3vPWxouuM13dPXGWI1cBh3oFLNcFJ8s9YA7S9l4mPI7+Q950QqOmqj06oa83hNWBA=="
+		},
+		"@webassemblyjs/helper-api-error": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.6.tgz",
+			"integrity": "sha512-SCzhcQWHXfrfMSKcj8zHg1/kL9kb3aa5TN4plc/EREOs5Xop0ci5bdVBApbk2yfVi8aL+Ly4Qpp3/TRAUInjrg=="
+		},
+		"@webassemblyjs/helper-buffer": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.6.tgz",
+			"integrity": "sha512-1/gW5NaGsEOZ02fjnFiU8/OEEXU1uVbv2um0pQ9YVL3IHSkyk6xOwokzyqqO1qDZQUAllb+V8irtClPWntbVqw=="
+		},
+		"@webassemblyjs/helper-code-frame": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.6.tgz",
+			"integrity": "sha512-+suMJOkSn9+vEvDvgyWyrJo5vJsWSDXZmJAjtoUq4zS4eqHyXImpktvHOZwXp1XQjO5H+YQwsBgqTQEc0J/5zg==",
+			"requires": {
+				"@webassemblyjs/wast-printer": "1.7.6"
+			}
+		},
+		"@webassemblyjs/helper-fsm": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.6.tgz",
+			"integrity": "sha512-HCS6KN3wgxUihGBW7WFzEC/o8Eyvk0d56uazusnxXthDPnkWiMv+kGi9xXswL2cvfYfeK5yiM17z2K5BVlwypw=="
+		},
+		"@webassemblyjs/helper-module-context": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.6.tgz",
+			"integrity": "sha512-e8/6GbY7OjLM+6OsN7f2krC2qYVNaSr0B0oe4lWdmq5sL++8dYDD1TFbD1TdAdWMRTYNr/Qq7ovXWzia2EbSjw==",
+			"requires": {
+				"mamacro": "^0.0.3"
+			}
+		},
+		"@webassemblyjs/helper-wasm-bytecode": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.6.tgz",
+			"integrity": "sha512-PzYFCb7RjjSdAOljyvLWVqd6adAOabJW+8yRT+NWhXuf1nNZWH+igFZCUK9k7Cx7CsBbzIfXjJc7u56zZgFj9Q=="
+		},
+		"@webassemblyjs/helper-wasm-section": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.6.tgz",
+			"integrity": "sha512-3GS628ppDPSuwcYlQ7cDCGr4W2n9c4hLzvnRKeuz+lGsJSmc/ADVoYpm1ts2vlB1tGHkjtQMni+yu8mHoMlKlA==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-buffer": "1.7.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+				"@webassemblyjs/wasm-gen": "1.7.6"
+			}
+		},
+		"@webassemblyjs/ieee754": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.6.tgz",
+			"integrity": "sha512-V4cIp0ruyw+hawUHwQLn6o2mFEw4t50tk530oKsYXQhEzKR+xNGDxs/SFFuyTO7X3NzEu4usA3w5jzhl2RYyzQ==",
+			"requires": {
+				"@xtuc/ieee754": "^1.2.0"
+			}
+		},
+		"@webassemblyjs/leb128": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.6.tgz",
+			"integrity": "sha512-ojdlG8WpM394lBow4ncTGJoIVZ4aAtNOWHhfAM7m7zprmkVcKK+2kK5YJ9Bmj6/ketTtOn7wGSHCtMt+LzqgYQ==",
+			"requires": {
+				"@xtuc/long": "4.2.1"
+			}
+		},
+		"@webassemblyjs/utf8": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.6.tgz",
+			"integrity": "sha512-oId+tLxQ+AeDC34ELRYNSqJRaScB0TClUU6KQfpB8rNT6oelYlz8axsPhf6yPTg7PBJ/Z5WcXmUYiHEWgbbHJw=="
+		},
+		"@webassemblyjs/wasm-edit": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.6.tgz",
+			"integrity": "sha512-pTNjLO3o41v/Vz9VFLl+I3YLImpCSpodFW77pNoH4agn5I6GgSxXHXtvWDTvYJFty0jSeXZWLEmbaSIRUDlekg==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-buffer": "1.7.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+				"@webassemblyjs/helper-wasm-section": "1.7.6",
+				"@webassemblyjs/wasm-gen": "1.7.6",
+				"@webassemblyjs/wasm-opt": "1.7.6",
+				"@webassemblyjs/wasm-parser": "1.7.6",
+				"@webassemblyjs/wast-printer": "1.7.6"
+			}
+		},
+		"@webassemblyjs/wasm-gen": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.6.tgz",
+			"integrity": "sha512-mQvFJVumtmRKEUXMohwn8nSrtjJJl6oXwF3FotC5t6e2hlKMh8sIaW03Sck2MDzw9xPogZD7tdP5kjPlbH9EcQ==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+				"@webassemblyjs/ieee754": "1.7.6",
+				"@webassemblyjs/leb128": "1.7.6",
+				"@webassemblyjs/utf8": "1.7.6"
+			}
+		},
+		"@webassemblyjs/wasm-opt": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.6.tgz",
+			"integrity": "sha512-go44K90fSIsDwRgtHhX14VtbdDPdK2sZQtZqUcMRvTojdozj5tLI0VVJAzLCfz51NOkFXezPeVTAYFqrZ6rI8Q==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-buffer": "1.7.6",
+				"@webassemblyjs/wasm-gen": "1.7.6",
+				"@webassemblyjs/wasm-parser": "1.7.6"
+			}
+		},
+		"@webassemblyjs/wasm-parser": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.6.tgz",
+			"integrity": "sha512-t1T6TfwNY85pDA/HWPA8kB9xA4sp9ajlRg5W7EKikqrynTyFo+/qDzIpvdkOkOGjlS6d4n4SX59SPuIayR22Yg==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-api-error": "1.7.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+				"@webassemblyjs/ieee754": "1.7.6",
+				"@webassemblyjs/leb128": "1.7.6",
+				"@webassemblyjs/utf8": "1.7.6"
+			}
+		},
+		"@webassemblyjs/wast-parser": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.6.tgz",
+			"integrity": "sha512-1MaWTErN0ziOsNUlLdvwS+NS1QWuI/kgJaAGAMHX8+fMJFgOJDmN/xsG4h/A1Gtf/tz5VyXQciaqHZqp2q0vfg==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/floating-point-hex-parser": "1.7.6",
+				"@webassemblyjs/helper-api-error": "1.7.6",
+				"@webassemblyjs/helper-code-frame": "1.7.6",
+				"@webassemblyjs/helper-fsm": "1.7.6",
+				"@xtuc/long": "4.2.1",
+				"mamacro": "^0.0.3"
+			}
+		},
+		"@webassemblyjs/wast-printer": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.6.tgz",
+			"integrity": "sha512-vHdHSK1tOetvDcl1IV1OdDeGNe/NDDQ+KzuZHMtqTVP1xO/tZ/IKNpj5BaGk1OYFdsDWQqb31PIwdEyPntOWRQ==",
+			"requires": {
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/wast-parser": "1.7.6",
+				"@xtuc/long": "4.2.1"
+			}
+		},
+		"@xtuc/ieee754": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+		},
+		"@xtuc/long": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
+			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
+		},
 		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
 		},
 		"accepts": {
 			"version": "1.3.5",
@@ -19,54 +1096,43 @@
 			}
 		},
 		"acorn": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-			"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+			"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
 		},
 		"acorn-dynamic-import": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"requires": {
-				"acorn": "^4.0.3"
+				"acorn": "^5.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
 				}
 			}
 		},
 		"acorn-globals": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
 			"requires": {
-				"acorn": "^4.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
 			}
 		},
 		"acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"requires": {
-				"acorn": "^3.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-				}
-			}
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
 		},
 		"adaptivecards": {
 			"version": "1.0.0",
@@ -79,62 +1145,39 @@
 			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+			"integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
+				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			}
+		},
+		"ajv-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 		},
 		"ajv-keywords": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
 			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
-			}
-		},
 		"alphanum-sort": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
 			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
 		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-		},
-		"ansi-align": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-			"requires": {
-				"string-width": "^2.0.0"
-			}
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
 			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-html": {
@@ -156,90 +1199,284 @@
 			}
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			},
 			"dependencies": {
 				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
 					}
 				},
 				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
 					}
 				},
 				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
 					}
 				},
 				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
 		"append-transform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"requires": {
-				"default-require-extensions": "^2.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -250,18 +1487,21 @@
 			}
 		},
 		"aria-query": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
-			"integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
 			"requires": {
 				"ast-types-flow": "0.0.7",
 				"commander": "^2.11.0"
 			}
 		},
 		"arr-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "^1.0.1"
+			}
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -275,7 +1515,7 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-filter": {
@@ -283,15 +1523,10 @@
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
 			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
 		},
-		"array-find-index": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-		},
 		"array-flatten": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
 		},
 		"array-includes": {
 			"version": "3.0.3",
@@ -326,9 +1561,9 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -341,9 +1576,12 @@
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -370,7 +1608,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"requires": {
 						"inherits": "2.0.1"
@@ -393,6 +1631,11 @@
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
 			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
 		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+		},
 		"async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -406,27 +1649,49 @@
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-			"integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+			"version": "9.4.3",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.3.tgz",
+			"integrity": "sha512-/XSnzDepRkAU//xLcXA/lUWxpsBuw0WiriAHOqnxkuCtzLhaz+fL4it4gp20BQ8n5SyLzK/FOc7A0+u/rti2FQ==",
 			"requires": {
-				"browserslist": "^2.5.1",
-				"caniuse-lite": "^1.0.30000748",
+				"browserslist": "^4.3.6",
+				"caniuse-lite": "^1.0.30000921",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^6.0.13",
-				"postcss-value-parser": "^3.2.3"
+				"postcss": "^7.0.6",
+				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"aws-sign2": {
@@ -435,14 +1700,14 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"axobject-query": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
-			"integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
 			"requires": {
 				"ast-types-flow": "0.0.7"
 			}
@@ -455,50 +1720,56 @@
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.2"
-			}
-		},
-		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"debug": "^2.6.8",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.7",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
+		"babel-core": {
+			"version": "7.0.0-bridge.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+		},
 		"babel-eslint": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-			"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+			"integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
 			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"babel-traverse": "^6.23.1",
-				"babel-types": "^6.23.0",
-				"babylon": "^6.17.0"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "^1.0.0"
+			}
+		},
+		"babel-extract-comments": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+			"integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+			"requires": {
+				"babylon": "^6.18.0"
 			}
 		},
 		"babel-generator": {
@@ -516,137 +1787,11 @@
 				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 				}
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-builder-react-jsx": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-define-map": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-optimise-call-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-replace-supers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -659,23 +1804,23 @@
 			}
 		},
 		"babel-jest": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
-			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.0.0",
-				"babel-preset-jest": "^20.0.3"
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-preset-jest": "^23.2.0"
 			}
 		},
 		"babel-loader": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
-			"integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
+			"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1"
+				"mkdirp": "^0.5.1",
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"babel-messages": {
@@ -686,27 +1831,17 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
 		"babel-plugin-dynamic-import-node": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz",
-			"integrity": "sha512-tTfZbM9Ecwj3GK50mnPrUpinTwA4xXmDiQGCk/aBYbvl1+X8YqldK86wZ1owVJ4u3mrKbRlXMma80J18qwiaTQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+			"integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"object.assign": "^4.1.0"
 			}
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -716,301 +1851,28 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
 		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+		"babel-plugin-macros": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
+			"integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+			"requires": {
+				"cosmiconfig": "^5.0.5",
+				"resolve": "^1.8.1"
+			}
 		},
-		"babel-plugin-syntax-class-properties": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-		},
-		"babel-plugin-syntax-dynamic-import": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-		},
-		"babel-plugin-syntax-flow": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-		},
-		"babel-plugin-syntax-jsx": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+		"babel-plugin-named-asset-import": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.3.tgz",
+			"integrity": "sha512-9mx2Z9M4EGbutvXxoLV7aUBCY6ps3sqLFl094FeA2tFQzQffIh0XSsmwwQRxiSfpg3rnb5x/o46qRLxS/OzFTg=="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-class-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-arrow-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoping": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-plugin-transform-es2015-classes": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-computed-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-duplicate-keys": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-for-of": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-amd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-shorthand-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-template-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-typeof-symbol": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-flow-strip-types": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
-			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
 			"version": "6.26.0",
@@ -1021,159 +1883,143 @@
 				"babel-runtime": "^6.26.0"
 			}
 		},
-		"babel-plugin-transform-react-constant-elements": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
-			"integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-display-name": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-self": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-source": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-regenerator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"requires": {
-				"regenerator-transform": "^0.10.0"
-			}
-		},
-		"babel-plugin-transform-runtime": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-preset-env": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^2.1.2",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
-			}
-		},
-		"babel-preset-flow": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
-			}
+		"babel-plugin-transform-react-remove-prop-types": {
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz",
+			"integrity": "sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw=="
 		},
 		"babel-preset-jest": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
-			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"requires": {
-				"babel-plugin-jest-hoist": "^20.0.3"
-			}
-		},
-		"babel-preset-react": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
+				"babel-plugin-jest-hoist": "^23.2.0",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-preset-react-app": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.1.1.tgz",
-			"integrity": "sha512-9fRHopNaGL5ScRZdPSoyxRaABKmkS2fx0HUJ5Yphan5G8QDFD7lETsPyY7El6b7YPT3sNrw9gfrWzl4/LsJcfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-6.1.0.tgz",
+			"integrity": "sha512-8PJ4N+acfYsjhDK4gMWkqJMVRMjDKb93D+nz7lWlNe73Jcv38FNu37i5K/dVQnFDdRYHbe1SjII+Y0mCgink9A==",
 			"requires": {
-				"babel-plugin-dynamic-import-node": "1.1.0",
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-object-rest-spread": "6.26.0",
-				"babel-plugin-transform-react-constant-elements": "6.23.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"babel-plugin-transform-runtime": "6.23.0",
-				"babel-preset-env": "1.6.1",
-				"babel-preset-react": "6.24.1"
+				"@babel/core": "7.1.0",
+				"@babel/plugin-proposal-class-properties": "7.1.0",
+				"@babel/plugin-proposal-decorators": "7.1.2",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "7.0.0",
+				"@babel/plugin-transform-classes": "7.1.0",
+				"@babel/plugin-transform-destructuring": "7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "7.0.0",
+				"@babel/plugin-transform-react-constant-elements": "7.0.0",
+				"@babel/plugin-transform-react-display-name": "7.0.0",
+				"@babel/plugin-transform-runtime": "7.1.0",
+				"@babel/preset-env": "7.1.0",
+				"@babel/preset-react": "7.0.0",
+				"@babel/preset-typescript": "7.1.0",
+				"@babel/runtime": "7.0.0",
+				"babel-loader": "8.0.4",
+				"babel-plugin-dynamic-import-node": "2.2.0",
+				"babel-plugin-macros": "2.4.2",
+				"babel-plugin-transform-react-remove-prop-types": "0.4.18"
+			},
+			"dependencies": {
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+					"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+					"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-define-map": "^7.1.0",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
+					"integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-constant-elements": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
+					"integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-display-name": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
+					"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
+					"integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+						"@babel/plugin-proposal-json-strings": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+						"@babel/plugin-syntax-async-generators": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-async-to-generator": "^7.1.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.1.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-dotall-regex": "^7.0.0",
+						"@babel/plugin-transform-duplicate-keys": "^7.0.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.1.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-amd": "^7.1.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.1.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.0.0",
+						"@babel/plugin-transform-modules-umd": "^7.1.0",
+						"@babel/plugin-transform-new-target": "^7.0.0",
+						"@babel/plugin-transform-object-super": "^7.1.0",
+						"@babel/plugin-transform-parameters": "^7.1.0",
+						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-sticky-regex": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"@babel/plugin-transform-typeof-symbol": "^7.0.0",
+						"@babel/plugin-transform-unicode-regex": "^7.0.0",
+						"browserslist": "^4.1.0",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.3.0"
+					}
+				}
 			}
 		},
 		"babel-register": {
@@ -1190,10 +2036,49 @@
 				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
 				"core-js": {
-					"version": "2.5.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
+					"integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -1207,9 +2092,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
+					"integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
 				}
 			}
 		},
@@ -1239,6 +2124,26 @@
 				"globals": "^9.18.0",
 				"invariant": "^2.2.2",
 				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-types": {
@@ -1250,6 +2155,13 @@
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.4",
 				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				}
 			}
 		},
 		"babylon": {
@@ -1309,6 +2221,11 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -1323,12 +2240,22 @@
 			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"optional": true,
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"requires": {
 				"tweetnacl": "^0.14.3"
+			}
+		},
+		"bfj": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
+			"integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
+			"requires": {
+				"bluebird": "^3.5.1",
+				"check-types": "^7.3.0",
+				"hoopy": "^0.1.2",
+				"tryer": "^1.0.0"
 			}
 		},
 		"big.js": {
@@ -1337,14 +2264,14 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"binary-extensions": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
 		},
 		"bluebird": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -1352,31 +2279,34 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
 			},
 			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
 				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -1411,37 +2341,6 @@
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.3.tgz",
 			"integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg=="
 		},
-		"boxen": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-			"requires": {
-				"ansi-align": "^2.0.0",
-				"camelcase": "^4.0.0",
-				"chalk": "^2.0.1",
-				"cli-boxes": "^1.0.0",
-				"string-width": "^2.0.0",
-				"term-size": "^1.2.0",
-				"widest-line": "^2.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1452,30 +2351,13 @@
 			}
 		},
 		"braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				}
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"brorand": {
@@ -1483,24 +2365,29 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+		},
 		"browser-resolve": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
 			"requires": {
 				"resolve": "1.1.7"
 			},
 			"dependencies": {
 				"resolve": {
 					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				}
 			}
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -1522,18 +2409,19 @@
 			}
 		},
 		"browserify-des": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -1563,12 +2451,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "2.11.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
+			"integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000792",
-				"electron-to-chromium": "^1.3.30"
+				"caniuse-lite": "^1.0.30000921",
+				"electron-to-chromium": "^1.3.92",
+				"node-releases": "^1.1.1"
 			}
 		},
 		"bser": {
@@ -1581,7 +2470,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
 				"base64-js": "^1.0.2",
@@ -1590,9 +2479,9 @@
 			}
 		},
 		"buffer-from": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -1619,6 +2508,47 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
+		"cacache": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+			"requires": {
+				"bluebird": "^3.5.3",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"lru-cache": "^5.1.1",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
+				"y18n": "^4.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
+			}
+		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1635,18 +2565,31 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "^2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"requires": {
+				"caller-callsite": "^2.0.0"
 			}
 		},
 		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"version": "2.0.0",
+			"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camel-case": {
 			"version": "3.0.0",
@@ -1658,110 +2601,63 @@
 			}
 		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-		},
-		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				}
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
 		"caniuse-api": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
 			"requires": {
-				"browserslist": "^1.3.6",
-				"caniuse-db": "^1.0.30000529",
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
 				"lodash.memoize": "^4.1.2",
 				"lodash.uniq": "^4.5.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				}
 			}
 		},
-		"caniuse-db": {
-			"version": "1.0.30000856",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000856.tgz",
-			"integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8="
-		},
 		"caniuse-lite": {
-			"version": "1.0.30000856",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-			"integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
+			"version": "1.0.30000923",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000923.tgz",
+			"integrity": "sha512-j5ur7eeluOFjjPUkydtXP4KFAsmH3XaQNch5tvWSO+dLHYt5PE+VgJZLWtbVOodfWij6m6zas28T4gB/cLYq1w=="
 		},
-		"capture-stack-trace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
 		},
 		"case-sensitive-paths-webpack-plugin": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
-			"integrity": "sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
+			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			}
-		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+		},
+		"check-types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
 		},
 		"chokidar": {
 			"version": "2.0.4",
@@ -1783,13 +2679,45 @@
 				"upath": "^1.0.5"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					}
 				},
 				"glob-parent": {
@@ -1823,13 +2751,34 @@
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
 				}
 			}
 		},
+		"chownr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+		},
+		"chrome-trace-event": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
+			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"ci-info": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -1844,14 +2793,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-		},
-		"clap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"requires": {
-				"chalk": "^1.1.3"
-			}
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -1880,24 +2821,19 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
-			"integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
 			"requires": {
-				"source-map": "0.5.x"
+				"source-map": "~0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
-		},
-		"cli-boxes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
@@ -1913,26 +2849,41 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
-		"clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+		"clone-deep": {
+			"version": "0.2.4",
+			"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+			"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+			"requires": {
+				"for-own": "^0.1.3",
+				"is-plain-object": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"lazy-cache": "^1.0.3",
+				"shallow-clone": "^0.1.2"
+			}
 		},
 		"co": {
 			"version": "4.6.0",
@@ -1940,10 +2891,12 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"coa": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
 			"requires": {
+				"@types/q": "^1.5.1",
+				"chalk": "^2.4.1",
 				"q": "^1.1.2"
 			}
 		},
@@ -1962,73 +2915,63 @@
 			}
 		},
 		"color": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
 			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
+				"color-convert": "^1.9.1",
+				"color-string": "^1.5.2"
 			}
 		},
 		"color-convert": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"requires": {
-				"color-name": "1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
 			"requires": {
-				"color-name": "^1.0.0"
-			}
-		},
-		"colormin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"requires": {
-				"color": "^0.11.0",
-				"css-color-names": "0.0.4",
-				"has": "^1.0.1"
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
 			}
 		},
 		"colors": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
 			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+		},
+		"common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-		},
-		"compare-versions": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-			"integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
@@ -2036,38 +2979,39 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
-			"integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
 			"requires": {
-				"mime-db": ">= 1.34.0 < 2"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.34.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-					"integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o="
-				}
+				"mime-db": ">= 1.36.0 < 2"
 			}
 		},
 		"compression": {
-			"version": "1.7.2",
-			"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
 			"requires": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "~2.0.13",
+				"compressible": "~2.0.14",
 				"debug": "2.6.9",
 				"on-headers": "~1.0.1",
-				"safe-buffer": "5.1.1",
+				"safe-buffer": "5.1.2",
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -2078,7 +3022,7 @@
 		},
 		"concat-stream": {
 			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -2087,18 +3031,10 @@
 				"typedarray": "^0.0.6"
 			}
 		},
-		"configstore": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-			"requires": {
-				"dot-prop": "^4.1.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"unique-string": "^1.0.0",
-				"write-file-atomic": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			}
+		"confusing-browser-globals": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.5.tgz",
+			"integrity": "sha512-tHo1tQL/9Ox5RELbkCAJhnViqWlzBz3MG1bB2czbHjH2mWd4aYUgNCNLfysFL7c4LoDws7pjg2tj48Gmpw4QHA=="
 		},
 		"connect-history-api-fallback": {
 			"version": "1.5.0",
@@ -2125,7 +3061,7 @@
 		},
 		"content-disposition": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
@@ -2133,15 +3069,13 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-		},
 		"convert-source-map": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -2152,6 +3086,19 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
+			}
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -2169,24 +3116,14 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
 			"requires": {
+				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.4.3",
-				"minimist": "^1.2.0",
-				"object-assign": "^4.1.0",
-				"os-homedir": "^1.0.1",
-				"parse-json": "^2.2.0",
-				"require-from-string": "^1.1.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
+				"js-yaml": "^3.9.0",
+				"parse-json": "^4.0.0"
 			}
 		},
 		"create-ecdh": {
@@ -2198,17 +3135,9 @@
 				"elliptic": "^6.0.0"
 			}
 		},
-		"create-error-class": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"requires": {
-				"capture-stack-trace": "^1.0.0"
-			}
-		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -2220,7 +3149,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -2232,11 +3161,13 @@
 			}
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
@@ -2259,15 +3190,36 @@
 				"randomfill": "^1.0.3"
 			}
 		},
-		"crypto-random-string": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-		},
 		"css-color-names": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+		},
+		"css-declaration-sorter": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+			"integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+			"requires": {
+				"postcss": "^7.0.1",
+				"timsort": "^0.3.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
 		},
 		"css-in-js-utils": {
 			"version": "2.0.1",
@@ -2279,94 +3231,108 @@
 			}
 		},
 		"css-loader": {
-			"version": "0.28.7",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
-			"integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
+			"integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
 			"requires": {
-				"babel-code-frame": "^6.11.0",
+				"babel-code-frame": "^6.26.0",
 				"css-selector-tokenizer": "^0.7.0",
-				"cssnano": ">=2.6.1 <4",
 				"icss-utils": "^2.1.0",
 				"loader-utils": "^1.0.2",
 				"lodash.camelcase": "^4.3.0",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.6",
-				"postcss-modules-extract-imports": "^1.0.0",
-				"postcss-modules-local-by-default": "^1.0.1",
-				"postcss-modules-scope": "^1.0.0",
-				"postcss-modules-values": "^1.1.0",
+				"postcss": "^6.0.23",
+				"postcss-modules-extract-imports": "^1.2.0",
+				"postcss-modules-local-by-default": "^1.2.0",
+				"postcss-modules-scope": "^1.1.0",
+				"postcss-modules-values": "^1.3.0",
 				"postcss-value-parser": "^3.3.0",
 				"source-list-map": "^2.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
 			}
 		},
 		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+			"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
 			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"boolbase": "^1.0.0",
+				"css-what": "^2.1.2",
+				"domutils": "^1.7.0",
+				"nth-check": "^1.0.2"
 			}
 		},
+		"css-select-base-adapter": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+		},
 		"css-selector-tokenizer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
 			"requires": {
 				"cssesc": "^0.1.0",
 				"fastparse": "^1.1.1",
 				"regexpu-core": "^1.0.0"
 			},
 			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				},
 				"regexpu-core": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
 					"requires": {
 						"regenerate": "^1.2.1",
 						"regjsgen": "^0.2.0",
 						"regjsparser": "^0.1.4"
 					}
+				},
+				"regjsgen": {
+					"version": "0.2.0",
+					"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+				},
+				"regjsparser": {
+					"version": "0.1.5",
+					"resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
 				}
 			}
 		},
+		"css-tree": {
+			"version": "1.0.0-alpha.28",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+			"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+			"requires": {
+				"mdn-data": "~1.1.0",
+				"source-map": "^0.5.3"
+			}
+		},
+		"css-unit-converter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
+		},
+		"css-url-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
+		},
 		"css-what": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+		},
+		"cssdb": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-3.2.1.tgz",
+			"integrity": "sha512-I0IS8zvxED8sQtFZnV7M+AkhWqTgp1HIyfMQJBbjdn4GgurBt7NCZaDgrWiAN2kNJN34mhF1p50aZIMQu290mA=="
 		},
 		"cssesc": {
 			"version": "0.1.0",
@@ -2374,141 +3340,163 @@
 			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
 		},
 		"cssnano": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
+			"integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
 			"requires": {
-				"autoprefixer": "^6.3.1",
-				"decamelize": "^1.1.2",
-				"defined": "^1.0.0",
-				"has": "^1.0.1",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.14",
-				"postcss-calc": "^5.2.0",
-				"postcss-colormin": "^2.1.8",
-				"postcss-convert-values": "^2.3.4",
-				"postcss-discard-comments": "^2.0.4",
-				"postcss-discard-duplicates": "^2.0.1",
-				"postcss-discard-empty": "^2.0.1",
-				"postcss-discard-overridden": "^0.1.1",
-				"postcss-discard-unused": "^2.2.1",
-				"postcss-filter-plugins": "^2.0.0",
-				"postcss-merge-idents": "^2.1.5",
-				"postcss-merge-longhand": "^2.0.1",
-				"postcss-merge-rules": "^2.0.3",
-				"postcss-minify-font-values": "^1.0.2",
-				"postcss-minify-gradients": "^1.0.1",
-				"postcss-minify-params": "^1.0.4",
-				"postcss-minify-selectors": "^2.0.4",
-				"postcss-normalize-charset": "^1.1.0",
-				"postcss-normalize-url": "^3.0.7",
-				"postcss-ordered-values": "^2.1.0",
-				"postcss-reduce-idents": "^2.2.2",
-				"postcss-reduce-initial": "^1.0.0",
-				"postcss-reduce-transforms": "^1.0.3",
-				"postcss-svgo": "^2.1.1",
-				"postcss-unique-selectors": "^2.0.2",
-				"postcss-value-parser": "^3.2.3",
-				"postcss-zindex": "^2.0.1"
+				"cosmiconfig": "^5.0.0",
+				"cssnano-preset-default": "^4.0.5",
+				"is-resolvable": "^1.0.0",
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"autoprefixer": {
-					"version": "6.7.7",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-					"requires": {
-						"browserslist": "^1.7.6",
-						"caniuse-db": "^1.0.30000634",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^5.2.16",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"csso": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+		"cssnano-preset-default": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.5.tgz",
+			"integrity": "sha512-f1uhya0ZAjPYtDD58QkBB0R+uYdzHPei7cDxJyQQIHt5acdhyGXaSXl2nDLzWHLwGFbZcHxQtkJS8mmNwnxTvw==",
 			"requires": {
-				"clap": "^1.0.9",
-				"source-map": "^0.5.3"
+				"css-declaration-sorter": "^4.0.1",
+				"cssnano-util-raw-cache": "^4.0.1",
+				"postcss": "^7.0.0",
+				"postcss-calc": "^7.0.0",
+				"postcss-colormin": "^4.0.2",
+				"postcss-convert-values": "^4.0.1",
+				"postcss-discard-comments": "^4.0.1",
+				"postcss-discard-duplicates": "^4.0.2",
+				"postcss-discard-empty": "^4.0.1",
+				"postcss-discard-overridden": "^4.0.1",
+				"postcss-merge-longhand": "^4.0.9",
+				"postcss-merge-rules": "^4.0.2",
+				"postcss-minify-font-values": "^4.0.2",
+				"postcss-minify-gradients": "^4.0.1",
+				"postcss-minify-params": "^4.0.1",
+				"postcss-minify-selectors": "^4.0.1",
+				"postcss-normalize-charset": "^4.0.1",
+				"postcss-normalize-display-values": "^4.0.1",
+				"postcss-normalize-positions": "^4.0.1",
+				"postcss-normalize-repeat-style": "^4.0.1",
+				"postcss-normalize-string": "^4.0.1",
+				"postcss-normalize-timing-functions": "^4.0.1",
+				"postcss-normalize-unicode": "^4.0.1",
+				"postcss-normalize-url": "^4.0.1",
+				"postcss-normalize-whitespace": "^4.0.1",
+				"postcss-ordered-values": "^4.1.1",
+				"postcss-reduce-initial": "^4.0.2",
+				"postcss-reduce-transforms": "^4.0.1",
+				"postcss-svgo": "^4.0.1",
+				"postcss-unique-selectors": "^4.0.1"
 			},
 			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"cssnano-util-get-arguments": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+			"integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8="
+		},
+		"cssnano-util-get-match": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+			"integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0="
+		},
+		"cssnano-util-raw-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+			"integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+			"requires": {
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"cssnano-util-same-parent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+			"integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
+		},
+		"csso": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+			"requires": {
+				"css-tree": "1.0.0-alpha.29"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.0.0-alpha.29",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+					"requires": {
+						"mdn-data": "~1.1.0",
+						"source-map": "^0.5.3"
+					}
 				}
 			}
 		},
 		"cssom": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
 		},
 		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"requires": {
 				"cssom": "0.3.x"
 			}
 		},
-		"currently-unhandled": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"requires": {
-				"array-find-index": "^1.0.1"
-			}
-		},
-		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"requires": {
-				"es5-ext": "^0.10.9"
-			}
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.4",
@@ -2523,17 +3511,27 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			}
+		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -2551,38 +3549,50 @@
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
-		"default-require-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+		"default-gateway": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
 			"requires": {
-				"strip-bom": "^3.0.0"
+				"execa": "^0.10.0",
+				"ip-regex": "^2.1.0"
 			},
 			"dependencies": {
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				"execa": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
 				}
 			}
 		},
-		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"strip-bom": "^2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
@@ -2619,26 +3629,51 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-		},
 		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"requires": {
-				"globby": "^5.0.0",
+				"globby": "^6.1.0",
 				"is-path-cwd": "^1.0.0",
 				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
 				"rimraf": "^2.2.8"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"delayed-stream": {
@@ -2673,10 +3708,15 @@
 				"repeating": "^2.0.0"
 			}
 		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+		},
 		"detect-node": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
 		"detect-port-alt": {
 			"version": "1.1.6",
@@ -2685,6 +3725,21 @@
 			"requires": {
 				"address": "^1.0.1",
 				"debug": "^2.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"diff": {
@@ -2694,12 +3749,36 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"dns-equal": {
@@ -2733,18 +3812,11 @@
 			}
 		},
 		"dom-converter": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
-			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+			"integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
 			"requires": {
-				"utila": "~0.3"
-			},
-			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
-				}
+				"utila": "~0.4"
 			}
 		},
 		"dom-serializer": {
@@ -2758,17 +3830,9 @@
 			"dependencies": {
 				"domelementtype": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
 					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
-			}
-		},
-		"dom-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
-			"integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
-			"requires": {
-				"urijs": "^1.16.1"
 			}
 		},
 		"domain-browser": {
@@ -2777,9 +3841,17 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"domhandler": {
 			"version": "2.1.0",
@@ -2790,9 +3862,9 @@
 			}
 		},
 		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -2807,9 +3879,9 @@
 			}
 		},
 		"dotenv": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-			"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+			"integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
 		},
 		"dotenv-expand": {
 			"version": "4.2.0",
@@ -2818,21 +3890,27 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		"duplexify": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"requires": {
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
 		},
 		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"optional": true,
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ee-first": {
@@ -2841,14 +3919,14 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.48",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-			"integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+			"version": "1.3.96",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
+			"integrity": "sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q=="
 		},
 		"elliptic": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -2882,15 +3960,22 @@
 				"iconv-lite": "~0.4.13"
 			}
 		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"enhanced-resolve": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
-				"object-assign": "^4.0.1",
-				"tapable": "^0.2.7"
+				"tapable": "^1.0.0"
 			}
 		},
 		"entities": {
@@ -2907,9 +3992,9 @@
 			}
 		},
 		"error-ex": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -2927,83 +4012,13 @@
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"requires": {
-				"is-callable": "^1.1.1",
+				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
-			}
-		},
-		"es5-ext": {
-			"version": "0.10.45",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-			"integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-map": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-set": "~0.1.5",
-				"es6-symbol": "~3.1.1",
-				"event-emitter": "~0.3.5"
-			}
-		},
-		"es6-promise": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
-		},
-		"es6-set": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
-		"es6-weak-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
-				"es6-symbol": "^3.1.1"
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-html": {
@@ -3017,9 +4032,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
-			"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -3032,62 +4047,58 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
 				}
 			}
 		},
-		"escope": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			}
-		},
 		"eslint": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
-			"integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
+			"integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
 			"requires": {
-				"ajv": "^5.2.0",
-				"babel-code-frame": "^6.22.0",
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.5.3",
 				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.0.1",
-				"doctrine": "^2.0.0",
-				"eslint-scope": "^3.7.1",
-				"espree": "^3.5.1",
-				"esquery": "^1.0.0",
-				"estraverse": "^4.2.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^4.0.0",
+				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^2.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
-				"globals": "^9.17.0",
-				"ignore": "^3.3.3",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify": "^1.0.1",
+				"inquirer": "^6.1.0",
+				"is-resolvable": "^1.1.0",
+				"js-yaml": "^3.12.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
 				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
+				"regexpp": "^2.0.0",
 				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
+				"semver": "^5.5.1",
 				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "^4.0.1",
-				"text-table": "~0.2.0"
+				"strip-json-comments": "^2.0.1",
+				"table": "^4.0.3",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3095,36 +4106,13 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"esprima": {
+				"eslint-scope": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				},
-				"js-yaml": {
-					"version": "3.12.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -3138,9 +4126,12 @@
 			}
 		},
 		"eslint-config-react-app": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz",
-			"integrity": "sha512-8QZrKWuHVC57Fmu+SsKAVxnI9LycZl7NFQ4H9L+oeISuCXhYdXqsOOIVSjQFW6JF5MXZLFE+21Syhd7mF1IRZQ=="
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.5.tgz",
+			"integrity": "sha512-GjPuy0pbaCkl4+9wm8p0xpl/x/AGFy3wKuju3WNVefDNDDu8T6Ap1OFMDDJbYnOAI+4jfyAE3VT06lAYcJVpdw==",
+			"requires": {
+				"confusing-browser-globals": "^1.0.5"
+			}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.2",
@@ -3149,12 +4140,27 @@
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"eslint-loader": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
-			"integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
+			"integrity": "sha512-1GrJFfSevQdYpoDzx8mEE2TDWsb/zmFuY09l6hURg1AeFIKQOvZ+vH0UPjzmd1CZIbfTV5HUkMeBmFiDBkgIsQ==",
 			"requires": {
 				"loader-fs-cache": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -3172,6 +4178,14 @@
 				"pkg-dir": "^1.0.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -3180,6 +4194,11 @@
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"path-exists": {
 					"version": "2.1.0",
@@ -3200,33 +4219,41 @@
 			}
 		},
 		"eslint-plugin-flowtype": {
-			"version": "2.39.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.39.1.tgz",
-			"integrity": "sha512-RiQv+7Z9QDJuzt+NO8sYgkLGT+h+WeCrxP7y8lI7wpU41x3x/2o3PGtHk9ck8QnA9/mlbNcy/hG0eKvmd7npaA==",
+			"version": "2.50.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
+			"integrity": "sha512-9kRxF9hfM/O6WGZcZPszOVPd2W0TLHBtceulLTsGfwMPtiCCLnCW0ssRiOOiXyqrCA20pm1iXdXm7gQeN306zQ==",
 			"requires": {
-				"lodash": "^4.15.0"
+				"lodash": "^4.17.10"
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
 			"requires": {
-				"builtin-modules": "^1.1.1",
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
 				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.1.1",
+				"eslint-module-utils": "^2.2.0",
 				"has": "^1.0.1",
-				"lodash.cond": "^4.3.0",
+				"lodash": "^4.17.4",
 				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0"
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"doctrine": {
 					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"requires": {
 						"esutils": "^2.0.2",
@@ -3235,13 +4262,26 @@
 				},
 				"load-json-file": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
 						"pify": "^2.0.0",
 						"strip-bom": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-type": {
@@ -3279,36 +4319,39 @@
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
-			"integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
+			"integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
 			"requires": {
-				"aria-query": "^0.7.0",
+				"aria-query": "^3.0.0",
 				"array-includes": "^3.0.3",
-				"ast-types-flow": "0.0.7",
-				"axobject-query": "^0.1.0",
-				"damerau-levenshtein": "^1.0.0",
-				"emoji-regex": "^6.1.0",
-				"jsx-ast-utils": "^1.4.0"
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.1",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^6.5.1",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1"
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
-			"integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
 			"requires": {
-				"doctrine": "^2.0.0",
-				"has": "^1.0.1",
-				"jsx-ast-utils": "^2.0.0",
-				"prop-types": "^15.5.10"
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1",
+				"prop-types": "^15.6.2"
 			},
 			"dependencies": {
-				"jsx-ast-utils": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-					"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 					"requires": {
-						"array-includes": "^3.0.3"
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -3322,19 +4365,30 @@
 				"estraverse": "^4.1.1"
 			}
 		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+		},
 		"espree": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+			"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "^6.0.2",
+				"acorn-jsx": "^5.0.0",
+				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"esprima": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.0.1",
@@ -3372,15 +4426,6 @@
 			"resolved": "https://registry.npmjs.org/event-as-promise/-/event-as-promise-1.0.3.tgz",
 			"integrity": "sha512-y3mOpfy6wRemQGFXaAsbekG05d72/IK5sxQHNo/KGiYVYRtG0zER+fO2AAkqsL1KLTNqY7Da+GJWjzx0SHgIxg=="
 		},
-		"event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -3388,7 +4433,7 @@
 		},
 		"events": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"eventsource": {
@@ -3409,11 +4454,11 @@
 			}
 		},
 		"exec-sh": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "^1.2.0"
 			}
 		},
 		"execa": {
@@ -3428,84 +4473,39 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			}
-		},
-		"expand-brackets": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				}
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
 			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
 				"fill-range": "^2.1.0"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"expand-tilde": {
@@ -3516,14 +4516,27 @@
 				"homedir-polyfill": "^1.0.1"
 			}
 		},
+		"expect": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
+			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^23.6.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0"
+			}
+		},
 		"express": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
 			"requires": {
 				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.2",
+				"body-parser": "1.18.3",
 				"content-disposition": "0.5.2",
 				"content-type": "~1.0.4",
 				"cookie": "0.3.1",
@@ -3540,10 +4553,10 @@
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.3",
-				"qs": "6.5.1",
+				"proxy-addr": "~2.0.4",
+				"qs": "6.5.2",
 				"range-parser": "~1.2.0",
-				"safe-buffer": "5.1.1",
+				"safe-buffer": "5.1.2",
 				"send": "0.16.2",
 				"serve-static": "1.13.2",
 				"setprototypeof": "1.1.0",
@@ -3555,30 +4568,28 @@
 			"dependencies": {
 				"array-flatten": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 				},
-				"path-to-regexp": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
 				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -3600,44 +4611,255 @@
 			}
 		},
 		"external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
 			}
 		},
 		"extglob": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"is-extglob": "^1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"fast-glob": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
+			"integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
 					}
 				},
 				"is-accessor-descriptor": {
@@ -3665,29 +4887,69 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
-		},
-		"extract-text-webpack-plugin": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
-			"integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
-			"requires": {
-				"async": "^2.4.1",
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.3.0",
-				"webpack-sources": "^1.0.1"
-			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -3700,9 +4962,9 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fastparse": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
 		},
 		"faye-websocket": {
 			"version": "0.11.1",
@@ -3734,6 +4996,11 @@
 				"ua-parser-js": "^0.7.18"
 			}
 		},
+		"figgy-pudding": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3752,12 +5019,12 @@
 			}
 		},
 		"file-loader": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz",
-			"integrity": "sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
+			"integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
 			"requires": {
 				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.3.0"
+				"schema-utils": "^1.0.0"
 			}
 		},
 		"filename-regex": {
@@ -3775,34 +5042,35 @@
 			}
 		},
 		"filesize": {
-			"version": "3.5.11",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-			"integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
 		},
 		"fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			},
 			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"isarray": "1.0.0"
 					}
 				}
 			}
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -3812,6 +5080,21 @@
 				"parseurl": "~1.3.2",
 				"statuses": "~1.4.0",
 				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -3833,13 +5116,13 @@
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 			"requires": {
 				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
 				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
 				"write": "^0.2.1"
 			}
 		},
@@ -3848,12 +5131,21 @@
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
-		"follow-redirects": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-			"integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+		"flush-write-stream": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"requires": {
-				"debug": "^3.1.0"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"requires": {
+				"debug": "=3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -3863,6 +5155,11 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -3879,23 +5176,296 @@
 				"for-in": "^1.0.1"
 			}
 		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
+		"fork-ts-checker-webpack-plugin-alt": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin-alt/-/fork-ts-checker-webpack-plugin-alt-0.4.14.tgz",
+			"integrity": "sha512-s0wjOBuPdylMRBzZ4yO8LSJuzem3g0MYZFxsjRXrFDQyL5KJBVSq30+GoHM/t/r2CRU4tI6zi04sq6OXK0UYnw==",
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.4.1",
+				"chokidar": "^2.0.4",
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.5.0",
+				"tapable": "^1.0.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "1.0.6",
+				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -3917,14 +5487,34 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
 		"fs-extra": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-			"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+			"integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"jsonfile": "^3.0.0",
+				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
 			}
 		},
 		"fs.realpath": {
@@ -3949,8 +5539,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3968,13 +5557,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3987,18 +5574,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4101,8 +5685,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4112,7 +5695,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4125,20 +5707,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -4155,7 +5734,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4228,8 +5806,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4239,7 +5816,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4315,8 +5891,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4346,7 +5921,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4364,7 +5938,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4403,13 +5976,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -4424,18 +5995,18 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		"get-own-enumerable-property-symbols": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -4464,9 +6035,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4493,13 +6064,10 @@
 				"is-glob": "^2.0.0"
 			}
 		},
-		"global-dirs": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-			"requires": {
-				"ini": "^1.3.4"
-			}
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global-modules": {
 			"version": "1.0.0",
@@ -4524,45 +6092,40 @@
 			}
 		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"version": "11.9.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+			"integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
 		},
 		"globby": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"version": "8.0.1",
+			"resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"requires": {
 				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			}
-		},
-		"got": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"requires": {
-				"create-error-class": "^3.0.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"is-redirect": "^1.0.0",
-				"is-retry-allowed": "^1.0.0",
-				"is-stream": "^1.0.0",
-				"lowercase-keys": "^1.0.0",
-				"safe-buffer": "^5.0.1",
-				"timed-out": "^4.0.0",
-				"unzip-response": "^2.0.1",
-				"url-parse-lax": "^1.0.0"
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "3.3.10",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -4570,72 +6133,89 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"gzip-size": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
-			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
+			"integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
 			"requires": {
-				"duplexer": "^0.1.1"
+				"duplexer": "^0.1.1",
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
+		},
+		"h2x-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/h2x-core/-/h2x-core-1.1.1.tgz",
+			"integrity": "sha512-LdXe4Irs731knLtHgLyFrnJCumfiqXXQwKN1IMUhi37li29PLfLbMDvfK7Rk4wmgHLKP+sIITT1mcJV4QsC3nw==",
+			"requires": {
+				"h2x-generate": "^1.1.0",
+				"h2x-parse": "^1.1.1",
+				"h2x-traverse": "^1.1.0"
+			}
+		},
+		"h2x-generate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/h2x-generate/-/h2x-generate-1.1.0.tgz",
+			"integrity": "sha512-L7Hym0yb20QIjvqeULUPOeh/cyvScdOAyJ6oRlh5dF0+w92hf3OiTk1q15KBijde7jGEe+0R4aOmtW8gkPNIzg==",
+			"requires": {
+				"h2x-traverse": "^1.1.0"
+			}
+		},
+		"h2x-parse": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/h2x-parse/-/h2x-parse-1.1.1.tgz",
+			"integrity": "sha512-WRSmPF+tIWuUXVEZaYRhcZx/JGEJx8LjZpDDtrvMr5m/GTR0NerydCik5dRzcKXPWCtfXxuJRLR4v2P4HB2B1A==",
+			"requires": {
+				"h2x-types": "^1.1.0",
+				"jsdom": ">=11.0.0"
+			}
+		},
+		"h2x-plugin-jsx": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/h2x-plugin-jsx/-/h2x-plugin-jsx-1.2.0.tgz",
+			"integrity": "sha512-a7Vb3BHhJJq0dPDNdqguEyQirENkVsFtvM2YkiaT5h/fmGhmM1nDy3BLeJeSKi2tL2g9v4ykm2Z+GG9QrhDgPA==",
+			"requires": {
+				"h2x-types": "^1.1.0"
+			}
+		},
+		"h2x-traverse": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/h2x-traverse/-/h2x-traverse-1.1.0.tgz",
+			"integrity": "sha512-1ND8ZbISLSUgpLHYJRvhvElITvs0g44L7RxjeXViz5XP6rooa+FtXTFLByl2Yg01zj2txubifHIuU4pgvj8l+A==",
+			"requires": {
+				"h2x-types": "^1.1.0"
+			}
+		},
+		"h2x-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/h2x-types/-/h2x-types-1.1.0.tgz",
+			"integrity": "sha512-QdH5qfLcdF209UsCdM0ZNZ9Dwm2PHvMfeLZtivBrjX3Y/df4US2pwsUC4HBfWhye/mx/t6puODeC7Oacb/Ol8g=="
 		},
 		"handle-thing": {
 			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
 			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
 		},
 		"handlebars": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"requires": {
-				"async": "^1.4.0",
+				"async": "^2.5.0",
 				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
 				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				},
-				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"optional": true,
-					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-							"optional": true
-						}
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"optional": true,
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -4645,13 +6225,18 @@
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"requires": {
-				"ajv": "^5.1.0",
+				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
+		},
+		"harmony-reflect": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+			"integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
 		},
 		"has": {
 			"version": "1.0.3",
@@ -4674,6 +6259,11 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -4693,6 +6283,24 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -4713,18 +6321,23 @@
 			}
 		},
 		"hash.js": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-			"integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 			"requires": {
 				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.1"
 			}
 		},
 		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+		},
+		"hex-color-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -4735,6 +6348,11 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"hoist-non-react-statics": {
 			"version": "2.5.5",
@@ -4758,10 +6376,15 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
+		"hoopy": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
+		},
 		"hosted-git-info": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -4774,10 +6397,20 @@
 				"wbuf": "^1.1.0"
 			}
 		},
+		"hsl-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
+		},
+		"hsla-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
+		},
 		"html-comment-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -4793,48 +6426,43 @@
 			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
 		"html-minifier": {
-			"version": "3.5.16",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
-			"integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
 			"requires": {
 				"camel-case": "3.0.x",
-				"clean-css": "4.1.x",
-				"commander": "2.15.x",
-				"he": "1.1.x",
+				"clean-css": "4.2.x",
+				"commander": "2.17.x",
+				"he": "1.2.x",
 				"param-case": "2.1.x",
 				"relateurl": "0.2.x",
-				"uglify-js": "3.3.x"
+				"uglify-js": "3.4.x"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				}
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
-			"integrity": "sha1-6Yf0IYU9O2k4yMTIFxhC5f0XryM=",
+			"version": "4.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz",
+			"integrity": "sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==",
 			"requires": {
-				"bluebird": "^3.4.7",
+				"@types/tapable": "1.0.2",
 				"html-minifier": "^3.2.3",
-				"loader-utils": "^0.2.16",
-				"lodash": "^4.17.3",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.10",
 				"pretty-error": "^2.0.2",
-				"toposort": "^1.0.0"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				}
+				"tapable": "^1.0.0",
+				"util.promisify": "1.0.0"
 			}
 		},
 		"htmlparser2": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
 			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
 			"requires": {
 				"domelementtype": "1",
@@ -4858,7 +6486,7 @@
 				},
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -4869,7 +6497,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -4881,7 +6509,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -4891,9 +6519,9 @@
 			}
 		},
 		"http-parser-js": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+			"integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w=="
 		},
 		"http-proxy": {
 			"version": "1.17.0",
@@ -4906,60 +6534,222 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "0.17.4",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"version": "0.18.0",
+			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
 			"requires": {
 				"http-proxy": "^1.16.2",
-				"is-glob": "^3.1.0",
-				"lodash": "^4.17.2",
-				"micromatch": "^2.3.11"
+				"is-glob": "^4.0.0",
+				"lodash": "^4.17.5",
+				"micromatch": "^3.1.9"
 			},
 			"dependencies": {
 				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
 					}
 				},
 				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
 					}
 				},
 				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
-						"is-extglob": {
+						"define-property": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-							"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
 						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-extglob": {
@@ -4968,55 +6758,60 @@
 					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"is-extglob": "^2.1.1"
 					}
 				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
-						"is-extglob": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-							"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-						},
-						"is-glob": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-extglob": "^1.0.0"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -5061,25 +6856,63 @@
 				"postcss": "^6.0.1"
 			}
 		},
+		"identity-obj-proxy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+			"integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+			"requires": {
+				"harmony-reflect": "^1.4.6"
+			}
+		},
 		"ieee754": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
 			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
 		},
-		"ignore": {
-			"version": "3.3.8",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
-		"import-lazy": {
+		"ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+		},
+		"immer": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-1.7.2.tgz",
+			"integrity": "sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA=="
+		},
+		"import-cwd": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+			"requires": {
+				"import-from": "^2.1.0"
+			}
+		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"requires": {
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
+			}
+		},
+		"import-from": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+			"requires": {
+				"resolve-from": "^3.0.0"
+			}
 		},
 		"import-local": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -5089,14 +6922,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-		},
-		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"requires": {
-				"repeating": "^2.0.0"
-			}
 		},
 		"indexes-of": {
 			"version": "1.0.1",
@@ -5137,63 +6962,56 @@
 			}
 		},
 		"inquirer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
 				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
+				"external-editor": "^3.0.0",
 				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"lodash": "^4.17.10",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
+				"rxjs": "^6.1.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
+				"strip-ansi": "^5.0.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
 				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"tslib": "^1.9.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.0.0"
 					}
 				}
 			}
 		},
 		"internal-ip": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
 			"requires": {
-				"meow": "^3.3.0"
+				"default-gateway": "^2.6.0",
+				"ipaddr.js": "^1.5.2"
 			}
-		},
-		"interpret": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -5213,10 +7031,15 @@
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+		},
 		"ipaddr.js": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -5225,20 +7048,10 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
 				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"is-arrayish": {
@@ -5261,41 +7074,44 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-ci": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "^1.5.0"
+			}
+		},
+		"is-color-stop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+			"requires": {
+				"css-color-names": "^0.0.4",
+				"hex-color-regex": "^1.1.0",
+				"hsl-regex": "^1.0.0",
+				"hsla-regex": "^1.0.0",
+				"rgb-regex": "^1.0.1",
+				"rgba-regex": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
 				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"is-date-object": {
@@ -5361,6 +7177,11 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -5369,57 +7190,18 @@
 				"is-extglob": "^1.0.0"
 			}
 		},
-		"is-installed-globally": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-			"requires": {
-				"global-dirs": "^0.1.0",
-				"is-path-inside": "^1.0.0"
-			}
-		},
-		"is-npm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-		},
 		"is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"requires": {
 				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-odd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"requires": {
-				"is-number": "^4.0.0"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				}
-			}
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
@@ -5441,11 +7223,6 @@
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -5470,11 +7247,6 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
-		"is-redirect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -5483,20 +7255,20 @@
 				"has": "^1.0.1"
 			}
 		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+		},
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
 			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
-		"is-retry-allowed": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-		},
 		"is-root": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
-			"integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
+			"integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -5504,17 +7276,20 @@
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-svg": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+			"integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
 			"requires": {
 				"html-comment-regex": "^1.1.0"
 			}
 		},
 		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -5541,6 +7316,14 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
+		"isemail": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+			"requires": {
+				"punycode": "2.x.x"
+			}
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5566,84 +7349,56 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"requires": {
 				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
 				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.4",
-				"istanbul-reports": "^1.3.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"istanbul-lib-hook": "^1.2.2",
+				"istanbul-lib-instrument": "^1.10.2",
+				"istanbul-lib-report": "^1.1.5",
+				"istanbul-lib-source-maps": "^1.2.6",
+				"istanbul-reports": "^1.5.1",
 				"js-yaml": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"once": "^1.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-					"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
-					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"istanbul-lib-coverage": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
 		},
 		"istanbul-lib-hook": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
-			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"requires": {
-				"append-transform": "^1.0.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"requires": {
 				"babel-generator": "^6.18.0",
 				"babel-template": "^6.16.0",
 				"babel-traverse": "^6.18.0",
 				"babel-types": "^6.18.0",
 				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-coverage": "^1.2.1",
 				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-coverage": "^1.2.1",
 				"mkdirp": "^0.5.1",
 				"path-parse": "^1.0.5",
 				"supports-color": "^3.1.2"
@@ -5665,534 +7420,477 @@
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"requires": {
 				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-coverage": "^1.2.1",
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.6.1",
 				"source-map": "^0.5.3"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"requires": {
 				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
-			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
+			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"requires": {
-				"jest-cli": "^20.0.4"
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.6.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-				},
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"callsites": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"jest-cli": {
-					"version": "20.0.4",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
-					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
+					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"requires": {
-						"ansi-escapes": "^1.4.0",
-						"callsites": "^2.0.0",
-						"chalk": "^1.1.3",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
 						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
 						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.1",
-						"istanbul-lib-coverage": "^1.0.1",
-						"istanbul-lib-instrument": "^1.4.2",
-						"istanbul-lib-source-maps": "^1.1.0",
-						"jest-changed-files": "^20.0.3",
-						"jest-config": "^20.0.4",
-						"jest-docblock": "^20.0.3",
-						"jest-environment-jsdom": "^20.0.3",
-						"jest-haste-map": "^20.0.4",
-						"jest-jasmine2": "^20.0.4",
-						"jest-message-util": "^20.0.3",
-						"jest-regex-util": "^20.0.3",
-						"jest-resolve-dependencies": "^20.0.3",
-						"jest-runtime": "^20.0.4",
-						"jest-snapshot": "^20.0.3",
-						"jest-util": "^20.0.3",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.4.2",
+						"jest-config": "^23.6.0",
+						"jest-environment-jsdom": "^23.4.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.6.0",
+						"jest-message-util": "^23.4.0",
+						"jest-regex-util": "^23.3.0",
+						"jest-resolve-dependencies": "^23.6.0",
+						"jest-runner": "^23.6.0",
+						"jest-runtime": "^23.6.0",
+						"jest-snapshot": "^23.6.0",
+						"jest-util": "^23.4.0",
+						"jest-validate": "^23.6.0",
+						"jest-watcher": "^23.4.0",
+						"jest-worker": "^23.2.0",
 						"micromatch": "^2.3.11",
-						"node-notifier": "^5.0.2",
-						"pify": "^2.3.0",
+						"node-notifier": "^5.2.1",
+						"prompts": "^0.1.9",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
 						"slash": "^1.0.0",
-						"string-length": "^1.0.1",
-						"throat": "^3.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
 						"which": "^1.2.12",
-						"worker-farm": "^1.3.1",
-						"yargs": "^7.0.2"
+						"yargs": "^11.0.0"
 					}
 				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
+			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+			"requires": {
+				"throat": "^4.0.0"
+			}
 		},
 		"jest-config": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
-			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
+			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"requires": {
-				"chalk": "^1.1.3",
+				"babel-core": "^6.0.0",
+				"babel-jest": "^23.6.0",
+				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^20.0.3",
-				"jest-environment-node": "^20.0.3",
-				"jest-jasmine2": "^20.0.4",
-				"jest-matcher-utils": "^20.0.3",
-				"jest-regex-util": "^20.0.3",
-				"jest-resolve": "^20.0.4",
-				"jest-validate": "^20.0.3",
-				"pretty-format": "^20.0.3"
+				"jest-environment-jsdom": "^23.4.0",
+				"jest-environment-node": "^23.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.6.0"
+			},
+			"dependencies": {
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"jest-diff": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
-			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
+			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"requires": {
-				"chalk": "^1.1.3",
+				"chalk": "^2.0.1",
 				"diff": "^3.2.0",
-				"jest-matcher-utils": "^20.0.3",
-				"pretty-format": "^20.0.3"
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
+			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+			"requires": {
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.6.0"
+			}
 		},
 		"jest-environment-jsdom": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
-			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
 			"requires": {
-				"jest-mock": "^20.0.3",
-				"jest-util": "^20.0.3",
-				"jsdom": "^9.12.0"
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0",
+				"jsdom": "^11.5.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				},
+				"jsdom": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+					"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^5.5.3",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": "^1.0.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.9.1",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.3.0",
+						"nwsapi": "^2.0.7",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.87.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.4",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^5.2.0",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"ws": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-node": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
-			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
+			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
 			"requires": {
-				"jest-mock": "^20.0.3",
-				"jest-util": "^20.0.3"
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0"
 			}
 		},
+		"jest-get-type": {
+			"version": "22.4.3",
+			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+		},
 		"jest-haste-map": {
-			"version": "20.0.5",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
-			"integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
+			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^20.0.3",
+				"invariant": "^2.2.4",
+				"jest-docblock": "^23.2.0",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.2.0",
 				"micromatch": "^2.3.11",
-				"sane": "~1.6.0",
-				"worker-farm": "^1.3.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
-				}
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
-			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
+			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"graceful-fs": "^4.1.11",
-				"jest-diff": "^20.0.3",
-				"jest-matcher-utils": "^20.0.3",
-				"jest-matchers": "^20.0.3",
-				"jest-message-util": "^20.0.3",
-				"jest-snapshot": "^20.0.3",
-				"once": "^1.4.0",
-				"p-map": "^1.1.1"
+				"babel-traverse": "^6.0.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^23.6.0",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^23.6.0",
+				"jest-each": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
+			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+			"requires": {
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
-			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"pretty-format": "^20.0.3"
-			}
-		},
-		"jest-matchers": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
-			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
-			"requires": {
-				"jest-diff": "^20.0.3",
-				"jest-matcher-utils": "^20.0.3",
-				"jest-message-util": "^20.0.3",
-				"jest-regex-util": "^20.0.3"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
-			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
+			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
 			"requires": {
-				"chalk": "^1.1.3",
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
 				"micromatch": "^2.3.11",
-				"slash": "^1.0.0"
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+			"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+		},
+		"jest-pnp-resolver": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.0.1.tgz",
+			"integrity": "sha512-kzhvJQp+9k0a/hpvIIzOJgOwfOqmnohdrAMZW2EscH3kxR2VWD7EcPa10cio8EK9V7PcD75bhG1pFnO70zGwSQ=="
+		},
+		"jest-regex-util": {
+			"version": "23.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
+			"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+		},
+		"jest-resolve": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
+			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+			"requires": {
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"realpath-native": "^1.0.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
+			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+			"requires": {
+				"jest-regex-util": "^23.3.0",
+				"jest-snapshot": "^23.6.0"
+			}
+		},
+		"jest-runner": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
+			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+			"requires": {
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-docblock": "^23.2.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-leak-detector": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-runtime": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-worker": "^23.2.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+				"source-map-support": {
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
 					}
 				}
 			}
 		},
-		"jest-mock": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
-		},
-		"jest-regex-util": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
-		},
-		"jest-resolve": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
-			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
-			"requires": {
-				"browser-resolve": "^1.11.2",
-				"is-builtin-module": "^1.0.0",
-				"resolve": "^1.3.2"
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
-			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
-			"requires": {
-				"jest-regex-util": "^20.0.3"
-			}
-		},
 		"jest-runtime": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
-			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
+			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^20.0.3",
-				"babel-plugin-istanbul": "^4.0.0",
-				"chalk": "^1.1.3",
+				"babel-plugin-istanbul": "^4.1.6",
+				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^20.0.4",
-				"jest-haste-map": "^20.0.4",
-				"jest-regex-util": "^20.0.3",
-				"jest-resolve": "^20.0.4",
-				"jest-util": "^20.0.3",
-				"json-stable-stringify": "^1.0.1",
+				"jest-config": "^23.6.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
 				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
-				"yargs": "^7.0.2"
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^11.0.0"
 			},
 			"dependencies": {
-				"arr-diff": {
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"strip-bom": {
 					"version": "3.0.0",
@@ -6201,48 +7899,93 @@
 				}
 			}
 		},
+		"jest-serializer": {
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+		},
 		"jest-snapshot": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
-			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
+			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"jest-diff": "^20.0.3",
-				"jest-matcher-utils": "^20.0.3",
-				"jest-util": "^20.0.3",
+				"babel-types": "^6.0.0",
+				"chalk": "^2.0.1",
+				"jest-diff": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-resolve": "^23.6.0",
+				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^20.0.3"
+				"pretty-format": "^23.6.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
-			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
+			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
 			"requires": {
-				"chalk": "^1.1.3",
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
 				"graceful-fs": "^4.1.11",
-				"jest-message-util": "^20.0.3",
-				"jest-mock": "^20.0.3",
-				"jest-validate": "^20.0.3",
-				"leven": "^2.1.0",
-				"mkdirp": "^0.5.1"
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^23.4.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"jest-validate": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
-			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"jest-matcher-utils": "^20.0.3",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^20.0.3"
+				"pretty-format": "^23.6.0"
 			}
 		},
-		"js-base64": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
-			"integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
+		"jest-watcher": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
+			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+			"requires": {
+				"merge-stream": "^1.0.1"
+			}
+		},
+		"joi": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+			"integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+			"requires": {
+				"hoek": "4.x.x",
+				"isemail": "3.x.x",
+				"topo": "2.x.x"
+			}
+		},
+		"js-levenshtein": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
+			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -6250,62 +7993,61 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
 				"argparse": "^1.0.7",
-				"esprima": "^2.6.0"
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"optional": true
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
-			"version": "9.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.1.0.tgz",
+			"integrity": "sha512-C2Kp0qNuopw0smXFaHeayvharqF3kkcNqlcIlSX71+3XrsOFwkEPLt/9f5JksMmaul2JZYIQuY+WTpqHpQQcLg==",
 			"requires": {
-				"abab": "^1.0.3",
-				"acorn": "^4.0.4",
-				"acorn-globals": "^3.1.0",
+				"abab": "^2.0.0",
+				"acorn": "^6.0.4",
+				"acorn-globals": "^4.3.0",
 				"array-equal": "^1.0.0",
-				"content-type-parser": "^1.0.1",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.2.37 < 0.3.0",
-				"escodegen": "^1.6.1",
-				"html-encoding-sniffer": "^1.0.1",
-				"nwmatcher": ">= 1.3.9 < 2.0.0",
-				"parse5": "^1.5.1",
-				"request": "^2.79.0",
-				"sax": "^1.2.1",
-				"symbol-tree": "^3.2.1",
-				"tough-cookie": "^2.3.2",
-				"webidl-conversions": "^4.0.0",
-				"whatwg-encoding": "^1.0.1",
-				"whatwg-url": "^4.3.0",
-				"xml-name-validator": "^2.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				}
+				"cssom": "^0.3.4",
+				"cssstyle": "^1.1.1",
+				"data-urls": "^1.1.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.11.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"nwsapi": "^2.0.9",
+				"parse5": "5.1.0",
+				"pn": "^1.1.0",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.5",
+				"saxes": "^3.1.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.5.0",
+				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^6.1.2",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"jsesc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
-		"json-loader": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -6313,9 +8055,9 @@
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -6324,6 +8066,11 @@
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -6337,13 +8084,13 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -6365,34 +8112,38 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
-		},
-		"killable": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
-		},
-		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-		},
-		"klaw": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 			"requires": {
-				"graceful-fs": "^4.1.9"
+				"array-includes": "^3.0.3"
 			}
 		},
-		"latest-version": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+		"killable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"package-json": "^4.0.0"
+				"is-buffer": "^1.1.5"
+			}
+		},
+		"kleur": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
+			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
+		},
+		"last-call-webpack-plugin": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+			"integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
+			"requires": {
+				"lodash": "^4.17.5",
+				"webpack-sources": "^1.1.0"
 			}
 		},
 		"lazy-cache": {
@@ -6407,6 +8158,11 @@
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
 		},
 		"leven": {
 			"version": "2.1.0",
@@ -6432,7 +8188,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -6440,6 +8196,16 @@
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0",
 				"strip-bom": "^2.0.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				}
 			}
 		},
 		"loader-fs-cache": {
@@ -6489,9 +8255,9 @@
 			}
 		},
 		"loader-runner": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
+			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
@@ -6532,25 +8298,25 @@
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
-		"lodash.cond": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
-		"lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.tail": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
@@ -6579,11 +8345,6 @@
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
 			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
 		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -6592,29 +8353,15 @@
 				"js-tokens": "^3.0.0"
 			}
 		},
-		"loud-rejection": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
-			}
-		},
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
-		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -6643,15 +8390,23 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"mamacro": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-		},
-		"map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -6678,24 +8433,25 @@
 			"resolved": "https://registry.npmjs.org/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz",
 			"integrity": "sha1-Q18jFvW15o4UUM+iJC8rjVmtx18="
 		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
-		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"md5.js": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"requires": {
 				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
+		},
+		"mdn-data": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
 		},
 		"mdurl": {
 			"version": "1.0.1",
@@ -6704,7 +8460,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -6729,39 +8485,38 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
-		},
 		"merge": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+		},
+		"merge-deep": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"clone-deep": "^0.2.4",
+				"kind-of": "^3.0.2"
+			}
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"merge2": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -6769,23 +8524,23 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"microsoft-speech-browser-sdk": {
@@ -6803,27 +8558,37 @@
 			}
 		},
 		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+			"integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
 		},
 		"mime-db": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
 		},
 		"mime-types": {
-			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"version": "2.1.21",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "~1.37.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"mini-css-extract-plugin": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
+			"integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
+			"requires": {
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^1.0.0",
+				"webpack-sources": "^1.1.0"
+			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -6845,8 +8610,25 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mississippi": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+			"requires": {
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^3.0.0",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
+			}
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
@@ -6867,18 +8649,47 @@
 				}
 			}
 		},
+		"mixin-object": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+			"requires": {
+				"for-in": "^0.1.3",
+				"is-extendable": "^0.1.1"
+			},
+			"dependencies": {
+				"for-in": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+				}
+			}
+		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
 			}
 		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
+			}
+		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -6900,28 +8711,44 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"optional": true
 		},
 		"nanomatch": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
 				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
 				"is-windows": "^1.0.2",
 				"kind-of": "^6.0.2",
 				"object.pick": "^1.3.0",
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"natural-compare": {
@@ -6935,14 +8762,14 @@
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"neo-async": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
 		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"no-case": {
 			"version": "2.3.2",
@@ -7009,14 +8836,22 @@
 			}
 		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
 			"requires": {
 				"growly": "^1.3.0",
-				"semver": "^5.4.1",
+				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			}
+		},
+		"node-releases": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.2.tgz",
+			"integrity": "sha512-j1gEV/zX821yxdWp/1vBMN0pSUjuH9oGUdLCb4PfUko6ZW7KdRs3Z+QGGwDUhYtSpQvdVVyLd2V0YvLsmdg5jQ==",
+			"requires": {
+				"semver": "^5.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -7044,15 +8879,9 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
 		},
 		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
-			}
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -7063,9 +8892,9 @@
 			}
 		},
 		"nth-check": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -7080,15 +8909,15 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
-		"nwmatcher": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+		"nwsapi": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
+			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -7112,21 +8941,13 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
 				}
 			}
 		},
 		"object-hash": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
-			"integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
 		},
 		"object-keys": {
 			"version": "1.0.12",
@@ -7139,6 +8960,26 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -7156,6 +8997,17 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
 				"isobject": "^3.0.1"
+			}
+		},
+		"object.values": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"obuf": {
@@ -7198,9 +9050,9 @@
 			}
 		},
 		"opn": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
-			"integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -7221,6 +9073,15 @@
 				}
 			}
 		},
+		"optimize-css-assets-webpack-plugin": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
+			"integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
+			"requires": {
+				"cssnano": "^4.1.0",
+				"last-call-webpack-plugin": "^3.0.0"
+			}
+		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -7235,11 +9096,11 @@
 			}
 		},
 		"original": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
-			"integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
 			"requires": {
-				"url-parse": "~1.4.0"
+				"url-parse": "^1.4.3"
 			}
 		},
 		"os-browserify": {
@@ -7249,26 +9110,38 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"lcid": "^1.0.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
 			"version": "1.3.0",
@@ -7296,21 +9169,20 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
-		"package-json": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"requires": {
-				"got": "^6.7.1",
-				"registry-auth-token": "^3.0.1",
-				"registry-url": "^3.0.3",
-				"semver": "^5.1.0"
-			}
-		},
 		"pako": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
+			"integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ=="
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
+			}
 		},
 		"param-case": {
 			"version": "2.1.1",
@@ -7322,7 +9194,7 @@
 		},
 		"parse-asn1": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -7344,11 +9216,12 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse-passwd": {
@@ -7357,9 +9230,9 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse5": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
 		},
 		"parseurl": {
 			"version": "1.3.2",
@@ -7373,7 +9246,7 @@
 		},
 		"path-browserify": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
@@ -7388,7 +9261,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
@@ -7402,24 +9275,14 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"requires": {
-				"isarray": "0.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				}
-			}
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "1.1.0",
@@ -7432,9 +9295,9 @@
 			}
 		},
 		"pbkdf2": {
-			"version": "3.0.16",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
-			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -7450,7 +9313,7 @@
 		},
 		"pify": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
@@ -7474,15 +9337,33 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
 			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
 		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"pnp-webpack-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.1.0.tgz",
+			"integrity": "sha512-CPCdcFxx7fEcDMWTDjXe2Wypt4JuMt4q5Q2UrpTcyBBkLiCIyPEh/mCGmUWIcNkKGyXwQ9Y2wVhlKm6ketiBNQ=="
+		},
 		"portfinder": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -7491,8 +9372,21 @@
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -7502,738 +9396,963 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "6.0.22",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-			"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+			"version": "6.0.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 			"requires": {
 				"chalk": "^2.4.1",
 				"source-map": "^0.6.1",
 				"supports-color": "^5.4.0"
 			},
 			"dependencies": {
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-attribute-case-insensitive": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.0.tgz",
+			"integrity": "sha512-K/zqdg0/UgUgC8qR0lDuxYzmowPpnvrrNC5YuoqzhHMubR9AuhsPlpVu3jjkLHgDAzR+ohD/m7//iGnN9WxbzQ==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-calc": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+			"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
 			"requires": {
-				"postcss": "^5.0.2",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-css-calc": "^1.2.6"
+				"css-unit-converter": "^1.1.1",
+				"postcss": "^7.0.5",
+				"postcss-selector-parser": "^5.0.0-rc.4",
+				"postcss-value-parser": "^3.3.1"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-color-functional-notation": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+			"integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-color-hex-alpha": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.2.tgz",
+			"integrity": "sha512-8bIOzQMGdZVifoBQUJdw+yIY00omBd2EwkJXepQo9cjp1UOHHHoeRDeSzTP6vakEpaRc6GAIOfvcQR7jBYaG5Q==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-color-mod-function": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+			"integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
+			"requires": {
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-color-rebeccapurple": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+			"integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-colormin": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.2.tgz",
+			"integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
 			"requires": {
-				"colormin": "^1.0.5",
-				"postcss": "^5.0.13",
-				"postcss-value-parser": "^3.2.3"
+				"browserslist": "^4.0.0",
+				"color": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-convert-values": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+			"integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
 			"requires": {
-				"postcss": "^5.0.11",
-				"postcss-value-parser": "^3.1.2"
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-custom-media": {
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.7.tgz",
+			"integrity": "sha512-bWPCdZKdH60wKOTG4HKEgxWnZVjAIVNOJDvi3lkuTa90xo/K0YHa2ZnlKLC5e2qF8qCcMQXt0yzQITBp8d0OFA==",
+			"requires": {
+				"postcss": "^7.0.5"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-custom-properties": {
+			"version": "8.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
+			"integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
+			"requires": {
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-custom-selectors": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+			"integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-dir-pseudo-class": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+			"integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-discard-comments": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz",
+			"integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-discard-duplicates": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+			"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-discard-empty": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+			"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-discard-overridden": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+			"integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
 			"requires": {
-				"postcss": "^5.0.16"
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-discard-unused": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+		"postcss-env-function": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+			"integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
 			"requires": {
-				"postcss": "^5.0.14",
-				"uniqs": "^2.0.0"
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-filter-plugins": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
-			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
-			"requires": {
-				"postcss": "^5.0.4"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-flexbugs-fixes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
-			"integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
+			"integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
 			"requires": {
-				"postcss": "^6.0.1"
-			}
-		},
-		"postcss-load-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0",
-				"postcss-load-options": "^1.2.0",
-				"postcss-load-plugins": "^2.3.0"
-			}
-		},
-		"postcss-load-options": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0"
-			}
-		},
-		"postcss-load-plugins": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-			"requires": {
-				"cosmiconfig": "^2.1.1",
-				"object-assign": "^4.1.0"
-			}
-		},
-		"postcss-loader": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.8.tgz",
-			"integrity": "sha512-KtXBiQ/r/WYW8LxTSJK7h8wLqvCMSub/BqmRnud/Mu8RzwflW9cmXxwsMwbn15TNv287Hcufdb3ZSs7xHKnG8Q==",
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^6.0.0",
-				"postcss-load-config": "^1.2.0",
-				"schema-utils": "^0.3.0"
-			}
-		},
-		"postcss-merge-idents": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.10",
-				"postcss-value-parser": "^3.1.1"
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-focus-visible": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+			"integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-focus-within": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+			"integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-font-variant": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+			"integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-gap-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+			"integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-image-set-function": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+			"integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-initial": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.0.tgz",
+			"integrity": "sha512-WzrqZ5nG9R9fUtrA+we92R4jhVvEB32IIRTzfIG/PLL8UV4CvbF1ugTEHEFX6vWxl41Xt5RTCJPEZkuWzrOM+Q==",
+			"requires": {
+				"lodash.template": "^4.2.4",
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-lab-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+			"integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
+			"requires": {
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-load-config": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"requires": {
+				"cosmiconfig": "^4.0.0",
+				"import-cwd": "^2.0.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+					"requires": {
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.9.0",
+						"parse-json": "^4.0.0",
+						"require-from-string": "^2.0.1"
+					}
+				}
+			}
+		},
+		"postcss-loader": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+			"integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+			"requires": {
+				"loader-utils": "^1.1.0",
+				"postcss": "^7.0.0",
+				"postcss-load-config": "^2.0.0",
+				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-logical": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
+			"integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-media-minmax": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+			"integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-merge-longhand": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.9.tgz",
+			"integrity": "sha512-UVMXrXF5K/kIwUbK/crPFCytpWbNX2Q3dZSc8+nQUgfOHrCT4+MHncpdxVphUlQeZxlLXUJbDyXc5NBhTnS2tA==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"css-color-names": "0.0.4",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"stylehacks": "^4.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-merge-rules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.2.tgz",
+			"integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
 			"requires": {
-				"browserslist": "^1.5.2",
-				"caniuse-api": "^1.5.2",
-				"postcss": "^5.0.4",
-				"postcss-selector-parser": "^2.2.2",
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"cssnano-util-same-parent": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0",
 				"vendors": "^1.0.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
-		},
 		"postcss-minify-font-values": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+			"integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
 			"requires": {
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-minify-gradients": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.1.tgz",
+			"integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
 			"requires": {
-				"postcss": "^5.0.12",
-				"postcss-value-parser": "^3.3.0"
+				"cssnano-util-get-arguments": "^4.0.0",
+				"is-color-stop": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-minify-params": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.1.tgz",
+			"integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.2",
-				"postcss-value-parser": "^3.0.2",
+				"alphanum-sort": "^1.0.0",
+				"browserslist": "^4.0.0",
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
 				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-minify-selectors": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.1.tgz",
+			"integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"has": "^1.0.1",
-				"postcss": "^5.0.14",
-				"postcss-selector-parser": "^2.0.0"
+				"alphanum-sort": "^1.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-modules-extract-imports": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
-			"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -8265,384 +10384,702 @@
 				"postcss": "^6.0.1"
 			}
 		},
-		"postcss-normalize-charset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+		"postcss-nesting": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.0.tgz",
+			"integrity": "sha512-WSsbVd5Ampi3Y0nk/SKr5+K34n52PqMqEfswu6RtU4r7wA8vSD+gM8/D9qq4aJkHImwn1+9iEFTbjoWsQeqtaQ==",
 			"requires": {
-				"postcss": "^5.0.5"
+				"postcss": "^7.0.2"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+			"integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+			"requires": {
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-display-values": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+			"integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-positions": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.1.tgz",
+			"integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-repeat-style": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.1.tgz",
+			"integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-string": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.1.tgz",
+			"integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
+			"requires": {
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-timing-functions": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.1.tgz",
+			"integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-unicode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+			"integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-normalize-url": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+			"integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
 			"requires": {
 				"is-absolute-url": "^2.0.0",
-				"normalize-url": "^1.4.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3"
+				"normalize-url": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-normalize-whitespace": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.1.tgz",
+			"integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
+			"requires": {
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-ordered-values": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.1.tgz",
+			"integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.1"
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-reduce-idents": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+		"postcss-overflow-shorthand": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+			"integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"postcss": "^7.0.2"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-page-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+			"integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-place": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
+			"integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-preset-env": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.0.6.tgz",
+			"integrity": "sha512-W1Wtqngl7BMe4s9o76odTaVs4HXVLhOHD+L5Ez+7x15yiA+98W/WVO6IPlC1q9BIkgAckRtUFmEDr0sNufXZIQ==",
+			"requires": {
+				"autoprefixer": "^9.1.5",
+				"browserslist": "^4.1.1",
+				"caniuse-lite": "^1.0.30000887",
+				"cssdb": "^3.2.1",
+				"postcss": "^7.0.2",
+				"postcss-attribute-case-insensitive": "^4.0.0",
+				"postcss-color-functional-notation": "^2.0.1",
+				"postcss-color-hex-alpha": "^5.0.2",
+				"postcss-color-mod-function": "^3.0.3",
+				"postcss-color-rebeccapurple": "^4.0.1",
+				"postcss-custom-media": "^7.0.4",
+				"postcss-custom-properties": "^8.0.5",
+				"postcss-custom-selectors": "^5.1.2",
+				"postcss-dir-pseudo-class": "^5.0.0",
+				"postcss-env-function": "^2.0.2",
+				"postcss-focus-visible": "^4.0.0",
+				"postcss-focus-within": "^3.0.0",
+				"postcss-font-variant": "^4.0.0",
+				"postcss-gap-properties": "^2.0.0",
+				"postcss-image-set-function": "^3.0.1",
+				"postcss-initial": "^3.0.0",
+				"postcss-lab-function": "^2.0.1",
+				"postcss-logical": "^3.0.0",
+				"postcss-media-minmax": "^4.0.0",
+				"postcss-nesting": "^7.0.0",
+				"postcss-overflow-shorthand": "^2.0.0",
+				"postcss-page-break": "^2.0.0",
+				"postcss-place": "^4.0.1",
+				"postcss-pseudo-class-any-link": "^6.0.0",
+				"postcss-replace-overflow-wrap": "^3.0.0",
+				"postcss-selector-matches": "^4.0.0",
+				"postcss-selector-not": "^4.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-pseudo-class-any-link": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+			"integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-reduce-initial": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.2.tgz",
+			"integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-reduce-transforms": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.1.tgz",
+			"integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.8",
-				"postcss-value-parser": "^3.0.1"
+				"cssnano-util-get-match": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-replace-overflow-wrap": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+			"integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
+			"requires": {
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-safe-parser": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+			"requires": {
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-selector-matches": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+			"integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"postcss-selector-not": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+			"integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"postcss": "^7.0.2"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"version": "5.0.0-rc.4",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0-rc.4.tgz",
+			"integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
 			"requires": {
-				"flatten": "^1.0.2",
+				"cssesc": "^2.0.0",
 				"indexes-of": "^1.0.1",
 				"uniq": "^1.0.1"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				}
 			}
 		},
 		"postcss-svgo": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.1.tgz",
+			"integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
 			"requires": {
-				"is-svg": "^2.0.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3",
-				"svgo": "^0.7.0"
+				"is-svg": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"svgo": "^1.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-unique-selectors": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+			"integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.4",
+				"alphanum-sort": "^1.0.0",
+				"postcss": "^7.0.0",
 				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
 					}
 				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-value-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
-		"postcss-zindex": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+		"postcss-values-parser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.0.tgz",
+			"integrity": "sha512-cyRdkgbRRefu91ByAlJow4y9w/hnBmmWgLpWmlFQ2bpIy2eKrqowt3VeYcaHQ08otVXmC9V2JtYW1Z/RpvYR8A==",
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
 			}
 		},
 		"prelude-ls": {
@@ -8650,19 +11087,19 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
+		"prettier": {
+			"version": "1.15.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
+		},
 		"pretty-bytes": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
 			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
 		},
 		"pretty-error": {
@@ -8675,12 +11112,19 @@
 			}
 		},
 		"pretty-format": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
-			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"requires": {
-				"ansi-regex": "^2.1.1",
-				"ansi-styles": "^3.0.0"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
 			}
 		},
 		"private": {
@@ -8699,9 +11143,9 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -8709,6 +11153,20 @@
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
 				"asap": "~2.0.3"
+			}
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+		},
+		"prompts": {
+			"version": "0.1.14",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
+			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+			"requires": {
+				"kleur": "^2.0.1",
+				"sisteransi": "^0.1.1"
 			}
 		},
 		"prop-types": {
@@ -8722,12 +11180,12 @@
 			}
 		},
 		"proxy-addr": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.6.0"
+				"ipaddr.js": "1.8.0"
 			}
 		},
 		"prr": {
@@ -8741,20 +11199,51 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.28",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"public-encrypt": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
-			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
 				"create-hash": "^1.1.0",
 				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1"
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"pumpify": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"requires": {
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
 			}
 		},
 		"punycode": {
@@ -8772,15 +11261,6 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
-		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8792,9 +11272,9 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"querystringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
 		},
 		"raf": {
 			"version": "3.4.0",
@@ -8805,9 +11285,9 @@
 			}
 		},
 		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -8818,6 +11298,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
 					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -8844,60 +11329,14 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
 			"requires": {
 				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
 				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				},
-				"http-errors": {
-					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"requires": {
-						"depd": "1.1.1",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.3",
-						"statuses": ">= 1.3.1 < 2"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-				},
-				"setprototypeof": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-				}
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"react": {
@@ -8911,29 +11350,158 @@
 				"prop-types": "^15.6.0"
 			}
 		},
-		"react-dev-utils": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",
-			"integrity": "sha512-+y92rG6pmXt3cpcg/NGmG4w/W309tWNSmyyPL8hCMxuCSg2UP/hUg3npACj2UZc8UKVSXexyLrCnxowizGoAsw==",
+		"react-app-polyfill": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
+			"integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
 			"requires": {
+				"core-js": "2.5.7",
+				"object-assign": "4.1.1",
+				"promise": "8.0.2",
+				"raf": "3.4.0",
+				"whatwg-fetch": "3.0.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+				},
+				"promise": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+					"integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+					"requires": {
+						"asap": "~2.0.6"
+					}
+				},
+				"whatwg-fetch": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+					"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+				}
+			}
+		},
+		"react-dev-utils": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.1.1.tgz",
+			"integrity": "sha512-ThbJ86coVd6wV/QiTo8klDTvdAJ1WsFCGQN07+UkN+QN9CtCSsl/+YuDJToKGeG8X4j9HMGXNKbk2QhPAZr43w==",
+			"requires": {
+				"@babel/code-frame": "7.0.0",
 				"address": "1.0.3",
-				"babel-code-frame": "6.26.0",
-				"chalk": "1.1.3",
-				"cross-spawn": "5.1.0",
+				"browserslist": "4.1.1",
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
 				"detect-port-alt": "1.1.6",
 				"escape-string-regexp": "1.0.5",
-				"filesize": "3.5.11",
+				"filesize": "3.6.1",
+				"find-up": "3.0.0",
 				"global-modules": "1.0.0",
-				"gzip-size": "3.0.0",
-				"inquirer": "3.3.0",
-				"is-root": "1.0.0",
-				"opn": "5.2.0",
-				"react-error-overlay": "^4.0.0",
-				"recursive-readdir": "2.2.1",
+				"globby": "8.0.1",
+				"gzip-size": "5.0.0",
+				"immer": "1.7.2",
+				"inquirer": "6.2.0",
+				"is-root": "2.0.0",
+				"loader-utils": "1.1.0",
+				"opn": "5.4.0",
+				"pkg-up": "2.0.0",
+				"react-error-overlay": "^5.1.0",
+				"recursive-readdir": "2.2.2",
 				"shell-quote": "1.6.1",
-				"sockjs-client": "1.1.4",
-				"strip-ansi": "3.0.1",
+				"sockjs-client": "1.1.5",
+				"strip-ansi": "4.0.0",
 				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"browserslist": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+					"integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+					"requires": {
+						"caniuse-lite": "^1.0.30000884",
+						"electron-to-chromium": "^1.3.62",
+						"node-releases": "^1.0.0-alpha.11"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.10",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.1.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+				},
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"react-dictate-button": {
@@ -8957,9 +11525,9 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
-			"integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
+			"integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ=="
 		},
 		"react-redux": {
 			"version": "5.0.7",
@@ -8986,64 +11554,58 @@
 			}
 		},
 		"react-scripts": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.1.4.tgz",
-			"integrity": "sha512-UVZIujEIT9BGbx+NGvyfS92eOrNIIpqqFi1FP7a0O9l94A/XV7bhPk70SfDKaXZouCX81tFdXo0948DjhCEgGw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.1.1.tgz",
+			"integrity": "sha512-f6KCUy7opItgeana1Ghwj+lYQp5BTHSaivG/dbfiIqSm5QdOIUV5eiFSBsbaAE6GEKqGYmZDK6Yw5WmbrhxaFg==",
 			"requires": {
-				"autoprefixer": "7.1.6",
-				"babel-core": "6.26.0",
-				"babel-eslint": "7.2.3",
-				"babel-jest": "20.0.3",
-				"babel-loader": "7.1.2",
-				"babel-preset-react-app": "^3.1.1",
-				"babel-runtime": "6.26.0",
-				"case-sensitive-paths-webpack-plugin": "2.1.1",
-				"chalk": "1.1.3",
-				"css-loader": "0.28.7",
-				"dotenv": "4.0.0",
+				"@babel/core": "7.1.0",
+				"@svgr/webpack": "2.4.1",
+				"babel-core": "7.0.0-bridge.0",
+				"babel-eslint": "9.0.0",
+				"babel-jest": "23.6.0",
+				"babel-loader": "8.0.4",
+				"babel-plugin-named-asset-import": "^0.2.3",
+				"babel-preset-react-app": "^6.1.0",
+				"bfj": "6.1.1",
+				"case-sensitive-paths-webpack-plugin": "2.1.2",
+				"chalk": "2.4.1",
+				"css-loader": "1.0.0",
+				"dotenv": "6.0.0",
 				"dotenv-expand": "4.2.0",
-				"eslint": "4.10.0",
-				"eslint-config-react-app": "^2.1.0",
-				"eslint-loader": "1.9.0",
-				"eslint-plugin-flowtype": "2.39.1",
-				"eslint-plugin-import": "2.8.0",
-				"eslint-plugin-jsx-a11y": "5.1.1",
-				"eslint-plugin-react": "7.4.0",
-				"extract-text-webpack-plugin": "3.0.2",
-				"file-loader": "1.1.5",
-				"fs-extra": "3.0.1",
-				"fsevents": "^1.1.3",
-				"html-webpack-plugin": "2.29.0",
-				"jest": "20.0.4",
-				"object-assign": "4.1.1",
-				"postcss-flexbugs-fixes": "3.2.0",
-				"postcss-loader": "2.0.8",
-				"promise": "8.0.1",
-				"raf": "3.4.0",
-				"react-dev-utils": "^5.0.1",
-				"resolve": "1.6.0",
-				"style-loader": "0.19.0",
-				"sw-precache-webpack-plugin": "0.11.4",
-				"url-loader": "0.6.2",
-				"webpack": "3.8.1",
-				"webpack-dev-server": "2.9.4",
-				"webpack-manifest-plugin": "1.3.2",
-				"whatwg-fetch": "2.0.3"
-			},
-			"dependencies": {
-				"promise": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
-					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
-					"requires": {
-						"asap": "~2.0.3"
-					}
-				},
-				"whatwg-fetch": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-					"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-				}
+				"eslint": "5.6.0",
+				"eslint-config-react-app": "^3.0.5",
+				"eslint-loader": "2.1.1",
+				"eslint-plugin-flowtype": "2.50.1",
+				"eslint-plugin-import": "2.14.0",
+				"eslint-plugin-jsx-a11y": "6.1.2",
+				"eslint-plugin-react": "7.11.1",
+				"file-loader": "2.0.0",
+				"fork-ts-checker-webpack-plugin-alt": "0.4.14",
+				"fs-extra": "7.0.0",
+				"fsevents": "1.2.4",
+				"html-webpack-plugin": "4.0.0-alpha.2",
+				"identity-obj-proxy": "3.0.0",
+				"jest": "23.6.0",
+				"jest-pnp-resolver": "1.0.1",
+				"jest-resolve": "23.6.0",
+				"mini-css-extract-plugin": "0.4.3",
+				"optimize-css-assets-webpack-plugin": "5.0.1",
+				"pnp-webpack-plugin": "1.1.0",
+				"postcss-flexbugs-fixes": "4.1.0",
+				"postcss-loader": "3.0.0",
+				"postcss-preset-env": "6.0.6",
+				"postcss-safe-parser": "4.0.1",
+				"react-app-polyfill": "^0.1.3",
+				"react-dev-utils": "^6.1.1",
+				"resolve": "1.8.1",
+				"sass-loader": "7.1.0",
+				"style-loader": "0.23.0",
+				"terser-webpack-plugin": "1.1.0",
+				"url-loader": "1.1.1",
+				"webpack": "4.19.1",
+				"webpack-dev-server": "3.1.9",
+				"webpack-manifest-plugin": "2.0.4",
+				"workbox-webpack-plugin": "3.6.3"
 			}
 		},
 		"read-pkg": {
@@ -9086,7 +11648,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -9099,73 +11661,287 @@
 			}
 		},
 		"readdirp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
+			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+			"requires": {
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"recursive-readdir": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
-			"integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+			"integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
 			"requires": {
-				"minimatch": "3.0.3"
-			},
-			"dependencies": {
-				"minimatch": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-					"requires": {
-						"brace-expansion": "^1.0.0"
-					}
-				}
-			}
-		},
-		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
-			}
-		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"requires": {
-				"balanced-match": "^0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
+				"minimatch": "3.0.4"
 			}
 		},
 		"redux": {
@@ -9182,18 +11958,24 @@
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
+		"regenerate-unicode-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
 			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
 				"private": "^0.1.6"
 			}
 		},
@@ -9214,49 +11996,40 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+		},
 		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
+			"integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
-			}
-		},
-		"registry-auth-token": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"requires": {
-				"rc": "^1.1.6",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"registry-url": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"requires": {
-				"rc": "^1.0.1"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^7.0.0",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.0.2"
 			}
 		},
 		"regjsgen": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
 		},
 		"regjsparser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -9272,28 +12045,43 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
-			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.2.tgz",
+			"integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
 			"requires": {
 				"css-select": "^1.1.0",
-				"dom-converter": "~0.1",
+				"dom-converter": "~0.2",
 				"htmlparser2": "~3.3.0",
 				"strip-ansi": "^3.0.0",
-				"utila": "~0.3"
+				"utila": "^0.4.0"
 			},
 			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+				"css-select": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+					"requires": {
+						"boolbase": "~1.0.0",
+						"css-what": "2.1",
+						"domutils": "1.5.1",
+						"nth-check": "~1.0.1"
+					}
+				},
+				"domutils": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					}
 				}
 			}
 		},
 		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
@@ -9309,30 +12097,30 @@
 			}
 		},
 		"request": {
-			"version": "2.87.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
+				"aws4": "^1.8.0",
 				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"punycode": {
@@ -9341,13 +12129,32 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				},
 				"tough-cookie": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"requires": {
+						"psl": "^1.1.24",
 						"punycode": "^1.4.1"
 					}
 				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -9356,9 +12163,9 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
@@ -9367,11 +12174,31 @@
 		},
 		"require-uncached": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"requires": {
 				"caller-path": "^0.1.0",
 				"resolve-from": "^1.0.0"
+			},
+			"dependencies": {
+				"caller-path": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+					"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+					"requires": {
+						"callsites": "^0.2.0"
+					}
+				},
+				"callsites": {
+					"version": "0.2.0",
+					"resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+					"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+				},
+				"resolve-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+				}
 			}
 		},
 		"requires-port": {
@@ -9380,9 +12207,9 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
-			"integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -9393,13 +12220,6 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
 				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
 			}
 		},
 		"resolve-dir": {
@@ -9412,9 +12232,9 @@
 			}
 		},
 		"resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -9435,13 +12255,15 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"requires": {
-				"align-text": "^0.1.1"
-			}
+		"rgb-regex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
+		},
+		"rgba-regex": {
+			"version": "1.0.0",
+			"resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
 		},
 		"rimraf": {
 			"version": "2.6.2",
@@ -9460,6 +12282,11 @@
 				"inherits": "^2.0.1"
 			}
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -9468,17 +12295,12 @@
 				"is-promise": "^2.1.0"
 			}
 		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"requires": {
-				"rx-lite": "*"
+				"aproba": "^1.1.1"
 			}
 		},
 		"rxjs": {
@@ -9503,7 +12325,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -9515,39 +12337,342 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
-			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"requires": {
-				"anymatch": "^1.3.0",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
 				"exec-sh": "^0.2.0",
-				"fb-watchman": "^1.8.0",
-				"minimatch": "^3.0.2",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5",
-				"watch": "~0.10.0"
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
-				"bser": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"node-int64": "^0.4.0"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
-				"fb-watchman": {
-					"version": "1.9.2",
-					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
-					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
-						"bser": "1.0.2"
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"sass-loader": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
+			"integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
+			"requires": {
+				"clone-deep": "^2.0.1",
+				"loader-utils": "^1.0.1",
+				"lodash.tail": "^4.1.1",
+				"neo-async": "^2.5.0",
+				"pify": "^3.0.0",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"clone-deep": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
+					"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+					"requires": {
+						"for-own": "^1.0.0",
+						"is-plain-object": "^2.0.4",
+						"kind-of": "^6.0.0",
+						"shallow-clone": "^1.0.0"
+					}
+				},
+				"for-own": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"shallow-clone": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
+					"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+					"requires": {
+						"is-extendable": "^0.1.1",
+						"kind-of": "^5.0.0",
+						"mixin-object": "^2.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
 				}
 			}
 		},
@@ -9556,12 +12681,22 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
-		"schema-utils": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+		"saxes": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.4.tgz",
+			"integrity": "sha512-GVZmLJnkS4Vl8Pe9o4nc5ALZ615VOVxCmea8Cs0l+8GZw3RQ5XGOSUomIUfuZuk4Todo44v4y+HY1EATkDDiZg==",
 			"requires": {
-				"ajv": "^5.0.0"
+				"xmlchars": "^1.3.1"
+			}
+		},
+		"schema-utils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+			"requires": {
+				"ajv": "^6.1.0",
+				"ajv-errors": "^1.0.0",
+				"ajv-keywords": "^3.1.0"
 			}
 		},
 		"select-hose": {
@@ -9570,25 +12705,17 @@
 			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
 		},
 		"selfsigned": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
-			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+			"integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
 			"requires": {
 				"node-forge": "0.7.5"
 			}
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-		},
-		"semver-diff": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-			"requires": {
-				"semver": "^5.0.3"
-			}
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
 		"send": {
 			"version": "0.16.2",
@@ -9610,12 +12737,30 @@
 				"statuses": "~1.4.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"mime": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
 					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
+		},
+		"serialize-javascript": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
 		},
 		"serve-index": {
 			"version": "1.9.1",
@@ -9629,6 +12774,21 @@
 				"http-errors": "~1.6.2",
 				"mime-types": "~2.1.17",
 				"parseurl": "~1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"serve-static": {
@@ -9642,20 +12802,10 @@
 				"send": "0.16.2"
 			}
 		},
-		"serviceworker-cache-polyfill": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
-			"integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
@@ -9690,11 +12840,37 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"shallow-clone": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+			"requires": {
+				"is-extendable": "^0.1.1",
+				"kind-of": "^2.0.1",
+				"lazy-cache": "^0.2.3",
+				"mixin-object": "^2.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "2.0.1",
+					"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+					"requires": {
+						"is-buffer": "^1.0.2"
+					}
+				},
+				"lazy-cache": {
+					"version": "0.2.7",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+				}
 			}
 		},
 		"shebang-command": {
@@ -9731,10 +12907,30 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			},
+			"dependencies": {
+				"is-arrayish": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+				}
+			}
+		},
 		"simple-update-in": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.3.0.tgz",
 			"integrity": "sha512-XQdzyPAjHeqcBDJfUBKgfnurtE9Z/PC7Jh73DAiNlS4vMkdVTrtNpg5GJEGSDOtJ5LPQdZ/BWTx5GNzsP89mlA=="
+		},
+		"sisteransi": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
+			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -9764,6 +12960,14 @@
 				"use": "^3.1.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -9780,10 +12984,10 @@
 						"is-extendable": "^0.1.0"
 					}
 				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -9830,6 +13034,11 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -9839,25 +13048,15 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
 				"kind-of": "^3.2.0"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"sockjs": {
-			"version": "0.3.18",
-			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
 			"requires": {
 				"faye-websocket": "^0.10.0",
-				"uuid": "^2.0.2"
+				"uuid": "^3.0.1"
 			},
 			"dependencies": {
 				"faye-websocket": {
@@ -9867,18 +13066,13 @@
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
-				},
-				"uuid": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
 		},
 		"sockjs-client": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
 			"requires": {
 				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
@@ -9886,25 +13080,32 @@
 				"inherits": "^2.0.1",
 				"json3": "^3.3.2",
 				"url-parse": "^1.1.8"
-			}
-		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"requires": {
-				"is-plain-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"source-list-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
 		},
 		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
@@ -9924,13 +13125,6 @@
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"requires": {
 				"source-map": "^0.5.6"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"source-map-url": {
@@ -9939,18 +13133,18 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
@@ -9962,9 +13156,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
 		},
 		"spdy": {
 			"version": "3.4.7",
@@ -9977,12 +13171,27 @@
 				"safe-buffer": "^5.0.1",
 				"select-hose": "^2.0.0",
 				"spdy-transport": "^2.0.18"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"spdy-transport": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+			"integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
 			"requires": {
 				"debug": "^2.6.8",
 				"detect-node": "^2.0.3",
@@ -9991,6 +13200,21 @@
 				"readable-stream": "^2.2.9",
 				"safe-buffer": "^5.0.1",
 				"wbuf": "^1.7.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"split-string": {
@@ -10007,9 +13231,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -10021,6 +13245,24 @@
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
+		},
+		"ssri": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"requires": {
+				"figgy-pudding": "^3.5.1"
+			}
+		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -10046,13 +13288,27 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
 		"stream-browserify": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"stream-each": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"stream-http": {
@@ -10067,17 +13323,33 @@
 				"xtend": "^4.0.0"
 			}
 		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"string-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"requires": {
-				"strip-ansi": "^3.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string-width": {
@@ -10106,15 +13378,25 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"stringify-object": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"requires": {
+				"get-own-enumerable-property-symbols": "^3.0.0",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -10128,18 +13410,19 @@
 				"is-utf8": "^0.2.0"
 			}
 		},
+		"strip-comments": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+			"integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+			"requires": {
+				"babel-extract-comments": "^1.0.0",
+				"babel-plugin-transform-object-rest-spread": "^6.26.0"
+			}
+		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-		},
-		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -10147,70 +13430,89 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"style-loader": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
-			"integrity": "sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==",
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.0.tgz",
+			"integrity": "sha512-uCcN7XWHkqwGVt7skpInW6IGO1tG6ReyFQ1Cseh0VcN6VdcFQi62aG/2F3Y9ueA8x4IVlfaSUxpmQXQD9QrEuQ==",
 			"requires": {
-				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.3.0"
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^0.4.5"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "0.4.7",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
+			}
+		},
+		"stylehacks": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.1.tgz",
+			"integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
 		},
 		"svgo": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
+			"integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
 			"requires": {
-				"coa": "~1.0.1",
+				"coa": "~2.0.1",
 				"colors": "~1.1.2",
-				"csso": "~2.3.1",
-				"js-yaml": "~3.7.0",
+				"css-select": "^2.0.0",
+				"css-select-base-adapter": "~0.1.0",
+				"css-tree": "1.0.0-alpha.28",
+				"css-url-regex": "^1.1.0",
+				"csso": "^3.5.0",
+				"js-yaml": "^3.12.0",
 				"mkdirp": "~0.5.1",
-				"sax": "~1.2.1",
-				"whet.extend": "~0.9.9"
-			}
-		},
-		"sw-precache": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
-			"integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
-			"requires": {
-				"dom-urls": "^1.1.0",
-				"es6-promise": "^4.0.5",
-				"glob": "^7.1.1",
-				"lodash.defaults": "^4.2.0",
-				"lodash.template": "^4.4.0",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"pretty-bytes": "^4.0.2",
-				"sw-toolbox": "^3.4.0",
-				"update-notifier": "^2.3.0"
-			}
-		},
-		"sw-precache-webpack-plugin": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.11.4.tgz",
-			"integrity": "sha1-ppUBflTu1XVVFJOlGdwdqNotxeA=",
-			"requires": {
-				"del": "^2.2.2",
-				"sw-precache": "^5.1.1",
-				"uglify-js": "^3.0.13"
-			}
-		},
-		"sw-toolbox": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
-			"integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
-			"requires": {
-				"path-to-regexp": "^1.0.1",
-				"serviceworker-cache-polyfill": "^4.0.0"
+				"object.values": "^1.0.4",
+				"sax": "~1.2.4",
+				"stable": "~0.1.6",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
 			}
 		},
 		"symbol-observable": {
@@ -10225,7 +13527,7 @@
 		},
 		"table": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
 			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 			"requires": {
 				"ajv": "^6.0.1",
@@ -10234,61 +13536,129 @@
 				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
 				"string-width": "^2.1.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-					"integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.1"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				}
 			}
 		},
 		"tapable": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
+			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
 		},
-		"term-size": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+		"terser": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-3.13.1.tgz",
+			"integrity": "sha512-ogyZye4DFqOtMzT92Y3Nxxw8OvXmL39HOALro4fc+EUYFFF9G/kk0znkvwMz6PPYgBtdKAodh3FPR70eugdaQA==",
 			"requires": {
-				"execa": "^0.7.0"
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1",
+				"source-map-support": "~0.5.6"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
+			}
+		},
+		"terser-webpack-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
+			"integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
+			"requires": {
+				"cacache": "^11.0.2",
+				"find-cache-dir": "^2.0.0",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"terser": "^3.8.1",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"test-exclude": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
+			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
 			"requires": {
 				"arrify": "^1.0.1",
-				"micromatch": "^3.1.8",
+				"micromatch": "^2.3.11",
 				"object-assign": "^4.1.0",
 				"read-pkg-up": "^1.0.1",
 				"require-main-filename": "^1.0.1"
@@ -10300,29 +13670,28 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throat": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
 		"thunky": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
-		},
-		"time-stamp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
-		},
-		"timed-out": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+			"integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow=="
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
@@ -10331,6 +13700,11 @@
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
+		},
+		"timsort": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -10351,9 +13725,9 @@
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -10361,16 +13735,6 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
 				"kind-of": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"to-regex": {
@@ -10391,47 +13755,61 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			}
-		},
-		"toposort": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
-		},
-		"tough-cookie": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
 			},
 			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
 				}
 			}
 		},
-		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		"topo": {
+			"version": "2.0.2",
+			"resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+			"requires": {
+				"hoek": "4.x.x"
+			}
 		},
-		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
+		"tryer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+		},
 		"tty-browserify": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
@@ -10445,8 +13823,7 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -10481,57 +13858,153 @@
 			"integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
 		},
 		"uglify-js": {
-			"version": "3.3.28",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
-			"integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"requires": {
-				"commander": "~2.15.0",
+				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
-			}
-		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"optional": true
-		},
-		"uglifyjs-webpack-plugin": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-			"requires": {
-				"source-map": "^0.5.6",
-				"uglify-js": "^2.8.29",
-				"webpack-sources": "^1.0.1"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				},
 				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
+			"requires": {
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"schema-utils": "^0.4.5",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"uglify-es": "^3.3.4",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "10.0.4",
+					"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+					"requires": {
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
+					}
+				},
+				"commander": {
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+				},
+				"mississippi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"schema-utils": {
+					"version": "0.4.7",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"ssri": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+					"requires": {
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"uglify-es": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"requires": {
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				}
+			}
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -10575,23 +14048,36 @@
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
 		},
-		"unique-string": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+		"unique-filename": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"requires": {
-				"crypto-random-string": "^1.0.0"
+				"unique-slug": "^2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"requires": {
+				"imurmurhash": "^0.1.4"
 			}
 		},
 		"universalify": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"unquote": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -10629,44 +14115,10 @@
 				}
 			}
 		},
-		"unzip-response": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-		},
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
 			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
-		},
-		"update-notifier": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-			"requires": {
-				"boxen": "^1.2.1",
-				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
-			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -10680,11 +14132,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"urijs": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-			"integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -10708,39 +14155,28 @@
 			}
 		},
 		"url-loader": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-			"integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.1.tgz",
+			"integrity": "sha512-vugEeXjyYFBCUOpX+ZuaunbK3QXMKaQ3zUnRfIpRBlGkY7QizCnzyyn2ASfcxsvyU3ef+CJppVywnl3Kgf13Gg==",
 			"requires": {
-				"loader-utils": "^1.0.2",
-				"mime": "^1.4.1",
-				"schema-utils": "^0.3.0"
+				"loader-utils": "^1.1.0",
+				"mime": "^2.0.3",
+				"schema-utils": "^1.0.0"
 			}
 		},
 		"url-parse": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-			"integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+			"integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
 			"requires": {
 				"querystringify": "^2.0.0",
 				"requires-port": "^1.0.0"
 			}
 		},
-		"url-parse-lax": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"requires": {
-				"prepend-http": "^1.0.1"
-			}
-		},
 		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"requires": {
-				"kind-of": "^6.0.2"
-			}
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
 			"version": "0.10.4",
@@ -10755,6 +14191,15 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
 		"utila": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
@@ -10766,14 +14211,14 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -10801,10 +14246,28 @@
 		},
 		"vm-browserify": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
 			"requires": {
 				"indexof": "0.0.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.0.1.tgz",
+			"integrity": "sha512-XZGI1OH/OLQr/NaJhhPmzhngwcAnZDLytsvXnRmlYeRkmbb0I7sqFFA22erq4WQR0sUu17ZSQOAV9mFwCqKRNg==",
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -10816,9 +14279,20 @@
 			}
 		},
 		"watch": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"requires": {
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
 		},
 		"watchpack": {
 			"version": "1.6.0",
@@ -10872,401 +14346,540 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.19.1.tgz",
+			"integrity": "sha512-j7Q/5QqZRqIFXJvC0E59ipLV5Hf6lAnS3ezC3I4HMUybwEDikQBVad5d+IpPtmaQPQArvgUZLXIN6lWijHBn4g==",
 			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^5.1.5",
-				"ajv-keywords": "^2.0.0",
-				"async": "^2.1.2",
-				"enhanced-resolve": "^3.4.0",
-				"escope": "^3.6.0",
-				"interpret": "^1.0.0",
-				"json-loader": "^0.5.4",
-				"json5": "^0.5.1",
+				"@webassemblyjs/ast": "1.7.6",
+				"@webassemblyjs/helper-module-context": "1.7.6",
+				"@webassemblyjs/wasm-edit": "1.7.6",
+				"@webassemblyjs/wasm-parser": "1.7.6",
+				"acorn": "^5.6.2",
+				"acorn-dynamic-import": "^3.0.0",
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chrome-trace-event": "^1.0.0",
+				"enhanced-resolve": "^4.1.0",
+				"eslint-scope": "^4.0.0",
+				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^2.3.0",
 				"loader-utils": "^1.1.0",
 				"memory-fs": "~0.4.1",
+				"micromatch": "^3.1.8",
 				"mkdirp": "~0.5.0",
+				"neo-async": "^2.5.0",
 				"node-libs-browser": "^2.0.0",
-				"source-map": "^0.5.3",
-				"supports-color": "^4.2.1",
-				"tapable": "^0.2.7",
-				"uglifyjs-webpack-plugin": "^0.4.6",
-				"watchpack": "^1.4.0",
-				"webpack-sources": "^1.0.1",
-				"yargs": "^8.0.2"
+				"schema-utils": "^0.4.4",
+				"tapable": "^1.1.0",
+				"uglifyjs-webpack-plugin": "^1.2.4",
+				"watchpack": "^1.5.0",
+				"webpack-sources": "^1.2.0"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
 				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"schema-utils": {
+					"version": "0.4.7",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
+			}
+		},
+		"webpack-dev-middleware": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
+			"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+			"requires": {
+				"memory-fs": "~0.4.1",
+				"mime": "^2.3.1",
+				"range-parser": "^1.0.3",
+				"webpack-log": "^2.0.0"
+			}
+		},
+		"webpack-dev-server": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.9.tgz",
+			"integrity": "sha512-fqPkuNalLuc/hRC2QMkVYJkgNmRvxZQo7ykA2e1XRg/tMJm3qY7ZaD6d89/Fqjxtj9bOrn5wZzLD2n84lJdvWg==",
+			"requires": {
+				"ansi-html": "0.0.7",
+				"bonjour": "^3.5.0",
+				"chokidar": "^2.0.0",
+				"compression": "^1.5.2",
+				"connect-history-api-fallback": "^1.3.0",
+				"debug": "^3.1.0",
+				"del": "^3.0.0",
+				"express": "^4.16.2",
+				"html-entities": "^1.2.0",
+				"http-proxy-middleware": "~0.18.0",
+				"import-local": "^2.0.0",
+				"internal-ip": "^3.0.1",
+				"ip": "^1.1.5",
+				"killable": "^1.0.0",
+				"loglevel": "^1.4.1",
+				"opn": "^5.1.0",
+				"portfinder": "^1.0.9",
+				"schema-utils": "^1.0.0",
+				"selfsigned": "^1.9.1",
+				"serve-index": "^1.7.2",
+				"sockjs": "0.3.19",
+				"sockjs-client": "1.1.5",
+				"spdy": "^3.4.1",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^5.1.0",
+				"webpack-dev-middleware": "3.4.0",
+				"webpack-log": "^2.0.0",
+				"yargs": "12.0.2"
+			},
+			"dependencies": {
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"decamelize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
+						"xregexp": "4.0.0"
 					}
 				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+				"execa": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"locate-path": "^3.0.0"
+					}
+				},
+				"import-local": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+					"requires": {
+						"pkg-dir": "^3.0.0",
+						"resolve-cwd": "^2.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+					"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^1.0.0",
+						"p-is-promise": "^1.1.0"
 					}
 				},
 				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+					"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "^0.10.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
 					}
 				},
-				"path-type": {
+				"p-limit": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 					"requires": {
-						"pify": "^2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"strip-bom": {
+				"p-locate": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"requires": {
-						"has-flag": "^2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
-				"which-module": {
+				"p-try": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"requires": {
+						"find-up": "^3.0.0"
+					}
 				},
 				"yargs": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"version": "12.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+					"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
 					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
+						"cliui": "^4.0.0",
+						"decamelize": "^2.0.0",
+						"find-up": "^3.0.0",
 						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
+						"os-locale": "^3.0.0",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^1.0.1",
 						"set-blocking": "^2.0.0",
 						"string-width": "^2.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^10.1.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
-		"webpack-dev-middleware": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+		"webpack-log": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
 			"requires": {
-				"memory-fs": "~0.4.1",
-				"mime": "^1.5.0",
-				"path-is-absolute": "^1.0.0",
-				"range-parser": "^1.0.3",
-				"time-stamp": "^2.0.0"
-			}
-		},
-		"webpack-dev-server": {
-			"version": "2.9.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz",
-			"integrity": "sha512-thrqC0EQEoSjXeYgP6pUXcUCZ+LNrKsDPn+mItLnn5VyyNZOJKd06hUP5vqkYwL8nWWXsii0loSF9NHNccT6ow==",
-			"requires": {
-				"ansi-html": "0.0.7",
-				"array-includes": "^3.0.3",
-				"bonjour": "^3.5.0",
-				"chokidar": "^1.6.0",
-				"compression": "^1.5.2",
-				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
-				"del": "^3.0.0",
-				"express": "^4.13.3",
-				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.17.4",
-				"import-local": "^0.1.1",
-				"internal-ip": "1.2.0",
-				"ip": "^1.1.5",
-				"killable": "^1.0.0",
-				"loglevel": "^1.4.1",
-				"opn": "^5.1.0",
-				"portfinder": "^1.0.9",
-				"selfsigned": "^1.9.1",
-				"serve-index": "^1.7.2",
-				"sockjs": "0.3.18",
-				"sockjs-client": "1.1.4",
-				"spdy": "^3.4.1",
-				"strip-ansi": "^3.0.1",
-				"supports-color": "^4.2.1",
-				"webpack-dev-middleware": "^1.11.0",
-				"yargs": "^6.6.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"chokidar": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-					"requires": {
-						"anymatch": "^1.3.0",
-						"async-each": "^1.0.0",
-						"fsevents": "^1.0.0",
-						"glob-parent": "^2.0.0",
-						"inherits": "^2.0.1",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^2.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0"
-					}
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"del": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"requires": {
-						"globby": "^6.1.0",
-						"is-path-cwd": "^1.0.0",
-						"is-path-in-cwd": "^1.0.0",
-						"p-map": "^1.1.1",
-						"pify": "^3.0.0",
-						"rimraf": "^2.2.8"
-					}
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"requires": {
-						"has-flag": "^2.0.0"
-					}
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
+				"ansi-colors": "^3.0.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"webpack-manifest-plugin": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.3.2.tgz",
-			"integrity": "sha512-MX60Bv2G83Zks9pi3oLOmRgnPAnwrlMn+lftMrWBm199VQjk46/xgzBi9lPfpZldw2+EI2S+OevuLIaDuxCWRw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
+			"integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
 			"requires": {
-				"fs-extra": "^0.30.0",
-				"lodash": ">=3.5 <5"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0",
-						"klaw": "^1.0.0",
-						"path-is-absolute": "^1.0.0",
-						"rimraf": "^2.2.8"
-					}
-				},
-				"jsonfile": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				}
+				"fs-extra": "^7.0.0",
+				"lodash": ">=3.5 <5",
+				"tapable": "^1.0.0"
 			}
 		},
 		"webpack-sources": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"websocket-driver": {
@@ -11284,17 +14897,20 @@
 			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
 		},
 		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "0.4.24"
 			},
 			"dependencies": {
 				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
 				}
 			}
 		},
@@ -11303,26 +14919,20 @@
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
 			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
-		"whatwg-url": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			},
-			"dependencies": {
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-				}
-			}
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
-		"whet.extend": {
-			"version": "0.9.9",
-			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+		"whatwg-url": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"which": {
 			"version": "1.3.1",
@@ -11333,27 +14943,166 @@
 			}
 		},
 		"which-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-		},
-		"widest-line": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-			"requires": {
-				"string-width": "^2.1.1"
-			}
-		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"workbox-background-sync": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
+			"integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-broadcast-cache-update": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
+			"integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-build": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
+			"integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"common-tags": "^1.4.0",
+				"fs-extra": "^4.0.2",
+				"glob": "^7.1.2",
+				"joi": "^11.1.1",
+				"lodash.template": "^4.4.0",
+				"pretty-bytes": "^4.0.2",
+				"stringify-object": "^3.2.2",
+				"strip-comments": "^1.0.2",
+				"workbox-background-sync": "^3.6.3",
+				"workbox-broadcast-cache-update": "^3.6.3",
+				"workbox-cache-expiration": "^3.6.3",
+				"workbox-cacheable-response": "^3.6.3",
+				"workbox-core": "^3.6.3",
+				"workbox-google-analytics": "^3.6.3",
+				"workbox-navigation-preload": "^3.6.3",
+				"workbox-precaching": "^3.6.3",
+				"workbox-range-requests": "^3.6.3",
+				"workbox-routing": "^3.6.3",
+				"workbox-strategies": "^3.6.3",
+				"workbox-streams": "^3.6.3",
+				"workbox-sw": "^3.6.3"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				}
+			}
+		},
+		"workbox-cache-expiration": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
+			"integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-cacheable-response": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
+			"integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-core": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz",
+			"integrity": "sha512-cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ=="
+		},
+		"workbox-google-analytics": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
+			"integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
+			"requires": {
+				"workbox-background-sync": "^3.6.3",
+				"workbox-core": "^3.6.3",
+				"workbox-routing": "^3.6.3",
+				"workbox-strategies": "^3.6.3"
+			}
+		},
+		"workbox-navigation-preload": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
+			"integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-precaching": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
+			"integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-range-requests": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
+			"integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-routing": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
+			"integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-strategies": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
+			"integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-streams": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
+			"integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
+			"requires": {
+				"workbox-core": "^3.6.3"
+			}
+		},
+		"workbox-sw": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz",
+			"integrity": "sha512-IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg=="
+		},
+		"workbox-webpack-plugin": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-3.6.3.tgz",
+			"integrity": "sha512-RwmKjc7HFHUFHoOlKoZUq9349u0QN3F8W5tZZU0vc1qsBZDINWXRiIBCAKvo/Njgay5sWz7z4I2adnyTo97qIQ==",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"json-stable-stringify": "^1.0.1",
+				"workbox-build": "^3.6.3"
+			}
 		},
 		"worker-farm": {
 			"version": "1.6.0",
@@ -11365,7 +15114,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -11382,7 +15131,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -11415,15 +15164,28 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"xdg-basedir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		"ws": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+			"integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+			"requires": {
+				"async-limiter": "~1.0.0"
+			}
 		},
 		"xml-name-validator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		},
+		"xmlchars": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
+			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
+		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -11441,72 +15203,36 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"version": "11.1.0",
+			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"requires": {
-				"camelcase": "^3.0.0",
-				"cliui": "^3.2.0",
+				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^1.4.0",
-				"read-pkg-up": "^1.0.1",
+				"os-locale": "^2.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
-				"string-width": "^1.0.2",
-				"which-module": "^1.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^5.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"requires": {
-				"camelcase": "^3.0.0"
+				"camelcase": "^4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -2,6 +2,12 @@
   "name": "playground",
   "version": "0.0.0-0",
   "private": true,
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
   "dependencies": {
     "adaptivecards": "^1.0.0",
     "botframework-directlinejs": "^0.10.0",
@@ -21,7 +27,7 @@
     "react-dom": "^16.4.1",
     "react-redux": "^5.0.7",
     "react-say": "1.0.1-master.1d32161",
-    "react-scripts": "1.1.4",
+    "react-scripts": "2.1.1",
     "redux": "^4.0.0",
     "rxjs": "5",
     "web-speech-cognitive-services": "2.1.1-master.0f7758b"


### PR DESCRIPTION
This is only hitting `playground`, but not the production bundle.

This will fix vulnerability of:
- `merge` >= `1.2.1`
- `url-parse` >= `1.4.3`