### PR TITLE
Bump botframework-directlinejs@0.11.2 in Ibiza

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
+- Bumps to [`botframework-directlinejs@0.11.2`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1700](https://github.com/Microsoft/BotFramework-WebChat/pull/1700)
+
+## [0.11.4-ibiza.46df236] - 2019-02-05
+
+### Changed
 - Bumps to [`botframework-directlinejs@0.11.1`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1694](https://github.com/Microsoft/BotFramework-WebChat/pull/1694)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@types/body-parser": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-0.0.33.tgz",
@@ -671,10 +679,11 @@
       }
     },
     "botframework-directlinejs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.1.tgz",
-      "integrity": "sha512-hmkWqgzUattdJeEDSTLR4cv8vJ+PuwOv6YaN7uU4lWqhbHXkGkTfBoSBO8IpCPoBlU+sXf+j0X+TLjaYz5aYVw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.2.tgz",
+      "integrity": "sha512-co+qBtlnLyw130Oig+04nZF+l9wnIJxRFCsHz42OTzebDnDwEFaB32UheEXiwYt4CsTlyO7aZkdLFv2gkWAkKA==",
       "requires": {
+        "@babel/runtime": "^7.3.1",
         "rxjs": "^5.0.3"
       }
     },
@@ -5637,6 +5646,11 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.13.0.tgz",
       "integrity": "sha1-NbJsLNu3HkmbMcqZYdoFgcKXOQk="
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/react": "15.0.38",
-    "botframework-directlinejs": "~0.11.1",
+    "botframework-directlinejs": "~0.11.2",
     "core-js": "2.4.1",
     "markdown-it": "8.3.1",
     "microsoft-adaptivecards": "0.6.1",


### PR DESCRIPTION
## Changelog

### Changed

- Bumps to [`botframework-directlinejs@0.11.2`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1700](https://github.com/Microsoft/BotFramework-WebChat/pull/1700)