### PR TITLE
Applying mime wrapper fix to avoid Angular CLI project build breaks

### DIFF
--- a/packages/core/src/sagas/sendFilesToPostActivitySaga.js
+++ b/packages/core/src/sagas/sendFilesToPostActivitySaga.js
@@ -4,6 +4,7 @@ import {
 } from 'redux-saga/effects';
 
 import mime from '../utils/mime-wrapper';
+
 import whileConnected from './effects/whileConnected';
 
 import { SEND_FILES } from '../actions/sendFiles';

--- a/packages/core/src/sagas/sendFilesToPostActivitySaga.js
+++ b/packages/core/src/sagas/sendFilesToPostActivitySaga.js
@@ -3,8 +3,7 @@ import {
   takeEvery
 } from 'redux-saga/effects';
 
-import mime from 'mime';
-
+import mime from '../utils/mime-wrapper';
 import whileConnected from './effects/whileConnected';
 
 import { SEND_FILES } from '../actions/sendFiles';

--- a/packages/core/src/utils/mime-wrapper.js
+++ b/packages/core/src/utils/mime-wrapper.js
@@ -1,0 +1,15 @@
+/**
+ * @description
+ * This file wraps the mime library constructor to include '.json' types. This is needed
+ * to support Angular CLI web projects, in which the webpack.config files are hidden away
+ * from the user, and do not support .json file extension module resolutions.
+ * 
+ * Refer to issue https://github.com/jshttp/mime-types/issues/50#issuecomment-390932678
+ * and issue https://github.com/broofa/node-mime/issues/208.
+ * 
+ * This file may need to change if the mime library is bumped a major that may cause a
+ * breaking change, as it relies on the internal library file placement.
+ */
+
+import Mime from 'mime/Mime';
+export default new Mime(require('mime/types/standard.json'), require('mime/types/other.json'));

--- a/packages/core/src/utils/mime-wrapper.js
+++ b/packages/core/src/utils/mime-wrapper.js
@@ -1,15 +1,16 @@
-/**
- * @description
- * This file wraps the mime library constructor to include '.json' types. This is needed
- * to support Angular CLI web projects, in which the webpack.config files are hidden away
- * from the user, and do not support .json file extension module resolutions.
- * 
- * Refer to issue https://github.com/jshttp/mime-types/issues/50#issuecomment-390932678
- * and issue https://github.com/broofa/node-mime/issues/208.
- * 
- * This file may need to change if the mime library is bumped a major that may cause a
- * breaking change, as it relies on the internal library file placement.
- */
+// This file wraps the mime library constructor to include '.json' types. This is needed
+// to support Angular CLI web projects, in which the webpack.config files are hidden away
+// from the user, and do not support .json file extension module resolutions.
+ 
+// Refer to issue https://github.com/jshttp/mime-types/issues/50#issuecomment-390932678
+// and issue https://github.com/broofa/node-mime/issues/208.
+ 
+// This file may need to change if the mime library is bumped a major that may cause a
+// breaking change, as it relies on the internal library file placement.
 
 import Mime from 'mime/Mime';
-export default new Mime(require('mime/types/standard.json'), require('mime/types/other.json'));
+
+export default new Mime(
+  require('mime/types/standard.json'), 
+  require('mime/types/other.json')
+)

--- a/packages/core/src/utils/mime-wrapper.js
+++ b/packages/core/src/utils/mime-wrapper.js
@@ -1,12 +1,36 @@
+// We adopted the work from mime-wrapper, at https://github.com/marlon360/mime-wrapper.
+
 // This file wraps the mime library constructor to include '.json' types. This is needed
 // to support Angular CLI web projects, in which the webpack.config files are hidden away
 // from the user, and do not support .json file extension module resolutions.
- 
+//
 // Refer to issue https://github.com/jshttp/mime-types/issues/50#issuecomment-390932678
 // and issue https://github.com/broofa/node-mime/issues/208.
- 
+//
 // This file may need to change if the mime library is bumped a major that may cause a
 // breaking change, as it relies on the internal library file placement.
+
+// MIT License
+// 
+// Copyright (c) 2018 Marlon Lückert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Mime from 'mime/Mime';
 


### PR DESCRIPTION
Supports #1423 

### Motivation
We want the web-chat widget to be usable from inside an Angular CLI project.

### Issue
- node-mime imports two JSON files via `require` statements without specifying the `.json` extension in their path.
- Angular CLI web-pack configurations do not support loading extension-less JSON modules/files paths.
- The only way users have to support `.json` file loading is to *eject* the web-pack configurations, which is less then optimal for users who expect to come and use the Angular CLI and have it handle all configurations for them.

### Solution
- Use a custom node-mime wrapper that requires the JSON files while adding their extensions in the paths.