### PR TITLE
Bump to botframework-directline@0.11.1 for Ibiza build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+<!-- CHANGELOG line template
+### Added/Changed/Removed
+- Added something, by [@johndoe](https://github.com/johndoe), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+
+### Changed (for dependency bumps)
+- `core`: Bumps to [`abc@1.2.3`](https://npmjs.com/package/abc/), in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+
+### Fixed
+- Fix [#XXX](https://github.com/Microsoft/BotFramework-WebChat/issues/XXX). Patched something, by [@johndoe](https://github.com/johndoe) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+-->
+
+## [Unreleased]
+- Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -->
 
 ## [Unreleased]
-- Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1694](https://github.com/Microsoft/BotFramework-WebChat/pull/1694)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -->
 
 ## [Unreleased]
+
+### Changed
 - Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1694](https://github.com/Microsoft/BotFramework-WebChat/pull/1694)

--- a/package-lock.json
+++ b/package-lock.json
@@ -671,9 +671,9 @@
       }
     },
     "botframework-directlinejs": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.9.13.tgz",
-      "integrity": "sha1-k1C1wnvjDEz287XOsQYhZZFuIJA=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
+      "integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
       "requires": {
         "rxjs": "^5.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/react": "15.0.38",
-    "botframework-directlinejs": "^0.11.1",
+    "botframework-directlinejs": "~0.11.1",
     "core-js": "2.4.1",
     "markdown-it": "8.3.1",
     "microsoft-adaptivecards": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/react": "15.0.38",
-    "botframework-directlinejs": "0.9.13",
+    "botframework-directlinejs": "^0.11.1",
     "core-js": "2.4.1",
     "markdown-it": "8.3.1",
     "microsoft-adaptivecards": "0.6.1",

--- a/src/AdaptiveCardContainer.tsx
+++ b/src/AdaptiveCardContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as AdaptiveCards from "microsoft-adaptivecards";
 import * as AdaptiveCardSchema from "microsoft-adaptivecards/built/schema";
-import { CardAction } from "botframework-directlinejs/built/directLine";
+import { CardActionTypes } from "botframework-directlinejs/built/directLine";
 import { classList, IDoCardAction } from "./Chat";
 import { AjaxResponse, AjaxRequest } from 'rxjs/observable/dom/AjaxObservable';
 import * as adaptivecardsHostConfig from '../adaptivecards-hostconfig.json';
@@ -25,8 +25,10 @@ class LinkedAdaptiveCard extends AdaptiveCards.AdaptiveCard {
     }
 }
 
-export interface BotFrameworkCardAction extends CardAction {
-    __isBotFrameworkCardAction: boolean
+export interface BotFrameworkCardAction {
+    __isBotFrameworkCardAction: boolean,
+    type: CardActionTypes,
+    value: any
 }
 
 function getLinkedAdaptiveCard(action: AdaptiveCards.Action) {

--- a/src/CardBuilder.tsx
+++ b/src/CardBuilder.tsx
@@ -56,7 +56,12 @@ export class AdaptiveCardBuilder {
     addButtons(buttons: CardAction[]) {
         if (buttons) {
             this.card.actions = buttons.map((button): AdaptiveCardSchema.ActionSubmit => {
-                const cardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...button };
+                const cardAction: BotFrameworkCardAction = {
+                    __isBotFrameworkCardAction: true,
+                    type: button.type,
+                    value: button.value
+                };
+
                 return {
                     title: button.title,
                     type: "Action.Submit",


### PR DESCRIPTION
## Changelog

### Changed

- Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1694](https://github.com/Microsoft/BotFramework-WebChat/pull/1694)
