### PR TITLE
Bump react-film@1.1.2 and react-scroll-to-bottom@1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
 - `*`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#1558](https://github.com/Microsoft/BotFramework-WebChat/pull/1558)
 - `core`: Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344). Use random user ID if not specified, by [@compulim](https://github.com/compulim) in PR [#1612](https://github.com/Microsoft/BotFramework-WebChat/pull/1612)
-- `component`: Bump to [`react-film@1.1.2`](https://npmjs.com/package/react-film/) and [`react-scroll-to-bottom@1.3.0`](https://npmjs.com/package/react-scroll-to-bottom/), by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- `component`: Bump to [`react-film@1.1.2`](https://npmjs.com/package/react-film/) and [`react-scroll-to-bottom@1.3.0`](https://npmjs.com/package/react-scroll-to-bottom/), by [@compulim](https://github.com/compulim), in PR [#1621](https://github.com/Microsoft/BotFramework-WebChat/pull/1621)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `playground`: Bumps to [`react-scripts@2.1.1`](https://npmjs.com/package/react-scripts/), in PR [#1535](https://github.com/Microsoft/BotFramework-WebChat/pull/1535)
 - `*`: Bump to [`adaptivecards@1.1.2`](https://npmjs.com/package/adaptivecards/), in [#1558](https://github.com/Microsoft/BotFramework-WebChat/pull/1558)
 - `core`: Fix [#1344](https://github.com/Microsoft/BotFramework-WebChat/issues/1344). Use random user ID if not specified, by [@compulim](https://github.com/compulim) in PR [#1612](https://github.com/Microsoft/BotFramework-WebChat/pull/1612)
+- `component`: Bump to [`react-film@1.1.2`](https://npmjs.com/package/react-film/) and [`react-scroll-to-bottom@1.3.0`](https://npmjs.com/package/react-scroll-to-bottom/), by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 - Fix [#1360](https://github.com/Microsoft/BotFramework-WebChat/issues/1360). Added `roles` to components of Web Chat, by [@corinagum](https://github.com/corinagum) in PR [#1462](https://github.com/Microsoft/BotFramework-WebChat/pull/1462)

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -7027,9 +7027,9 @@
       }
     },
     "react-film": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/react-film/-/react-film-1.1.1.tgz",
-      "integrity": "sha512-el6Uw1yDeiu7cKyyuL0eupAKO6vmmTX8un+5btvyYlzD15J1JWLp+Q4rKR3JfcJ2ZM8LKPhAHMfCUGV8t9lVMQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/react-film/-/react-film-1.1.2.tgz",
+      "integrity": "sha512-E6wkN9Ar/uD1VquM93Gw9om4PlVVH3UsljI9H8zYMCh9sQJwRTh1kJPFC5pJl/XkYDAw7RHurHMLc7MHz8T82A==",
       "requires": {
         "classnames": "^2.2.6",
         "glamor": "^2.20.40"
@@ -7067,9 +7067,9 @@
       }
     },
     "react-scroll-to-bottom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-scroll-to-bottom/-/react-scroll-to-bottom-1.2.0.tgz",
-      "integrity": "sha512-/tAaVVnSpnMtv4PVIxmxOFh45g6PcUihIK6zH17WTPkqreRFRrbCBnC7ieVu2isV68Zjee98cmBMGgKapI9fCw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-scroll-to-bottom/-/react-scroll-to-bottom-1.3.0.tgz",
+      "integrity": "sha512-pTCdgk4DNsSIy7pKK3ieKJpp/OddCvymsKbm2kaLBAnBz9i6VqnJyZSunik0kT9/RLdOmvtPFjzoehDeS9LqGw==",
       "requires": {
         "classnames": "^2.2.6",
         "glamor": "^2.20.40",
@@ -7078,9 +7078,9 @@
       },
       "dependencies": {
         "memoize-one": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-          "integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
         },
         "simple-update-in": {
           "version": "1.4.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -68,10 +68,10 @@
     "glamor": "^2.20.40",
     "memoize-one": "^3.1.1",
     "react-dictate-button": "^1.1.3",
-    "react-film": "^1.1.1",
+    "react-film": "~1.1.2",
     "react-redux": "^5.0.7",
     "react-say": "^1.1.1",
-    "react-scroll-to-bottom": "^1.2.0",
+    "react-scroll-to-bottom": "~1.3.0",
     "redux": "^4.0.0",
     "sanitize-html": "^1.18.2",
     "simple-update-in": "^1.3.0"

--- a/packages/component/src/Activity/ScrollToEndButton.js
+++ b/packages/component/src/Activity/ScrollToEndButton.js
@@ -1,5 +1,4 @@
 import {
-  FunctionContext as ScrollToBottomFunctionContext,
   StateContext as ScrollToBottomStateContext
 } from 'react-scroll-to-bottom';
 
@@ -11,7 +10,7 @@ import Localize from '../Localization/Localize';
 
 const ScrollToEndButton = connectToWebChat(
   ({ scrollToEnd, styleSet }) => ({ scrollToEnd, styleSet })
-)(({ children, className, scrollToEnd, styleSet }) =>
+)(({ className, scrollToEnd, styleSet }) =>
   <button
     className={ classNames(
       styleSet.scrollToEndButton + '',
@@ -25,5 +24,5 @@ const ScrollToEndButton = connectToWebChat(
 
 export default props =>
   <ScrollToBottomStateContext.Consumer>
-    { ({ animating, atEnd }) => !animating && !atEnd && <ScrollToEndButton { ...props } /> }
+    { ({ sticky }) => !sticky && <ScrollToEndButton { ...props } /> }
   </ScrollToBottomStateContext.Consumer>

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -326,7 +326,7 @@ class Composer extends React.Component {
 const ConnectedComposer = connect(
   ({ referenceGrammarID }) => ({ referenceGrammarID })
 )(props =>
-  <ScrollToBottomComposer threshold={ 40 }>
+  <ScrollToBottomComposer>
     <ScrollToBottomFunctionContext.Consumer>
       { ({ scrollToEnd }) =>
         <Composer


### PR DESCRIPTION
This will fix React warnings for suggested actions and improve reliability of scroll to bottom feature.

## Changelog

### Changed
- `component`: Bump to [`react-film@1.1.2`](https://npmjs.com/package/react-film/) and [`react-scroll-to-bottom@1.3.0`](https://npmjs.com/package/react-scroll-to-bottom/), by [@compulim](https://github.com/compulim), in PR [#1621](https://github.com/Microsoft/BotFramework-WebChat/pull/1621)
