### PR TITLE
Bump botframework-directlinejs@0.11.2 in v4

### DIFF
--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -2364,11 +2364,22 @@
 			"dev": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
-			"integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.2.tgz",
+			"integrity": "sha512-co+qBtlnLyw130Oig+04nZF+l9wnIJxRFCsHz42OTzebDnDwEFaB32UheEXiwYt4CsTlyO7aZkdLFv2gkWAkKA==",
 			"requires": {
+				"@babel/runtime": "^7.3.1",
 				"rxjs": "^5.0.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+					"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				}
 			}
 		},
 		"brace-expansion": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "^0.11.1",
+    "botframework-directlinejs": "~0.11.2",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",
     "core-js": "^2.5.7",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -875,6 +875,23 @@
         "@babel/plugin-transform-typescript": "^7.1.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -2394,11 +2411,12 @@
       "optional": true
     },
     "botframework-directlinejs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
-      "integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.2.tgz",
+      "integrity": "sha512-co+qBtlnLyw130Oig+04nZF+l9wnIJxRFCsHz42OTzebDnDwEFaB32UheEXiwYt4CsTlyO7aZkdLFv2gkWAkKA==",
       "dev": true,
       "requires": {
+        "@babel/runtime": "^7.3.1",
         "rxjs": "^5.0.3"
       }
     },

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "^0.11.1",
+    "botframework-directlinejs": "~0.11.2",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "react": "^16.4.1",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2788,12 +2788,30 @@
 			"optional": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
-			"integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.2.tgz",
+			"integrity": "sha512-co+qBtlnLyw130Oig+04nZF+l9wnIJxRFCsHz42OTzebDnDwEFaB32UheEXiwYt4CsTlyO7aZkdLFv2gkWAkKA==",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.3.1",
 				"rxjs": "^5.0.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+					"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+					"dev": true
+				}
 			}
 		},
 		"brace-expansion": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "babel-jest": "^23.6.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "^0.11.1",
+    "botframework-directlinejs": "~0.11.2",
     "concurrently": "^4.0.1",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -2329,11 +2329,27 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
-			"integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.2.tgz",
+			"integrity": "sha512-co+qBtlnLyw130Oig+04nZF+l9wnIJxRFCsHz42OTzebDnDwEFaB32UheEXiwYt4CsTlyO7aZkdLFv2gkWAkKA==",
 			"requires": {
+				"@babel/runtime": "^7.3.1",
 				"rxjs": "^5.0.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+					"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+				}
 			}
 		},
 		"bowser": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "adaptivecards": "~1.1.2",
-    "botframework-directlinejs": "^0.11.1",
+    "botframework-directlinejs": "~0.11.2",
     "botframework-webchat": "^0.0.0-0",
     "botframework-webchat-component": "^0.0.0-0",
     "botframework-webchat-core": "^0.0.0-0",


### PR DESCRIPTION
## Changelog

### Changed

- `*`: Bumps to [`botframework-directlinejs@0.11.2`](https://github.com/Microsoft/BotFramework-DirectLineJS/), by [@compulim](https://github.com/compulim), in PR [#1699](https://github.com/Microsoft/BotFramework-WebChat/pull/1699)