### PR TITLE
Use Speech Services token for speech UI sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `component`: [Password input activity](https://microsoft.github.io/BotFramework-WebChat/10.b.customization-password-input/), in [#1569](https://github.com/Microsoft/BotFramework-WebChat/pull/1569)
 - `*`: Updated [minimizable Web Chat](https://microsoft.github.io/BotFramework-WebChat/12.customization-minimizable-web-chat/) sample to use `WEB_CHAT/SEND_EVENT` action, in [#1631](https://github.com/Microsoft/BotFramework-WebChat/pull/1631)
 - `component`: [Hybrid speech engine](https://microsoft.github.io/BotFramework-WebChat/06.f.hybrid-speech/), in [#1617](https://github.com/Microsoft/BotFramework-WebChat/pull/1617)
+- `component`: Use Speech Services token for [speech UI sample](https://microsoft.github.io/BotFramework-WebChat/13.customization-speech-ui/), in [#1634](https://github.com/Microsoft/BotFramework-WebChat/pull/1634)
 
 ## [4.2.0] - 2018-12-11
 ### Added

--- a/samples/06.b.cognitive-services-bing-speech-react/index.html
+++ b/samples/06.b.cognitive-services-bing-speech-react/index.html
@@ -35,7 +35,7 @@
         const { render } = window.ReactDOM;
         const {
           Context,
-          createCognitiveServicesWebSpeechPonyfillFactory,
+          createCognitiveServicesBingSpeechPonyfillFactory,
           createDirectLine,
           ReactWebChat
         } = window.WebChat;
@@ -55,12 +55,12 @@
         if (subscriptionKey) {
           // In case you are using your own subscription key, please note that client should always authenticate against your server
           // to avoid exposing the subscription key to any part of your client code.
-          webSpeechPonyfillFactory = await window.WebChat.createCognitiveServicesBingSpeechPonyfillFactory({ subscriptionKey });
+          webSpeechPonyfillFactory = await createCognitiveServicesBingSpeechPonyfillFactory({ subscriptionKey });
         } else {
           const res = await fetch('https://webchat-mockbot.azurewebsites.net/bingspeech/token', { method: 'POST' });
           const { token: authorizationToken } = await res.json();
 
-          webSpeechPonyfillFactory = await window.WebChat.createCognitiveServicesBingSpeechPonyfillFactory({ authorizationToken });
+          webSpeechPonyfillFactory = await createCognitiveServicesBingSpeechPonyfillFactory({ authorizationToken });
         }
 
         // Pass a Web Speech ponyfill factory to renderWebChat.

--- a/samples/13.customization-speech-ui/src/App.js
+++ b/samples/13.customization-speech-ui/src/App.js
@@ -1,10 +1,10 @@
 import './App.css';
-import { Components, createDirectLine, createCognitiveServicesWebSpeechPonyfillFactory } from 'botframework-webchat';
+import { Components, createDirectLine, createCognitiveServicesSpeechServicesPonyfillFactory } from 'botframework-webchat';
 import React, { Component } from 'react';
 
 import CustomDictationInterims from './CustomDictationInterims';
 import CustomMicrophoneButton from './CustomMicrophoneButton';
-import fetchBingSpeechToken from './fetchBingSpeechToken';
+import fetchSpeechServicesToken from './fetchSpeechServicesToken';
 import LastBotActivity from './LastBotActivity';
 
 const { Composer } = Components;
@@ -25,7 +25,11 @@ export default class App extends Component {
     this.setState(() => ({
       directLine: createDirectLine({
         token,
-        webSpeechPonyfillFactory: createCognitiveServicesWebSpeechPonyfillFactory(fetchBingSpeechToken)
+        webSpeechPonyfillFactory: createCognitiveServicesSpeechServicesPonyfillFactory({
+          // TODO: [P3] Fetch token should be able to return different region
+          region: 'westus',
+          token: fetchSpeechServicesToken
+        })
       })
     }));
   }

--- a/samples/13.customization-speech-ui/src/fetchSpeechServicesToken.js
+++ b/samples/13.customization-speech-ui/src/fetchSpeechServicesToken.js
@@ -7,7 +7,7 @@ export default function () {
   const now = Date.now();
 
   if (!fetchPromise || (now - lastFetch) > RENEW_EVERY) {
-    fetchPromise = fetch('https://webchat-mockbot.azurewebsites.net/bingspeech/token', { method: 'POST' })
+    fetchPromise = fetch('https://webchat-mockbot.azurewebsites.net/speechservices/token', { method: 'POST' })
       .then(res => res.json())
       .then(({ token }) => token)
       .catch(() => { lastFetch = 0; });


### PR DESCRIPTION
> Fix #1633.

Updated to use Speech Services token for speech UI sample.

## Changelog
### Samples
- `component`: Use Speech Services token for [speech UI sample](https://microsoft.github.io/BotFramework-WebChat/13.customization-speech-ui/), in [#1634](https://github.com/Microsoft/BotFramework-WebChat/pull/1634)
