### PR TITLE
Use random user ID if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `playground`: Bumps to [`botframework-directlinejs@0.10.0`](https://github.com/Microsoft/BotFramework-DirectLineJS/), in PR [#1511](https://github.com/Microsoft/BotFramework-WebChat/pull/1511)
 - `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
 - `*`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#1558](https://github.com/Microsoft/BotFramework-WebChat/pull/1558)
+- `core`: Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344). Use random user ID if not specified, by [@compulim](https://github.com/compulim) in PR [#1612](https://github.com/Microsoft/BotFramework-WebChat/pull/1612)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -6564,10 +6564,9 @@
 			}
 		},
 		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
 		},
 		"mem": {
 			"version": "1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "jsonwebtoken": "^8.3.0",
+    "math-random": "^1.0.4",
     "mime": "^2.3.1",
     "redux": "^4.0.0",
     "redux-promise-middleware": "^5.1.1",

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -8,6 +8,7 @@ import {
 } from 'redux-saga/effects';
 
 import { decode } from 'jsonwebtoken';
+import random from 'math-random';
 
 import callUntil from './effects/callUntil';
 import forever from './effects/forever';
@@ -36,7 +37,9 @@ const ONLINE = 2;
 // const FAILED_TO_CONNECT = 4;
 const ENDED = 5;
 
-const DEFAULT_USER_ID = 'default-user';
+function randomUserID() {
+  return `r_${ random().toString(36).substr(2, 10) }`;
+}
 
 export default function* () {
   for (;;) {
@@ -53,14 +56,14 @@ export default function* () {
     } else if (userID) {
       if (typeof userID !== 'string') {
         console.warn('Web Chat: user ID must be a string.');
-        userID = DEFAULT_USER_ID;
+        userID = randomUserID();
       } else if (/^dl_/.test(userID)) {
         console.warn('Web Chat: user ID prefixed with "dl_" is reserved and must be embedded into the Direct Line token to prevent forgery.');
-        userID = DEFAULT_USER_ID;
+        userID = randomUserID();
       }
     } else {
       // Only specify "default-user" if not found from token and not passed in
-      userID = DEFAULT_USER_ID;
+      userID = randomUserID();
     }
 
     const connectTask = yield fork(connectSaga, directLine, userID);


### PR DESCRIPTION
> Fix #1344.

## Background

Instead of using `default-user`, use a random user ID if not specified. Will try to use RNG if the environment support.

## Changelog

- `core`: Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344). Use random user ID if not specified, by [@compulim](https://github.com/compulim) in PR [#1612](https://github.com/Microsoft/BotFramework-WebChat/pull/1612)
