### PR TITLE
Do not rsync sample 16

### DIFF
--- a/scripts/deploy_pages
+++ b/scripts/deploy_pages
@@ -1,14 +1,17 @@
 #!/bin/bash
 
-rsync -av --progress samples/ gh-pages/ --exclude backend-cli --exclude 13.customization-speech-ui --exclude 12.customization-minimizable-web-chat --exclude 14.customization-piping-to-redux
-
-mkdir gh-pages/13.customization-speech-ui
-rsync -av --progress samples/13.customization-speech-ui/build/ gh-pages/13.customization-speech-ui/
+rsync -av --progress samples/ gh-pages/ --exclude backend-cli --exclude 12.customization-minimizable-web-chat --exclude 13.customization-speech-ui --exclude 14.customization-piping-to-redux --exclude 16.customization-selectable-activity
 
 mkdir gh-pages/12.customization-minimizable-web-chat
 rsync -av --progress samples/12.customization-minimizable-web-chat/build/ gh-pages/12.customization-minimizable-web-chat/
 
+mkdir gh-pages/13.customization-speech-ui
+rsync -av --progress samples/13.customization-speech-ui/build/ gh-pages/13.customization-speech-ui/
+
 mkdir gh-pages/14.customization-piping-to-redux
 rsync -av --progress samples/14.customization-piping-to-redux/build/ gh-pages/14.customization-piping-to-redux/
+
+mkdir gh-pages/16.customization-selectable-activity
+rsync -av --progress samples/16.customization-selectable-activity/build/ gh-pages/16.customization-selectable-activity/
 
 rsync -av --progress samples/redirects/ gh-pages/


### PR DESCRIPTION
`create-react-app`-based samples need to be handled differently when deploying to gh-pages.

Instead of deploying the whole folder, it will be built by Travis, and we only deploy `/build/` folder (which contains `index.html` and bundled files).