### PR TITLE
Rework connect saga to support connectivity status and reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `bundle`: Fix [#1613](https://github.com/Microsoft/BotFramework-WebChat/issues/1613). Pass conversationId to DirectLineJS constructor, by [@neetu-das](https://github.com/neetu-das) in PR [#1614](https://github.com/Microsoft/BotFramework-WebChat/pull/1614)
 - `component`: Fix [#1626](https://github.com/Microsoft/BotFramework-WebChat/issues/1626). Fixed `Number.isNaN` is not available in IE11, by [@compulim](https://github.com/compulim) in PR [#1628](https://github.com/Microsoft/BotFramework-WebChat/pull/1628)
 - `bundle`: Fix [#1652](https://github.com/Microsoft/BotFramework-WebChat/issues/1652). Pass `pollingInterval` to DirectLineJS constructor, by [@neetu-das](https://github.com/neetu-das) in PR [#1655](https://github.com/Microsoft/BotFramework-WebChat/pull/1655)
+- `core`: Reworked logic on connect/disconnect for reliability on handling corner cases, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Removed
 - `botAvatarImage` and `userAvatarImage` props, as they are moved inside `styleOptions`, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `bundle`: Fix [#1613](https://github.com/Microsoft/BotFramework-WebChat/issues/1613). Pass conversationId to DirectLineJS constructor, by [@neetu-das](https://github.com/neetu-das) in PR [#1614](https://github.com/Microsoft/BotFramework-WebChat/pull/1614)
 - `component`: Fix [#1626](https://github.com/Microsoft/BotFramework-WebChat/issues/1626). Fixed `Number.isNaN` is not available in IE11, by [@compulim](https://github.com/compulim) in PR [#1628](https://github.com/Microsoft/BotFramework-WebChat/pull/1628)
 - `bundle`: Fix [#1652](https://github.com/Microsoft/BotFramework-WebChat/issues/1652). Pass `pollingInterval` to DirectLineJS constructor, by [@neetu-das](https://github.com/neetu-das) in PR [#1655](https://github.com/Microsoft/BotFramework-WebChat/pull/1655)
-- `core`: Reworked logic on connect/disconnect for reliability on handling corner cases, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- `core`: Reworked logic on connect/disconnect for reliability on handling corner cases, by [@compulim](https://github.com/compulim) in PR [#1649](https://github.com/Microsoft/BotFramework-WebChat/pull/1649)
 
 ### Removed
 - `botAvatarImage` and `userAvatarImage` props, as they are moved inside `styleOptions`, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -2364,9 +2364,9 @@
 			"dev": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.10.2.tgz",
-			"integrity": "sha512-BDUL8xrkZyzC0/bKSzAPqPaVSHZF8slWc5ZsN5IrwC4au42YcDsKba9fld4j5+kqsIoB0uQbsnca4PkaYQ1FkQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.0.tgz",
+			"integrity": "sha512-u65BE6iDYGNos3CoYLC/uSa+Y9Eocwf+OUEz3UqLUdQgcqgZDSo2I9uziENnvan5vdTAIy67pa5iWgw+LLBBJQ==",
 			"requires": {
 				"rxjs": "^5.0.3"
 			}

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "0.11.0",
+    "botframework-directlinejs": "^0.11.0",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",
     "core-js": "^2.5.7",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "^0.10.2",
+    "botframework-directlinejs": "0.11.0",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",
     "core-js": "^2.5.7",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -2394,9 +2394,9 @@
       "optional": true
     },
     "botframework-directlinejs": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.10.2.tgz",
-      "integrity": "sha512-BDUL8xrkZyzC0/bKSzAPqPaVSHZF8slWc5ZsN5IrwC4au42YcDsKba9fld4j5+kqsIoB0uQbsnca4PkaYQ1FkQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.0.tgz",
+      "integrity": "sha512-u65BE6iDYGNos3CoYLC/uSa+Y9Eocwf+OUEz3UqLUdQgcqgZDSo2I9uziENnvan5vdTAIy67pa5iWgw+LLBBJQ==",
       "dev": true,
       "requires": {
         "rxjs": "^5.0.3"

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "0.11.0",
+    "botframework-directlinejs": "^0.11.0",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "react": "^16.4.1",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "^0.10.2",
+    "botframework-directlinejs": "0.11.0",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "react": "^16.4.1",
@@ -77,7 +77,7 @@
     "simple-update-in": "^1.3.0"
   },
   "peerDependencies": {
-    "botframework-directlinejs": "^0.10.2",
+    "botframework-directlinejs": "^0.11.0",
     "react": "^16.4.1"
   }
 }

--- a/packages/component/src/BasicWebChat.js
+++ b/packages/component/src/BasicWebChat.js
@@ -1,7 +1,5 @@
-import { createStore } from 'botframework-webchat-core';
 import { css } from 'glamor';
 import classNames from 'classnames';
-import memoize from 'memoize-one';
 import React from 'react';
 
 import BasicSendBox from './BasicSendBox';
@@ -30,7 +28,6 @@ export default class extends React.Component {
   constructor(props) {
     super(props);
 
-    this.createMemoizedStore = memoize(() => createStore());
     this.sendBoxRef = React.createRef();
 
     this.state = {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2788,9 +2788,9 @@
 			"optional": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.10.2.tgz",
-			"integrity": "sha512-BDUL8xrkZyzC0/bKSzAPqPaVSHZF8slWc5ZsN5IrwC4au42YcDsKba9fld4j5+kqsIoB0uQbsnca4PkaYQ1FkQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.0.tgz",
+			"integrity": "sha512-u65BE6iDYGNos3CoYLC/uSa+Y9Eocwf+OUEz3UqLUdQgcqgZDSo2I9uziENnvan5vdTAIy67pa5iWgw+LLBBJQ==",
 			"dev": true,
 			"requires": {
 				"rxjs": "^5.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "^0.10.2",
+    "botframework-directlinejs": "0.11.0",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "0.11.0",
+    "botframework-directlinejs": "^0.11.0",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",

--- a/packages/core/src/actions/updateConnectionStatus.js
+++ b/packages/core/src/actions/updateConnectionStatus.js
@@ -1,0 +1,10 @@
+const UPDATE_CONNECTION_STATUS = 'DIRECT_LINE/UPDATE_CONNECTION_STATUS';
+
+export default function updateConnectionStatus(connectionStatus) {
+  return {
+    type: UPDATE_CONNECTION_STATUS,
+    payload: { connectionStatus }
+  };
+}
+
+export { UPDATE_CONNECTION_STATUS }

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -131,11 +131,10 @@ function* connectSaga(directLine) {
 export default function* () {
   for (;;) {
     const { payload: { directLine, userID: userIDFromAction } } = yield take(CONNECT);
-    const userID = rectifyUserID(directLine, userIDFromAction);
     const updateConnectionStatusTask = yield fork(observeAndPutConnectionStatusUpdate, directLine);
 
     try {
-      const meta = { userID };
+      const meta = { userID: rectifyUserID(directLine, userIDFromAction) };
       let endDirectLine;
 
       yield put({ type: CONNECT_PENDING, meta });
@@ -167,8 +166,8 @@ export default function* () {
           yield take(negativeUpdateConnectionStatusAction);
         }
       } finally {
-        // It is meaningless to continue to use the Direct Line object even disconnect fail.
-        // And we will still unsubscribe to incoming activities.
+        // It is meaningless to continue to use the Direct Line object even disconnect failed.
+        // We will still unsubscribe to incoming activities and consider Direct Line object abandoned.
         yield put({ type: DISCONNECT_FULFILLED });
 
         endDirectLine();

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -49,13 +49,9 @@ function* observeAndPutConnectionStatusUpdate(directLine) {
     for (;;) {
       const connectionStatus = yield call(connectionStatusQueue.shift);
 
-      console.log(`DirectLineJS connectionStatus updated to: ${ connectionStatus }`);
-
       yield put(updateConnectionStatus(connectionStatus));
     }
   } finally {
-    console.log(`Stop subscribing connectionStatus from DirectLineJS.`);
-
     connectionStatusSubscription.unsubscribe();
   }
 }
@@ -134,8 +130,6 @@ function* connectSaga(directLine) {
 
 export default function* () {
   for (;;) {
-    console.log('Waiting for CONNECT');
-
     const { payload: { directLine, userID: userIDFromAction } } = yield take(CONNECT);
     const userID = rectifyUserID(directLine, userIDFromAction);
     const updateConnectionStatusTask = yield fork(observeAndPutConnectionStatusUpdate, directLine);

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -93,7 +93,7 @@ function rectifyUserID(directLine, userIDFromAction) {
 
 function* connectSaga(directLine) {
   // DirectLineJS start the connection only after the first subscriber for activity$, but not connectionStatus$
-  const activitySubscription = directLine.activity$.subscribe(() => 0);
+  const activitySubscription = directLine.activity$.subscribe({ next: () => 0 });
 
   try {
     for (;;) {

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -10,8 +10,7 @@ import {
 import { decode } from 'jsonwebtoken';
 import random from 'math-random';
 
-import callUntil from './effects/callUntil';
-import forever from './effects/forever';
+import updateConnectionStatus, { UPDATE_CONNECTION_STATUS } from '../actions/updateConnectionStatus';
 
 import createPromiseQueue from '../createPromiseQueue';
 
@@ -26,108 +25,162 @@ import {
 import {
   DISCONNECT,
   DISCONNECT_PENDING,
-  DISCONNECT_REJECTED,
   DISCONNECT_FULFILLED
 } from '../actions/disconnect';
 
 // const UNINITIALIZED = 0;
-// const CONNECTING = 1;
+const CONNECTING = 1;
 const ONLINE = 2;
-// const EXPIRED_TOKEN = 3;
-// const FAILED_TO_CONNECT = 4;
+const EXPIRED_TOKEN = 3;
+const FAILED_TO_CONNECT = 4;
 const ENDED = 5;
 
 function randomUserID() {
   return `r_${ random().toString(36).substr(2, 10) }`;
 }
 
-export default function* () {
-  for (;;) {
-    const { payload: { directLine, userID } } = yield take(CONNECT);
-    const { token } = directLine;
-    const { user: userIDFromToken } = decode(token) || {};
-
-    if (userIDFromToken) {
-      if (userID && userID !== userIDFromToken) {
-        console.warn('Web Chat: user ID is both specified in the Direct Line token and passed in, will use the user ID from the token.');
-      }
-
-      userID = userIDFromToken;
-    } else if (userID) {
-      if (typeof userID !== 'string') {
-        console.warn('Web Chat: user ID must be a string.');
-        userID = randomUserID();
-      } else if (/^dl_/.test(userID)) {
-        console.warn('Web Chat: user ID prefixed with "dl_" is reserved and must be embedded into the Direct Line token to prevent forgery.');
-        userID = randomUserID();
-      }
-    } else {
-      // Only specify "default-user" if not found from token and not passed in
-      userID = randomUserID();
-    }
-
-    const connectTask = yield fork(connectSaga, directLine, userID);
-
-    yield take(DISCONNECT);
-    yield call(disconnectSaga, connectTask, directLine);
-  }
-}
-
-function* connectSaga(directLine, userID) {
-  const meta = { userID };
-
-  yield put({ type: CONNECT_PENDING, meta });
-
+function* observeAndPutConnectionStatusUpdate(directLine) {
   const connectionStatusQueue = createPromiseQueue();
-  const connectionStatusSubscription = directLine.connectionStatus$.subscribe({ next: connectionStatusQueue.push });
-
-  // DirectLineJS start the connection only after the first subscriber for activity$, but not connectionStatus$
-  const activitySubscription = directLine.activity$.subscribe({ next: () => 0 });
+  const connectionStatusSubscription = directLine.connectionStatus$.subscribe({
+    next: connectionStatusQueue.push
+  });
 
   try {
-    try {
-      yield callUntil(connectionStatusQueue.shift, [], connectionStatus => connectionStatus === ONLINE);
-      yield put({ type: CONNECT_FULFILLING, meta, payload: { directLine } });
-      yield put({ type: CONNECT_FULFILLED, meta, payload: { directLine } });
-    } catch (err) {
-      yield put({ type: CONNECT_REJECTED, error: true, meta, payload: err });
-    } finally {
-      if (yield cancelled()) {
-        yield put({ type: CONNECT_REJECTED, error: true, meta, payload: new Error('cancelled') });
-      }
-    }
+    for (;;) {
+      const connectionStatus = yield call(connectionStatusQueue.shift);
 
-    yield forever();
+      console.log(`DirectLineJS connectionStatus updated to: ${ connectionStatus }`);
+
+      yield put(updateConnectionStatus(connectionStatus));
+    }
   } finally {
-    // TODO: [P2] DirectLineJS should kill the connection when we unsubscribe
-    //       But currently in v3, DirectLineJS does not have this functionality
-    //       Thus, we need to call "end()" explicitly
-    directLine.end();
-    activitySubscription.unsubscribe();
+    console.log(`Stop subscribing connectionStatus from DirectLineJS.`);
+
     connectionStatusSubscription.unsubscribe();
   }
 }
 
-function* disconnectSaga(connectTask, directLine) {
-  yield put({ type: DISCONNECT_PENDING });
+function negativeUpdateConnectionStatusAction({ payload, type }) {
+  if (type === UPDATE_CONNECTION_STATUS) {
+    const { connectionStatus } = payload;
 
-  const connectionStatusQueue = createPromiseQueue();
-  const unsubscribe = directLine.connectionStatus$.subscribe({ next: connectionStatusQueue.push });
+    return connectionStatus !== CONNECTING && connectionStatus !== ONLINE;
+  }
+}
 
-  // DirectLineJS should cancel underlying REST/WS when we cancel
-  // the connect task, which subsequently unsubscribe connectionStatus$
-  yield cancel(connectTask);
+function rectifyUserID(directLine, userIDFromAction) {
+  const { token } = directLine;
+  const { user: userIDFromToken } = decode(token) || {};
 
-  try {
-    yield callUntil(connectionStatusQueue.shift, [], connectionStatus => connectionStatus === ENDED);
-    yield put({ type: DISCONNECT_FULFILLED });
-  } catch (err) {
-    yield put({ type: DISCONNECT_REJECTED, error: true, payload: err });
-  } finally {
-    if (yield cancelled()) {
-      yield put({ type: DISCONNECT_REJECTED, error: true, payload: new Error('cancelled') });
+  if (userIDFromToken) {
+    if (userIDFromAction && userIDFromAction !== userIDFromToken) {
+      console.warn('Web Chat: user ID is both specified in the Direct Line token and passed in, will use the user ID from the token.');
     }
 
-    unsubscribe();
+    return userIDFromToken;
+  } else if (userIDFromAction) {
+    if (typeof userIDFromAction !== 'string') {
+      console.warn('Web Chat: user ID must be a string.');
+
+      return randomUserID();
+    } else if (/^dl_/.test(userIDFromAction)) {
+      console.warn('Web Chat: user ID prefixed with "dl_" is reserved and must be embedded into the Direct Line token to prevent forgery.');
+
+      return randomUserID();
+    }
+  } else {
+    return randomUserID();
+  }
+
+  return userIDFromAction;
+}
+
+function* connectSaga(directLine) {
+  // DirectLineJS start the connection only after the first subscriber for activity$, but not connectionStatus$
+  const activitySubscription = directLine.activity$.subscribe(() => 0);
+
+  try {
+    for (;;) {
+      const { payload: { connectionStatus } } = yield take(UPDATE_CONNECTION_STATUS);
+
+      // We will ignore DISCONNECT actions until we connect
+
+      if (connectionStatus === ONLINE) {
+        // TODO: [P2] DirectLineJS should kill the connection when we unsubscribe
+        //       But currently in v3, DirectLineJS does not have this functionality
+        //       Thus, we need to call "end()" explicitly
+
+        return () => {
+          activitySubscription.unsubscribe();
+
+          try {
+            // TODO: [P3] DirectLineJS will throw an error saying "conversation ended", it seems redundant
+            directLine.end();
+          } catch (err) {}
+        };
+      } else if (connectionStatus === ENDED || connectionStatus === EXPIRED_TOKEN || connectionStatus === FAILED_TO_CONNECT) {
+        // If we receive anything negative, we will assume the connection is errored out
+        throw new Error('Failed to connect');
+      }
+    }
+  } finally {
+    if (yield cancelled()) {
+      activitySubscription.unsubscribe();
+
+      throw new Error('Cancelled');
+    }
+  }
+}
+
+export default function* () {
+  for (;;) {
+    console.log('Waiting for CONNECT');
+
+    const { payload: { directLine, userID: userIDFromAction } } = yield take(CONNECT);
+    const userID = rectifyUserID(directLine, userIDFromAction);
+    const updateConnectionStatusTask = yield fork(observeAndPutConnectionStatusUpdate, directLine);
+
+    try {
+      const meta = { userID };
+      let endDirectLine;
+
+      yield put({ type: CONNECT_PENDING, meta });
+
+      try {
+        endDirectLine = yield call(connectSaga, directLine);
+      } catch (err) {
+        yield put({ type: CONNECT_REJECTED, error: true, meta, payload: err });
+
+        continue;
+      }
+
+      // At this point, we established connection to Direct Line.
+      // Any errors from this point, we need to make sure we call endDirectLine() to release resources.
+      try {
+        yield put({ type: CONNECT_FULFILLING, meta, payload: { directLine } });
+        yield put({ type: CONNECT_FULFILLED, meta, payload: { directLine } });
+
+        const terminateAction = yield take([DISCONNECT, negativeUpdateConnectionStatusAction]);
+
+        // Even if the connection is interrupted, we will still emitting DISCONNECT_PENDING.
+        // This will makes handling logic easier. If CONNECT_FULFILLED, we guarantee DISCONNECT_PENDING.
+        yield put({ type: DISCONNECT_PENDING });
+
+        endDirectLine();
+
+        if (terminateAction.type === DISCONNECT) {
+          // For graceful disconnect, we wait until Direct Line say it is ended
+          yield take(negativeUpdateConnectionStatusAction);
+        }
+      } finally {
+        // It is meaningless to continue to use the Direct Line object even disconnect fail.
+        // And we will still unsubscribe to incoming activities.
+        yield put({ type: DISCONNECT_FULFILLED });
+
+        endDirectLine();
+      }
+    } finally {
+      yield cancel(updateConnectionStatusTask);
+    }
   }
 }

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -14,6 +14,8 @@ import updateConnectionStatus, { UPDATE_CONNECTION_STATUS } from '../actions/upd
 
 import createPromiseQueue from '../createPromiseQueue';
 
+import { ConnectionStatus } from 'botframework-directlinejs';
+
 import {
   CONNECT,
   CONNECT_PENDING,
@@ -28,12 +30,13 @@ import {
   DISCONNECT_FULFILLED
 } from '../actions/disconnect';
 
-// const UNINITIALIZED = 0;
-const CONNECTING = 1;
-const ONLINE = 2;
-const EXPIRED_TOKEN = 3;
-const FAILED_TO_CONNECT = 4;
-const ENDED = 5;
+const {
+  Connecting: CONNECTING,
+  Online: ONLINE,
+  ExpiredToken: EXPIRED_TOKEN,
+  FailedToConnect: FAILED_TO_CONNECT,
+  Ended: ENDED
+} = ConnectionStatus;
 
 function randomUserID() {
   return `r_${ random().toString(36).substr(2, 10) }`;

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -63,7 +63,10 @@ function negativeUpdateConnectionStatusAction({ payload, type }) {
   if (type === UPDATE_CONNECTION_STATUS) {
     const { connectionStatus } = payload;
 
-    return connectionStatus !== CONNECTING && connectionStatus !== ONLINE;
+    return (
+      connectionStatus !== CONNECTING
+      && connectionStatus !== ONLINE
+    );
   }
 }
 
@@ -117,7 +120,11 @@ function* connectSaga(directLine) {
             directLine.end();
           } catch (err) {}
         };
-      } else if (connectionStatus === ENDED || connectionStatus === EXPIRED_TOKEN || connectionStatus === FAILED_TO_CONNECT) {
+      } else if (
+        connectionStatus === ENDED
+        || connectionStatus === EXPIRED_TOKEN
+        || connectionStatus === FAILED_TO_CONNECT
+      ) {
         // If we receive anything negative, we will assume the connection is errored out
         throw new Error('Failed to connect');
       }

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -114,11 +114,7 @@ function* connectSaga(directLine) {
 
         return () => {
           activitySubscription.unsubscribe();
-
-          try {
-            // TODO: [P3] DirectLineJS will throw an error saying "conversation ended", it seems redundant
-            directLine.end();
-          } catch (err) {}
+          directLine.end();
         };
       } else if (
         connectionStatus === ENDED

--- a/packages/core/src/sagas/effects/whileConnected.js
+++ b/packages/core/src/sagas/effects/whileConnected.js
@@ -6,7 +6,7 @@ import {
 } from 'redux-saga/effects';
 
 import { CONNECT_FULFILLING } from '../../actions/connect';
-import { DISCONNECT_FULFILLED } from '../../actions/disconnect';
+import { DISCONNECT_PENDING } from '../../actions/disconnect';
 
 export default function (fn) {
   return call(function* () {
@@ -14,7 +14,8 @@ export default function (fn) {
       const { meta: { userID }, payload: { directLine } } = yield take(CONNECT_FULFILLING);
       const task = yield fork(fn, directLine, userID);
 
-      yield take(DISCONNECT_FULFILLED);
+      // When we receive DISCONNECT_PENDING, the Direct Line connection is tearing down and should not be used.
+      yield take(DISCONNECT_PENDING);
       yield cancel(task);
     }
   });

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -2329,9 +2329,9 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"botframework-directlinejs": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.10.2.tgz",
-			"integrity": "sha512-BDUL8xrkZyzC0/bKSzAPqPaVSHZF8slWc5ZsN5IrwC4au42YcDsKba9fld4j5+kqsIoB0uQbsnca4PkaYQ1FkQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.0.tgz",
+			"integrity": "sha512-u65BE6iDYGNos3CoYLC/uSa+Y9Eocwf+OUEz3UqLUdQgcqgZDSo2I9uziENnvan5vdTAIy67pa5iWgw+LLBBJQ==",
 			"requires": {
 				"rxjs": "^5.0.3"
 			}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "0.11.0",
+    "botframework-directlinejs": "^0.11.0",
     "botframework-webchat": "^0.0.0-0",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "^0.10.2",
+    "botframework-directlinejs": "0.11.0",
     "botframework-webchat": "^0.0.0-0",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -95,8 +95,7 @@ export default class extends React.Component {
         domain,
         fetch,
         token: directLineToken,
-        webSocket: false
-        // webSocket: webSocket === 'true' || +webSocket
+        webSocket: webSocket === 'true' || !!+webSocket
       }),
       disabled: false,
       faulty: false,

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -58,6 +58,7 @@ export default class extends React.Component {
 
     this.handleBotAvatarInitialsChange = this.handleBotAvatarInitialsChange.bind(this);
     this.handleDisabledChange = this.handleDisabledChange.bind(this);
+    this.handleDisconnectClick = this.handleDisconnectClick.bind(this);
     this.handleGroupTimestampChange = this.handleGroupTimestampChange.bind(this);
     this.handleHideSendBoxChange = this.handleHideSendBoxChange.bind(this);
     this.handleLanguageChange = this.handleLanguageChange.bind(this);
@@ -94,7 +95,8 @@ export default class extends React.Component {
         domain,
         fetch,
         token: directLineToken,
-        webSocket: webSocket === 'true' || +webSocket
+        webSocket: false
+        // webSocket: webSocket === 'true' || +webSocket
       }),
       disabled: false,
       faulty: false,
@@ -145,6 +147,10 @@ export default class extends React.Component {
 
   handleBotAvatarInitialsChange({ target: { value } }) {
     this.setState(() => ({ botAvatarInitials: value }));
+  }
+
+  handleDisconnectClick() {
+    this.props.store.dispatch({ type: 'DIRECT_LINE/DISCONNECT' });
   }
 
   handleGroupTimestampChange({ target: { value } }) {
@@ -289,6 +295,12 @@ export default class extends React.Component {
             type="button"
           >
             Start conversation with local MockBot
+          </button>
+          <button
+            onClick={ this.handleDisconnectClick }
+            type="button"
+          >
+            Disconnect
           </button>
           <div>
             <label>


### PR DESCRIPTION
> This PR is pre-requisite of #1521 and related PRs.

Today, we do not support failed to connect initially and interrupted connection. Both features are also not supported in DLJS currently. In addition, we also do not support abort before a connection is made.

This PR will enable those scenarios. And we will work on support from DLJS side.

## Changelog
### Changed
- `core`: Reworked logic on connect/disconnect for reliability on handling corner cases, by [@compulim](https://github.com/compulim) in PR [#1649](https://github.com/Microsoft/BotFramework-WebChat/pull/1649)