### PR TITLE
Add `autoFocus` props to Web Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `autoFocus` props to disable auto focus on send box, by default, this is set to `true`. By [@compulim](https://github.com/compulim) in PR [#1698](https://github.com/Microsoft/BotFramework-WebChat/pull/1698)
+
 ### Changed
 - Add more error handling to mountAdaptiveCards, by [@corinagum](https://github.com/corinagum) [#1395](https://github.com/Microsoft/BotFramework-WebChat/pull/1395)
 - Fix [botbuilder-tools#702](https://github.com/Microsoft/botbuilder-tools/issues/702): assume activity is not from user if `from` is falsy, by [@corinagum](https://github.com/corinagum) in PR [#1385](https://github.com/Microsoft/BotFramework-WebChat/pull/1385)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Behavioral customization will require changing the TypeScript files in `/src`. A
 
 Web Chat uses [markdown-it](https://markdown-it.github.io/) for markdown rendering. Markdown-it offers many rendering [options](https://github.com/markdown-it/markdown-it#init-with-presets-and-options), such as HTML rendering within markdown. You can change these options in `/src/FormattedText.tsx` in your own build of Web Chat.
 
+### Auto focus
+
+You can supply `false` to `autoFocus` props to disable auto focus. If the props is not set, it will focus on send box when Web Chat is instantiated on the page. This behavior is contrary to web standard, but to maintain compatibility with previous versions.
+
 ### Contributing
 
 If you feel your change might benefit the community, please submit a [pull request](https://github.com/Microsoft/BotFramework-WebChat/pulls).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2273,7 +2273,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2294,12 +2295,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2314,17 +2317,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2441,7 +2447,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2453,6 +2460,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2467,6 +2475,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2474,12 +2483,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2498,6 +2509,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2585,7 +2597,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2597,6 +2610,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2682,7 +2696,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2718,6 +2733,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2737,6 +2753,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2780,12 +2797,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -16,6 +16,7 @@ import { ActivityOrID, FormatOptions } from './Types';
 
 export interface ChatProps {
     adaptiveCardsHostConfig: any;
+    autoFocus: boolean;
     bot: User;
     botConnection?: IBotConnection;
     chatTitle?: boolean | string;
@@ -300,7 +301,11 @@ export class Chat extends React.Component<ChatProps, {}> {
                         />
                     </MessagePane>
                     {
-                        !this.props.disabled && <Shell ref={ this._saveShellRef } />
+                        !this.props.disabled &&
+                            <Shell
+                                autoFocus={ this.props.autoFocus !== false }
+                                ref={ this._saveShellRef }
+                            />
                     }
                     {
                         this.props.resize === 'detect' &&

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -8,6 +8,7 @@ import { ChatState } from './Store';
 import { Strings } from './Strings';
 
 interface Props {
+    autoFocus: boolean;
     inputText: string;
     strings: Strings;
     listeningState: ListeningState;
@@ -155,7 +156,6 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                         type="text"
                         className="wc-shellinput"
                         ref={ input => this.textInput = input }
-                        autoFocus
                         value={ this.props.inputText }
                         onChange={ _ => this.props.onChangeText(this.textInput.value) }
                         onKeyPress={ e => this.onKeyPress(e) }
@@ -163,6 +163,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                         placeholder={ placeholder }
                         aria-label={ this.props.inputText ? null : placeholder }
                         aria-live="polite"
+                        autoFocus={ this.props.autoFocus }
                     />
                 </div>
                 <button
@@ -223,6 +224,8 @@ export const Shell = connect(
         listeningState: stateProps.listeningState,
         // from dispatchProps
         onChangeText: dispatchProps.onChangeText,
+        // from ownProps
+        autoFocus: ownProps.autoFocus,
         // helper functions
         sendMessage: (text: string) => dispatchProps.sendMessage(text, stateProps.user, stateProps.locale),
         sendFiles: (files: FileList) => dispatchProps.sendFiles(files, stateProps.user, stateProps.locale),


### PR DESCRIPTION
> Fix #568.

## Readme

### Auto focus

You can supply `false` to `autoFocus` props to disable auto focus. If the props is not set, it will focus on send box when Web Chat is instantiated on the page. This behavior is contrary to web standard, but to maintain compatibility with previous versions.

## Changelog

### Added

- Added `autoFocus` props to disable auto focus on send box, by default, this is set to `true`. By [@compulim](https://github.com/compulim) in PR [#1698](https://github.com/Microsoft/BotFramework-WebChat/pull/1698)