### PR TITLE
Send test image snapshots to Azure Blob for further study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 # Do not commit binaries
 /chromedriver*
 chromedriver.exe
+
+/image-snapshots.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ script:
 - docker-compose down --rmi all
 - npm run coveralls
 
+# Upload image snapshots to build artifact curator
+- zip image-snapshots __tests__/__image_snapshots__/**/*
+- curl -T image-snapshots.zip https://webchat-curator.azurewebsites.net/upload
+
 before_deploy:
 - git config --local user.name "Bot Framework"
 - git config --local user.email "botframework@microsoft.com"


### PR DESCRIPTION
## Background

Sometimes, Travis CI fail because of difference in visual regression test.

This script will ship image snapshot results to our server.

After the build, the additional scripts will ZIP the image snapshots and send it to blob storage for further investigation. Like the one below,

![image](https://user-images.githubusercontent.com/1622400/51214496-f5599b80-18d2-11e9-9db6-3b0b19038039.png)
