### PR TITLE
Pass `conversationId` to DirectLineJS constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1539], outgoing typing indicators are not sent and acknowledged properly, in PR [#1541](https://github.com/Microsoft/BotFramework-WebChat/pull/1541)
 - `component`: Fix [#1547](https://github.com/Microsoft/BotFramework-WebChat/issues/1547). Fixed unhandled activity type should be forwarded to custom middleware, by [@compulim](https://github.com/compulim) in PR [#1569](https://github.com/Microsoft/BotFramework-WebChat/pull/1569)
 - `playground`: Fix [#1610](https://github.com/Microsoft/BotFramework-WebChat/issues/1610). Fixed bot and user avatar initials not working, by [@compulim](https://github.com/compulim) in PR [#1611](https://github.com/Microsoft/BotFramework-WebChat/pull/1611)
+- `bundle`: Fix [#1613](https://github.com/Microsoft/BotFramework-WebChat/issues/1613). Pass conversationId to DirectLineJS constructor, by [@neetu-das](https://github.com/neetu-das) in PR [#1614](https://github.com/Microsoft/BotFramework-WebChat/pull/1614)
 
 ### Removed
 - `botAvatarImage` and `userAvatarImage` props, as they are moved inside `styleOptions`, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)

--- a/packages/bundle/src/createDirectLine.js
+++ b/packages/bundle/src/createDirectLine.js
@@ -1,13 +1,13 @@
 import { DirectLine } from 'botframework-directlinejs';
 
-export default function ({ domain, fetch, secret, token, webSocket, conversationId }) {
+export default function ({conversationId, domain, fetch, secret, token, webSocket}) {
   return new DirectLine({
+    conversationId,
     domain,
     fetch,
     secret,
     token,
     webSocket,
-    conversationId,
     createFormData: attachments => {
       const formData = new FormData();
 

--- a/packages/bundle/src/createDirectLine.js
+++ b/packages/bundle/src/createDirectLine.js
@@ -1,12 +1,13 @@
 import { DirectLine } from 'botframework-directlinejs';
 
-export default function ({ domain, fetch, secret, token, webSocket }) {
+export default function ({ domain, fetch, secret, token, webSocket, conversationId }) {
   return new DirectLine({
     domain,
     fetch,
     secret,
     token,
     webSocket,
+    conversationId,
     createFormData: attachments => {
       const formData = new FormData();
 


### PR DESCRIPTION
Added conversationId as an argument while instantiating DirectLine. Doing this will resume the conversation history related to a particular conversationId