### PR TITLE
Add Intl fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1602](https://github.com/Microsoft/BotFramework-WebChat/issues/1602). Fix suggested actions regression of buttons, by [@corinagum](https://github.com/corinagum) in PR [#1616](https://github.com/Microsoft/BotFramework-WebChat/pull/1616)
 - `core`: Send `conversationUpdate` activity on connect, by [@compulim](https://github.com/compulim), in PR [#1608](https://github.com/Microsoft/BotFramework-WebChat/pull/1608)
 - `component`: Allow font family and adaptive cards text color to be set via styleOptions, by [@a-b-r-o-w-n](https://github.com/a-b-r-o-w-n), in PR [#1670](https://github.com/Microsoft/BotFramework-WebChat/pull/1670)
+- `component`: Add fallback logic to browser which do not support `window.Intl`, by [@compulim](https://github.com/compulim), in PR [#1696](https://github.com/Microsoft/BotFramework-WebChat/pull/1696)
 
 ### Changed
 - Moved `botAvatarImage` and `userAvatarImage` to `styleOptions.botAvatarImage` and `styleOptions.userAvatarImage` respectively, in PR [#1486](https://github.com/Microsoft/BotFramework-WebChat/pull/1486)

--- a/packages/component/src/Localization/en-US.js
+++ b/packages/component/src/Localization/en-US.js
@@ -33,8 +33,17 @@ function xMinutesAgo(dateStr) {
     return `Today`;
   } else if (deltaInHours <= 48) {
     return `Yesterday`;
-  } else {
+  } else if (window.Intl) {
     return new Intl.DateTimeFormat('en-US').format(date);
+  } else {
+    return date.toLocaleString('en-US', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 

--- a/packages/component/src/Localization/fr-FR.js
+++ b/packages/component/src/Localization/fr-FR.js
@@ -25,8 +25,17 @@ function xMinutesAgo(dateStr) {
     return `Aujourd'hui`;
   } else if (deltaInHours <= 48) {
     return `Hier`;
-  } else {
+  } else if (window.Intl) {
     return new Intl.DateTimeFormat('fr-FR').format(date);
+  } else {
+    return date.toLocaleString('fr-FR', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 

--- a/packages/component/src/Localization/ja-JP.js
+++ b/packages/component/src/Localization/ja-JP.js
@@ -21,8 +21,17 @@ function xMinutesAgo(dateStr) {
     return '今日';
   } else if (deltaInHours <= 48) {
     return '昨日';
-  } else {
+  } else if (window.Intl) {
     return new Intl.DateTimeFormat('ja-JP').format(date);
+  } else {
+    return date.toLocaleString('ja-JP', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 

--- a/packages/component/src/Localization/zh-HANS.js
+++ b/packages/component/src/Localization/zh-HANS.js
@@ -25,8 +25,17 @@ function xMinutesAgo(dateStr) {
     return `今日`;
   } else if (deltaInHours <= 48) {
     return `昨日`;
-  } else {
+  } else if (window.Intl) {
     return new Intl.DateTimeFormat('zh-HANS').format(date);
+  } else {
+    return date.toLocaleString('zh-HANS', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 

--- a/packages/component/src/Localization/zh-HANT.js
+++ b/packages/component/src/Localization/zh-HANT.js
@@ -25,8 +25,17 @@ function xMinutesAgo(dateStr) {
     return `今日`;
   } else if (deltaInHours <= 48) {
     return `昨日`;
+  } else if (window.Intl) {
+    return new Intl.DateTimeFormat('zh-HANT').format(date);
   } else {
-    return new Intl.DateTimeFormat('zh-HK').format(date);
+    return date.toLocaleString('zh-HANT', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 

--- a/packages/component/src/Localization/zh-YUE.js
+++ b/packages/component/src/Localization/zh-YUE.js
@@ -26,8 +26,17 @@ function xMinutesAgo(dateStr) {
   } else if (deltaInHours <= 48) {
     // https://zh-yue.wikipedia.org/wiki/尋日
     return `尋日`;
-  } else {
+  } else if (window.Intl) {
     return new Intl.DateTimeFormat('zh-HK').format(date);
+  } else {
+    return date.toLocaleString('zh-HK', {
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+      minute: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
   }
 }
 


### PR DESCRIPTION
> Fix #1533.

## Changelog

### Added

- `component`: Add fallback logic to browser which do not support `window.Intl`, by [@compulim](https://github.com/compulim), in PR [#1696](https://github.com/Microsoft/BotFramework-WebChat/pull/1696)
