### PR TITLE
Use `WEB_CHAT/SEND_EVENT` for minimizable Web Chat sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `core`: [Send welcome event](https://microsoft.github.io/BotFramework-WebChat/15.b.backchannel-send-welcome-event/), in PR [#1286](https://github.com/Microsoft/BotFramework-WebChat/pull/1286)
 - `core`: [Send typing indicator](https://microsoft.github.io/BotFramework-WebChat/07.b.customization-send-typing-indicator), in [#1541](https://github.com/Microsoft/BotFramework-WebChat/pull/1541)
 - `component`: [Password input activity](https://microsoft.github.io/BotFramework-WebChat/10.b.customization-password-input/), in [#1569](https://github.com/Microsoft/BotFramework-WebChat/pull/1569)
+- `*`: Updated [minimizable Web Chat](https://microsoft.github.io/BotFramework-WebChat/12.customization-minimizable-web-chat/) sample to use `WEB_CHAT/SEND_EVENT` action, in [#1631](https://github.com/Microsoft/BotFramework-WebChat/pull/1631)
 
 ## [4.2.0] - 2018-12-11
 ### Added

--- a/samples/12.customization-minimizable-web-chat/src/MinimizableWebChat.js
+++ b/samples/12.customization-minimizable-web-chat/src/MinimizableWebChat.js
@@ -19,14 +19,11 @@ export default class extends React.Component {
       if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
         setTimeout(() => {
           dispatch({
-            type: 'DIRECT_LINE/POST_ACTIVITY',
+            type: 'WEB_CHAT/SEND_EVENT',
             payload: {
-              activity: {
-                name: 'webchat/join',
-                type: 'event',
-                value: {
-                  language: window.navigator.language
-                }
+              name: 'webchat/join',
+              value: {
+                language: window.navigator.language
               }
             }
           });


### PR DESCRIPTION
> Fix #1619.

Updated to use `WEB_CHAT/SEND_EVENT` for minimizable Web Chat sample, instead of using `DIRECT_LINE/POST_ACTIVITY`, which is a low-level action.

## Changelog
### Samples
- `*`: Updated [minimizable Web Chat](https://microsoft.github.io/BotFramework-WebChat/12.customization-minimizable-web-chat/) sample to use `WEB_CHAT/SEND_EVENT` action, in [#1631](https://github.com/Microsoft/BotFramework-WebChat/pull/1631)
