### PR TITLE
Bump to adaptivecards@1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix string interpolation error in Russian localization and fallback for browsers without Intl support by [@odysseus1973](https://github.com/odysseus1973) in PR [#1509](https://github.com/Microsoft/BotFramework-WebChat/pull/1509)
 - `playground`: Bumps to [`botframework-directlinejs@0.10.0`](https://github.com/Microsoft/BotFramework-DirectLineJS/), in PR [#1511](https://github.com/Microsoft/BotFramework-WebChat/pull/1511)
 - `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
+- `component`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix string interpolation error in Russian localization and fallback for browsers without Intl support by [@odysseus1973](https://github.com/odysseus1973) in PR [#1509](https://github.com/Microsoft/BotFramework-WebChat/pull/1509)
 - `playground`: Bumps to [`botframework-directlinejs@0.10.0`](https://github.com/Microsoft/BotFramework-DirectLineJS/), in PR [#1511](https://github.com/Microsoft/BotFramework-WebChat/pull/1511)
 - `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
-- `component`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- `*`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#1558](https://github.com/Microsoft/BotFramework-WebChat/pull/1558)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3773,12 +3773,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3793,17 +3795,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3920,7 +3925,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3932,6 +3938,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3946,6 +3953,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3953,12 +3961,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3977,6 +3987,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4057,7 +4068,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4069,6 +4081,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4190,6 +4203,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3603,7 +3603,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4018,7 +4019,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4074,6 +4076,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4117,12 +4120,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1172,9 +1172,9 @@
 			}
 		},
 		"adaptivecards": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.0.0.tgz",
-			"integrity": "sha1-96HxdpJRYmirQMpU8Z/aP6WJdjQ="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.1.2.tgz",
+			"integrity": "sha512-fpFLxQzgPfIvi+SV0MH5Cl+wdXVDvMF98fBY/DQJLF47hVEbyMWtxpTFJUR6bSo1FjXyJxrqoT+qLlm1xVpTYw=="
 		},
 		"ajv": {
 			"version": "6.5.3",
@@ -1187,6 +1187,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ajv-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "3.2.0",
@@ -2926,6 +2932,143 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"css-loader": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.0.tgz",
+			"integrity": "sha512-MoOu+CStsGrSt5K2OeZ89q3Snf+IkxRfAIt9aAKg4piioTrhtP1iEFPu+OVn3Ohz24FO6L+rw9UJxBILiSBw5Q==",
+			"dev": true,
+			"requires": {
+				"icss-utils": "^4.0.0",
+				"loader-utils": "^1.2.1",
+				"lodash": "^4.17.11",
+				"postcss": "^7.0.6",
+				"postcss-modules-extract-imports": "^2.0.0",
+				"postcss-modules-local-by-default": "^2.0.3",
+				"postcss-modules-scope": "^2.0.0",
+				"postcss-modules-values": "^2.0.0",
+				"postcss-value-parser": "^3.3.0",
+				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"big.js": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^2.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"css-selector-tokenizer": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+			"dev": true,
+			"requires": {
+				"cssesc": "^0.1.0",
+				"fastparse": "^1.1.1",
+				"regexpu-core": "^1.0.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.2.1",
+						"regjsgen": "^0.2.0",
+						"regjsparser": "^0.1.4"
+					}
+				},
+				"regjsgen": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				}
+			}
+		},
+		"cssesc": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+			"dev": true
+		},
 		"csstype": {
 			"version": "2.5.6",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.6.tgz",
@@ -3464,6 +3607,12 @@
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 			"dev": true
 		},
+		"fastparse": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+			"dev": true
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -3603,8 +3752,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3625,14 +3773,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3647,20 +3793,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3777,8 +3920,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3790,7 +3932,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3805,7 +3946,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3813,14 +3953,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3839,7 +3977,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3920,8 +4057,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3933,7 +4069,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4019,8 +4154,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4056,7 +4190,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4076,7 +4209,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4120,14 +4252,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4367,6 +4497,40 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"icss-replace-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
+		},
+		"icss-utils": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.0.0.tgz",
+			"integrity": "sha512-bA/xGiwWM17qjllIs9X/y0EjsB7e0AV08F3OL8UPsoNkNRibIuu8f1eKTnQ8QO1DteKKTxTUAn+IEWUToIwGOA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.5"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"ieee754": {
@@ -5587,6 +5751,128 @@
 				}
 			}
 		},
+		"postcss-modules-extract-imports": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+			"integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.5"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-modules-local-by-default": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.4.tgz",
+			"integrity": "sha512-WvuSaTKXUqYJbnT7R3YrsNrHv/C5vRfr5VglS4bFOk0MYT4CLBfc/xgExA+x2RftlYgiBDvWmVs191Xv8S8gZQ==",
+			"dev": true,
+			"requires": {
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^7.0.6",
+				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-modules-scope": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.0.1.tgz",
+			"integrity": "sha512-7+6k9c3/AuZ5c596LJx9n923A/j3nF3ormewYBF1RrIQvjvjXe1xE8V8A1KFyFwXbvnshT6FBZFX0k/F1igneg==",
+			"dev": true,
+			"requires": {
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^7.0.6"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-modules-values": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+			"integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
+			"dev": true,
+			"requires": {
+				"icss-replace-symbols": "^1.1.0",
+				"postcss": "^7.0.6"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+					"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-value-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+			"dev": true
+		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -6487,6 +6773,29 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
+		},
+		"style-loader": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+			"integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
+			}
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3752,7 +3752,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4167,7 +4168,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4223,6 +4225,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4266,12 +4269,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "adaptivecards": "^1.0.0",
+    "adaptivecards": "1.1.2",
     "botframework-directlinejs": "^0.10.1",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",
@@ -63,6 +63,8 @@
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
     "concurrently": "^4.0.1",
+    "css-loader": "^2.1.0",
+    "style-loader": "^0.23.1",
     "typescript": "^3.1.6",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "adaptivecards": "1.1.2",
+    "adaptivecards": "~1.1.2",
     "botframework-directlinejs": "^0.10.1",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",

--- a/packages/bundle/webpack.config.js
+++ b/packages/bundle/webpack.config.js
@@ -8,6 +8,16 @@ module.exports = {
     'webchat-minimal': './lib/index-minimal.js'
   },
   mode: 'production',
+  module: {
+    rules: [{
+      // TODO: [P2] We prefer bundler-independent, that means, we could easily move around Webpack or Rollup.js for better bundling.
+      //       And non-JS resources should not be loaded in bundler because this will assume our project to always run in a browser.
+      //       But Adaptive Cards 1.1.2 load CSS using import/require, so we are whitelisting it here, until they get it fixed.
+      //       Track at https://github.com/Microsoft/AdaptiveCards/issues/2279.
+      test: /adaptivecards-default\.css$/,
+      use: ['style-loader', 'css-loader']
+    }]
+  },
   output: {
     filename: '[name].js',
     libraryTarget: 'umd',

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -3726,12 +3726,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3746,17 +3748,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3873,7 +3878,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3885,6 +3891,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3899,6 +3906,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3906,12 +3914,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3930,6 +3940,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4010,7 +4021,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4022,6 +4034,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4143,6 +4156,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -3705,7 +3705,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4120,7 +4121,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4176,6 +4178,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4219,12 +4222,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -1037,9 +1037,9 @@
       "dev": true
     },
     "adaptivecards": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.0.0.tgz",
-      "integrity": "sha1-96HxdpJRYmirQMpU8Z/aP6WJdjQ="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.1.2.tgz",
+      "integrity": "sha512-fpFLxQzgPfIvi+SV0MH5Cl+wdXVDvMF98fBY/DQJLF47hVEbyMWtxpTFJUR6bSo1FjXyJxrqoT+qLlm1xVpTYw=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -3705,8 +3705,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3727,14 +3726,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3749,20 +3746,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3879,8 +3873,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3892,7 +3885,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3907,7 +3899,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3915,14 +3906,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3941,7 +3930,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4022,8 +4010,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4035,7 +4022,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4121,8 +4107,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4158,7 +4143,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4178,7 +4162,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4222,14 +4205,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -61,7 +61,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "adaptivecards": "1.1.2",
+    "adaptivecards": "~1.1.2",
     "botframework-webchat-core": "^0.0.0-0",
     "bytes": "^3.0.0",
     "classnames": "^2.2.6",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -61,7 +61,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "adaptivecards": "^1.0.0",
+    "adaptivecards": "1.1.2",
     "botframework-webchat-core": "^0.0.0-0",
     "bytes": "^3.0.0",
     "classnames": "^2.2.6",

--- a/packages/component/src/Attachment/AdaptiveCardRenderer.js
+++ b/packages/component/src/Attachment/AdaptiveCardRenderer.js
@@ -90,8 +90,10 @@ class AdaptiveCardRenderer extends React.PureComponent {
       //       Because there could be timing difference between .parse and .render, we could be using wrong Markdown engine
 
       adaptiveCard.constructor.onProcessMarkdown = (text, result) => {
-        result.outputHtml = renderMarkdown(text);
-        result.didProcess = true;
+        if (renderMarkdown) {
+          result.outputHtml = renderMarkdown(text);
+          result.didProcess = true;
+        }
       };
 
       adaptiveCard.hostConfig = adaptiveCardHostConfig;

--- a/packages/component/src/Attachment/AdaptiveCardRenderer.js
+++ b/packages/component/src/Attachment/AdaptiveCardRenderer.js
@@ -89,7 +89,11 @@ class AdaptiveCardRenderer extends React.PureComponent {
       //       This could be limitations from Adaptive Cards package
       //       Because there could be timing difference between .parse and .render, we could be using wrong Markdown engine
 
-      adaptiveCard.constructor.processMarkdown = renderMarkdown || (text => text);
+      adaptiveCard.constructor.onProcessMarkdown = (text, result) =>
+        result.outputHtml = renderMarkdown(text);
+        result.didProcess = true;
+      };
+
       adaptiveCard.hostConfig = adaptiveCardHostConfig;
       adaptiveCard.onExecuteAction = this.handleExecuteAction;
 

--- a/packages/component/src/Attachment/AdaptiveCardRenderer.js
+++ b/packages/component/src/Attachment/AdaptiveCardRenderer.js
@@ -89,7 +89,7 @@ class AdaptiveCardRenderer extends React.PureComponent {
       //       This could be limitations from Adaptive Cards package
       //       Because there could be timing difference between .parse and .render, we could be using wrong Markdown engine
 
-      adaptiveCard.constructor.onProcessMarkdown = (text, result) =>
+      adaptiveCard.constructor.onProcessMarkdown = (text, result) => {
         result.outputHtml = renderMarkdown(text);
         result.didProcess = true;
       };

--- a/packages/component/src/Utils/AdaptiveCardBuilder.ts
+++ b/packages/component/src/Utils/AdaptiveCardBuilder.ts
@@ -7,7 +7,7 @@ import {
   Image,
   OpenUrlAction,
   Size,
-  SizeUnit,
+  SizeAndUnit,
   SubmitAction,
   TextBlock,
   TextSize,
@@ -67,10 +67,7 @@ export class AdaptiveCardBuilder {
     return sizes.map(size => {
       const column = new Column();
 
-      column.width = {
-        physicalSize: size,
-        unit: SizeUnit.Pixel
-      };
+      column.width = SizeAndUnit.parse(size);
 
       columnSet.addColumn(column);
 

--- a/packages/component/src/Utils/AdaptiveCardBuilder.ts
+++ b/packages/component/src/Utils/AdaptiveCardBuilder.ts
@@ -7,6 +7,7 @@ import {
   Image,
   OpenUrlAction,
   Size,
+  SizeUnit,
   SubmitAction,
   TextBlock,
   TextSize,
@@ -66,7 +67,11 @@ export class AdaptiveCardBuilder {
     return sizes.map(size => {
       const column = new Column();
 
-      column.width = size;
+      column.width = {
+        physicalSize: size,
+        unit: SizeUnit.Pixel
+      };
+
       columnSet.addColumn(column);
 
       return column;

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -5539,7 +5539,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5904,7 +5905,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5952,6 +5954,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5990,11 +5993,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -5557,11 +5557,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5574,15 +5576,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5685,7 +5690,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5695,6 +5701,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5707,17 +5714,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5734,6 +5744,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5806,7 +5817,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5816,6 +5828,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5921,6 +5934,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -1135,9 +1135,9 @@
 			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
 		},
 		"adaptivecards": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.0.0.tgz",
-			"integrity": "sha1-96HxdpJRYmirQMpU8Z/aP6WJdjQ="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.1.2.tgz",
+			"integrity": "sha512-fpFLxQzgPfIvi+SV0MH5Cl+wdXVDvMF98fBY/DQJLF47hVEbyMWtxpTFJUR6bSo1FjXyJxrqoT+qLlm1xVpTYw=="
 		},
 		"address": {
 			"version": "1.0.3",
@@ -5539,8 +5539,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5558,13 +5557,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5577,18 +5574,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5691,8 +5685,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5702,7 +5695,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5715,20 +5707,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5745,7 +5734,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5818,8 +5806,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5829,7 +5816,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5905,8 +5891,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5936,7 +5921,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5954,7 +5938,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5993,13 +5976,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "adaptivecards": "^1.0.0",
+    "adaptivecards": "1.1.2",
     "botframework-directlinejs": "^0.10.1",
     "botframework-webchat": "^0.0.0-0",
     "botframework-webchat-component": "^0.0.0-0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "adaptivecards": "1.1.2",
+    "adaptivecards": "~1.1.2",
     "botframework-directlinejs": "^0.10.1",
     "botframework-webchat": "^0.0.0-0",
     "botframework-webchat-component": "^0.0.0-0",


### PR DESCRIPTION
## Background

Due to a security vulnerability issue found recently, we are bumping to `adaptivecards@1.1.2`.

Web Chat has 2 bundles: minimal and full. Minimal bundle does not include Adaptive Cards. And the full bundle have Adaptive Cards pre-configured with Markdown-It engine.

The security vulnerability only affect users who is using Adaptive Cards **without** any Markdown engine. By default, Web Chat ship and pre-configured with Adaptive Cards and Markdown-It, thus, the security vulnerability does not affect our default configurations. Only advanced users who manually configure Adaptive Cards explicitly without Markdown is affected.

## Changelog

### Changed
- `*`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#1558](https://github.com/Microsoft/BotFramework-WebChat/pull/1558)

## Design considerations

### Inclusion of `css-loader` and `style-loader`

Adaptive Cards 1.1.2 requires `css-loader`. The [code here](https://github.com/Microsoft/AdaptiveCards/blob/master/source/nodejs/adaptivecards/src/adaptivecards.ts#L6) read `import "./adaptivecards-default.css";`. Thus, in order to pack Adaptive Cards inside Web Chat, we have to add `css-loader` and `style-loader` in our pipeline.

Web Chat prefer bundler-independent:

- We reserve the flexibility to switch between [Webpack](https://webpack.js.org/), [rollup.js](https://rollupjs.org/) and other bundlers we see fit
- We prefer not to bundle any non-JavaScript assets in the bundle
   - Non-JavaScript assets usually assume the bundled code is running inside a browser (with a `window` object and corresponding functions to load different assets into memory)
   - Web Chat prefer to be platform-independent and reserve the flexibility to run on headless device

But since Adaptive Cards 1.1.2 requires `css-loader` and `style-loader`, we have to give up our bundler-independent flexibility. We have filed [bug #2279](https://github.com/Microsoft/AdaptiveCards/issues/2279) to Adaptive Cards team and see if they could remove the CSS or pre-compile it into JavaScript code before publishing their project to NPM to preserve their purity.