### PR TITLE
Fix render card without tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - by [@corinagum](https://github.com/corinagum) in PR [#1528](https://github.com/Microsoft/BotFramework-WebChat/pull/1528)
 - `component`: Fix [#1560](https://github.com/Microsoft/BotFramework-WebChat/issues/1560). Fixed carousel layout did not show date and alignment issues, by [@compulim](https://github.com/compulim) in PR [#1561](https://github.com/Microsoft/BotFramework-WebChat/pull/1561)
 - `playground`: Fix [#1562](https://github.com/Microsoft/BotFramework-WebChat/issues/1562). Fixed timestamp grouping "Don't group" and added "Don't show timestamp", by [@compulim](https://github.com/compulim) in PR [#1563](https://github.com/Microsoft/BotFramework-WebChat/pull/1563)
+- `component`: Fix [#1576](https://github.com/Microsoft/BotFramework-WebChat/issues/1576). Rich card without `tap` should be rendered properly, by [@compulim](https://github.com/compulim) in PR [#1577](https://github.com/Microsoft/BotFramework-WebChat/pull/1577)
 
 ### Removed
 - `botAvatarImage` and `userAvatarImage` props, as they are moved inside `styleOptions`, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)

--- a/packages/component/src/Attachment/CommonCard.js
+++ b/packages/component/src/Attachment/CommonCard.js
@@ -28,7 +28,7 @@ export default class extends React.Component {
     return (
       <AdaptiveCardRenderer
         adaptiveCard={ content && this.buildCard(adaptiveCards, content) }
-        tapAction={ content.tap }
+        tapAction={ content && content.tap }
       />
     );
   }

--- a/packages/component/src/Attachment/HeroCardAttachment.js
+++ b/packages/component/src/Attachment/HeroCardAttachment.js
@@ -30,7 +30,7 @@ export default class extends React.Component {
     return (
       <AdaptiveCardRenderer
         adaptiveCard={ content && this.buildCard(adaptiveCards, content) }
-        tapAction={ content.tap }
+        tapAction={ content && content.tap }
       />
     );
   }

--- a/packages/component/src/Attachment/ReceiptCardAttachment.js
+++ b/packages/component/src/Attachment/ReceiptCardAttachment.js
@@ -83,7 +83,7 @@ class ReceiptCardAttachment extends React.Component {
     return (
       <AdaptiveCardRenderer
         adaptiveCard={ content && this.buildCard(adaptiveCards, content, language) }
-        tapAction={ content.tap }
+        tapAction={ content && content.tap }
       />
     );
   }

--- a/packages/component/src/Attachment/ThumbnailCardAttachment.js
+++ b/packages/component/src/Attachment/ThumbnailCardAttachment.js
@@ -39,7 +39,7 @@ export default class extends React.Component {
     return (
       <AdaptiveCardRenderer
         adaptiveCard={ content && this.buildCard(adaptiveCards, content) }
-        tapAction={ content.tap }
+        tapAction={ content && content.tap }
       />
     );
   }


### PR DESCRIPTION
> Fix #1576 

When rendering [this Chatdown file](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Chatdown/Examples/cards/herocard.json), it render a hero card without `tap` action and errored out.