### PR TITLE
Improve test reliability

### DIFF
--- a/__tests__/basic.js
+++ b/__tests__/basic.js
@@ -9,7 +9,6 @@ import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 test('setup', async () => {
   const { driver, pageObjects } = await setupWebDriver();
 
-  await pageObjects.pingBot();
   await pageObjects.sendMessageViaSendBox('layout carousel');
 
   await driver.wait(minNumActivitiesShown(3), 2000);

--- a/__tests__/basic.js
+++ b/__tests__/basic.js
@@ -1,9 +1,6 @@
-import { By, Key } from 'selenium-webdriver';
-
 import { imageSnapshotOptions, timeouts } from './constants.json';
 
 import allImagesLoaded from './setup/conditions/allImagesLoaded';
-import botConnected from './setup/conditions/botConnected';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 
 // selenium-webdriver API doc:
@@ -12,11 +9,9 @@ import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 test('setup', async () => {
   const { driver, pageObjects } = await setupWebDriver();
 
-  await driver.wait(botConnected(), timeouts.directLine);
+  await pageObjects.pingBot();
+  await pageObjects.sendMessageViaSendBox('layout carousel');
 
-  const input = await driver.findElement(By.css('input[type="text"]'));
-
-  await input.sendKeys('layout carousel', Key.RETURN);
   await driver.wait(minNumActivitiesShown(3), 2000);
   await driver.wait(allImagesLoaded(), 2000);
 
@@ -26,4 +21,4 @@ test('setup', async () => {
   const base64PNG = await driver.takeScreenshot();
 
   expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-}, 60000);
+}, timeouts.test);

--- a/__tests__/carousel.js
+++ b/__tests__/carousel.js
@@ -1,9 +1,8 @@
-import { By, Key } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 import { imageSnapshotOptions, timeouts } from './constants.json';
 
 import allImagesLoaded from './setup/conditions/allImagesLoaded';
-import botConnected from './setup/conditions/botConnected';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 
 // selenium-webdriver API doc:
@@ -13,11 +12,9 @@ describe('carousel without avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -37,16 +34,14 @@ describe('carousel without avatar initials', () => {
     await driver.sleep(1000);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('4 attachments and message', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -66,16 +61,14 @@ describe('carousel without avatar initials', () => {
     await driver.sleep(1000);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('2 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout double');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout double', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -83,16 +76,14 @@ describe('carousel without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('2 attachments with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout double');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout double', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -100,16 +91,14 @@ describe('carousel without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -117,16 +106,14 @@ describe('carousel without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -134,7 +121,7 @@ describe('carousel without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });
 
 describe('carousel with avatar initials', () => {
@@ -143,11 +130,9 @@ describe('carousel with avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -167,16 +152,14 @@ describe('carousel with avatar initials', () => {
     await driver.sleep(1000);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('4 attachments and message', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -196,16 +179,14 @@ describe('carousel with avatar initials', () => {
     await driver.sleep(1000);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('2 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout double');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout double', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -213,16 +194,14 @@ describe('carousel with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('2 attachments with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout double');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout double', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -230,16 +209,14 @@ describe('carousel with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -247,16 +224,14 @@ describe('carousel with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single carousel');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single carousel', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -264,5 +239,5 @@ describe('carousel with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });

--- a/__tests__/carousel.js
+++ b/__tests__/carousel.js
@@ -12,7 +12,6 @@ describe('carousel without avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -39,7 +38,6 @@ describe('carousel without avatar initials', () => {
   test('4 attachments and message', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -66,7 +64,6 @@ describe('carousel without avatar initials', () => {
   test('2 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout double');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -81,7 +78,6 @@ describe('carousel without avatar initials', () => {
   test('2 attachments with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout double');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -96,7 +92,6 @@ describe('carousel without avatar initials', () => {
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -111,7 +106,6 @@ describe('carousel without avatar initials', () => {
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -130,7 +124,6 @@ describe('carousel with avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -157,7 +150,6 @@ describe('carousel with avatar initials', () => {
   test('4 attachments and message', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -184,7 +176,6 @@ describe('carousel with avatar initials', () => {
   test('2 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout double');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -199,7 +190,6 @@ describe('carousel with avatar initials', () => {
   test('2 attachments with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout double');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -214,7 +204,6 @@ describe('carousel with avatar initials', () => {
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -229,7 +218,6 @@ describe('carousel with avatar initials', () => {
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single carousel');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);

--- a/__tests__/constants.json
+++ b/__tests__/constants.json
@@ -8,6 +8,7 @@
     "directLine": 5000,
     "fetch": 2500,
     "navigation": 5000,
-    "postActivity": 30000
+    "postActivity": 30000,
+    "test": 60000
   }
 }

--- a/__tests__/offlineUI.js
+++ b/__tests__/offlineUI.js
@@ -37,6 +37,7 @@ describe('offline UI', async () => {
           })
         };
       },
+      pingBotOnLoad: false,
       setup: () => new Promise(resolve => {
         const scriptElement = document.createElement('script');
 
@@ -59,6 +60,7 @@ describe('offline UI', async () => {
       createDirectLine: () => {
         return window.WebChat.createDirectLine({ token: 'INVALID-TOKEN' });
       },
+      pingBotOnLoad: false,
       setup: () => new Promise(resolve => {
         const scriptElement = document.createElement('script');
 
@@ -106,8 +108,6 @@ describe('offline UI', async () => {
         document.head.appendChild(scriptElement);
       })
     });
-
-    await pageObjects.pingBot();
 
     const input = await driver.findElement(By.css('input[type="text"]'));
 
@@ -161,8 +161,6 @@ describe('offline UI', async () => {
         document.head.appendChild(scriptElement);
       })
     });
-
-    await pageObjects.pingBot();
 
     const input = await driver.findElement(By.css('input[type="text"]'));
 

--- a/__tests__/offlineUI.js
+++ b/__tests__/offlineUI.js
@@ -1,7 +1,6 @@
 import { By, Condition, Key } from 'selenium-webdriver';
 
 import { imageSnapshotOptions, timeouts } from './constants.json';
-import botConnected from './setup/conditions/botConnected';
 
 // selenium-webdriver API doc:
 // https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
@@ -53,7 +52,7 @@ describe('offline UI', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should show "unable to connect" UI when credentials are incorrect', async () => {
     const { driver } = await setupWebDriver({
@@ -79,10 +78,10 @@ describe('offline UI', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should display "Send failed. Retry" when activity is not able to send', async () => {
-    const { driver } = await setupWebDriver({
+    const { driver, pageObjects } = await setupWebDriver({
       createDirectLine: options => {
         const workingDirectLine = window.WebChat.createDirectLine(options);
 
@@ -108,7 +107,7 @@ describe('offline UI', async () => {
       })
     });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
 
     const input = await driver.findElement(By.css('input[type="text"]'));
 
@@ -118,10 +117,10 @@ describe('offline UI', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should display "Send failed. Retry" when activity is sent but not acknowledged', async() => {
-    const { driver } = await setupWebDriver({
+    const { driver, pageObjects } = await setupWebDriver({
       createDirectLine: options => {
         const workingDirectLine = window.WebChat.createDirectLine(options);
         const bannedClientActivityIDs = [];
@@ -163,7 +162,7 @@ describe('offline UI', async () => {
       })
     });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
 
     const input = await driver.findElement(By.css('input[type="text"]'));
 
@@ -173,5 +172,5 @@ describe('offline UI', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });

--- a/__tests__/sendTypingIndicator.js
+++ b/__tests__/sendTypingIndicator.js
@@ -9,7 +9,6 @@ import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 test('Send typing indicator', async () => {
   const { driver, pageObjects } = await setupWebDriver({ props: { sendTypingIndicator: true } });
 
-  await pageObjects.pingBot();
   await pageObjects.sendMessageViaSendBox('echo-typing');
 
   await driver.wait(minNumActivitiesShown(3), 2000);
@@ -26,7 +25,6 @@ test('Send typing indicator', async () => {
 test('Send typing indicator using deprecated props', async () => {
   const { driver, pageObjects } = await setupWebDriver({ props: { sendTyping: true } });
 
-  await pageObjects.pingBot();
   await pageObjects.sendMessageViaSendBox('echo-typing');
 
   await driver.wait(minNumActivitiesShown(3), 2000);

--- a/__tests__/sendTypingIndicator.js
+++ b/__tests__/sendTypingIndicator.js
@@ -1,38 +1,32 @@
-import { By, Key } from 'selenium-webdriver';
-
-import botConnected from './setup/conditions/botConnected';
+import { timeouts } from './constants.json';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 
 // selenium-webdriver API doc:
 // https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
 
 test('Send typing indicator', async () => {
-  const { driver } = await setupWebDriver({ props: { sendTypingIndicator: true } });
+  const { driver, pageObjects } = await setupWebDriver({ props: { sendTypingIndicator: true } });
 
-  await driver.wait(botConnected(), 2000);
+  await pageObjects.pingBot();
+  await pageObjects.sendMessageViaSendBox('echo-typing');
 
-  const input = await driver.findElement(By.tagName('input[type="text"]'));
-
-  await input.sendKeys('echo-typing', Key.RETURN);
   await driver.wait(minNumActivitiesShown(3), 2000);
   await input.sendKeys('ABC');
 
   // Typing indicator takes longer to come back
   await driver.wait(minNumActivitiesShown(4), 5000);
-}, 60000);
+}, timeouts.test);
 
 // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
 test('Send typing indicator using deprecated props', async () => {
   const { driver } = await setupWebDriver({ props: { sendTyping: true } });
 
-  await driver.wait(botConnected(), 2000);
+  await pageObjects.pingBot();
+  await pageObjects.sendMessageViaSendBox('echo-typing');
 
-  const input = await driver.findElement(By.tagName('input[type="text"]'));
-
-  await input.sendKeys('echo-typing', Key.RETURN);
   await driver.wait(minNumActivitiesShown(3), 2000);
   await input.sendKeys('ABC');
 
   // Typing indicator takes longer to come back
   await driver.wait(minNumActivitiesShown(4), 5000);
-}, 60000);
+}, timeouts.test);

--- a/__tests__/sendTypingIndicator.js
+++ b/__tests__/sendTypingIndicator.js
@@ -1,3 +1,5 @@
+import { By } from 'selenium-webdriver';
+
 import { timeouts } from './constants.json';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 
@@ -11,6 +13,9 @@ test('Send typing indicator', async () => {
   await pageObjects.sendMessageViaSendBox('echo-typing');
 
   await driver.wait(minNumActivitiesShown(3), 2000);
+
+  const input = await driver.findElement(By.css('input[type="text"]'));
+
   await input.sendKeys('ABC');
 
   // Typing indicator takes longer to come back
@@ -19,12 +24,15 @@ test('Send typing indicator', async () => {
 
 // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
 test('Send typing indicator using deprecated props', async () => {
-  const { driver } = await setupWebDriver({ props: { sendTyping: true } });
+  const { driver, pageObjects } = await setupWebDriver({ props: { sendTyping: true } });
 
   await pageObjects.pingBot();
   await pageObjects.sendMessageViaSendBox('echo-typing');
 
   await driver.wait(minNumActivitiesShown(3), 2000);
+
+  const input = await driver.findElement(By.css('input[type="text"]'));
+
   await input.sendKeys('ABC');
 
   // Typing indicator takes longer to come back

--- a/__tests__/setup/conditions/directLineConnected.js
+++ b/__tests__/setup/conditions/directLineConnected.js
@@ -1,0 +1,7 @@
+import { Condition } from 'selenium-webdriver';
+
+export default function () {
+  return new Condition('Direct Line to connect', async driver =>
+    await driver.executeScript(() => ~window.WebChatTest.actions.findIndex(({ type }) => type === 'DIRECT_LINE/CONNECT_FULFILLED'))
+  );
+}

--- a/__tests__/setup/pageObjects/dispatchAction.js
+++ b/__tests__/setup/pageObjects/dispatchAction.js
@@ -1,0 +1,17 @@
+export default async function dispatchAction(driver, action) {
+  if (!action) {
+    throw new Error('"action" cannot be empty.');
+  } else if (!action.type || typeof action.type !== 'string') {
+    throw new Error('"action.type" must be a string.');
+  }
+
+  return await driver.executeScript(action => {
+    const { store } = window.WebChatTest || {};
+
+    if (store) {
+      return store.dispatch(action);
+    } else {
+      throw new Error('Web Chat is not loaded, cannot dispatch action.');
+    }
+  }, action);
+}

--- a/__tests__/setup/pageObjects/index.js
+++ b/__tests__/setup/pageObjects/index.js
@@ -1,7 +1,21 @@
+import dispatchAction from './dispatchAction';
 import hideCursor from './hideCursor';
+import pingBot from './pingBot';
+import sendMessageViaSendBox from './sendMessageViaSendBox';
+
+function mapMap(map, mapper) {
+  return Object.keys(map).reduce((final, key) => {
+    final[key] = mapper.call(map, map[key], key);
+
+    return final;
+  }, {});
+}
 
 export default function (driver) {
-  return {
-    hideCursor: hideCursor.bind(null, driver)
-  };
+  return mapMap({
+    dispatchAction,
+    hideCursor,
+    pingBot,
+    sendMessageViaSendBox
+  }, fn => fn.bind(null, driver));
 }

--- a/__tests__/setup/pageObjects/pingBot.js
+++ b/__tests__/setup/pageObjects/pingBot.js
@@ -1,0 +1,24 @@
+import { Condition } from 'selenium-webdriver';
+
+import { timeouts } from '../../constants.json';
+import directLineConnected from '../conditions/directLineConnected';
+import dispatchAction from './dispatchAction';
+
+async function waitForPong(driver, expectedValue) {
+  return await driver.executeScript(expectedValue =>
+    window.WebChatTest.store.getState().activities.some(({ name, type, value }) =>
+      name === 'webchat/pong'
+      && type === 'event'
+      && value === expectedValue
+    ),
+    expectedValue
+  );
+}
+
+export default async function (driver) {
+  const timestamp = Date.now();
+
+  await driver.wait(directLineConnected(), timeouts.directLine);
+  await dispatchAction(driver, { type: 'WEB_CHAT/SEND_EVENT', payload: { name: 'webchat/ping', value: timestamp } });
+  await driver.wait(new Condition('bot to send pong', driver => waitForPong(driver, timestamp)), timeouts.directLine);
+}

--- a/__tests__/setup/pageObjects/sendMessageViaSendBox.js
+++ b/__tests__/setup/pageObjects/sendMessageViaSendBox.js
@@ -1,0 +1,11 @@
+import { By, Key } from 'selenium-webdriver';
+
+import { timeouts } from '../../constants.json';
+import allOutgoingActivitiesSent from '../conditions/allOutgoingActivitiesSent';
+
+export default async function (driver, text) {
+  const input = await driver.findElement(By.css('input[type="text"]'));
+
+  await input.sendKeys(text, Key.RETURN);
+  await driver.wait(allOutgoingActivitiesSent, timeouts.directLine);
+}

--- a/__tests__/setup/pageObjects/sendMessageViaSendBox.js
+++ b/__tests__/setup/pageObjects/sendMessageViaSendBox.js
@@ -7,5 +7,5 @@ export default async function (driver, text) {
   const input = await driver.findElement(By.css('input[type="text"]'));
 
   await input.sendKeys(text, Key.RETURN);
-  await driver.wait(allOutgoingActivitiesSent, timeouts.directLine);
+  await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
 }

--- a/__tests__/setup/retry.js
+++ b/__tests__/setup/retry.js
@@ -1,0 +1,13 @@
+export default async function (fn, retries) {
+  let lastErr;
+
+  for (; retries > 0; retries--) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  throw lastErr;
+}

--- a/__tests__/stacked.js
+++ b/__tests__/stacked.js
@@ -13,11 +13,9 @@ describe('stacked without avatar initials', () => {
   test('4 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout stacked');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout stacked', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -25,16 +23,14 @@ describe('stacked without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -42,16 +38,14 @@ describe('stacked without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -59,7 +53,7 @@ describe('stacked without avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });
 
 describe('stacked with avatar initials', () => {
@@ -68,11 +62,9 @@ describe('stacked with avatar initials', () => {
   test('4 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout stacked');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout stacked', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -80,16 +72,14 @@ describe('stacked with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -97,16 +87,14 @@ describe('stacked with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('layout single');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('layout single', Key.RETURN);
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
@@ -114,5 +102,5 @@ describe('stacked with avatar initials', () => {
     await pageObjects.hideCursor();
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });

--- a/__tests__/stacked.js
+++ b/__tests__/stacked.js
@@ -13,7 +13,6 @@ describe('stacked without avatar initials', () => {
   test('4 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout stacked');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -28,7 +27,6 @@ describe('stacked without avatar initials', () => {
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -43,7 +41,6 @@ describe('stacked without avatar initials', () => {
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -62,7 +59,6 @@ describe('stacked with avatar initials', () => {
   test('4 attachments', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout stacked');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -77,7 +73,6 @@ describe('stacked with avatar initials', () => {
   test('1 attachment', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
@@ -92,7 +87,6 @@ describe('stacked with avatar initials', () => {
   test('1 attachment with wide screen', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS, width: 640 });
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('layout single');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);

--- a/__tests__/suggestedActions.js
+++ b/__tests__/suggestedActions.js
@@ -1,9 +1,8 @@
-import { By, Key } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 import { imageSnapshotOptions, timeouts } from './constants.json';
 
 import allOutgoingActivitiesSent from './setup/conditions/allOutgoingActivitiesSent';
-import botConnected from './setup/conditions/botConnected';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 import suggestedActionsShowed from './setup/conditions/suggestedActionsShowed';
 
@@ -14,11 +13,9 @@ describe('suggested-actions command', async () => {
   test('should show correctly formatted buttons when suggested actions are displayed', async() => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
     await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
     await pageObjects.hideCursor();
@@ -26,16 +23,14 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should show response from bot and no text from user on imback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
 
     const buttons = await driver.findElements(By.css('button'));
@@ -50,16 +45,14 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should show response from bot and no text from user on postback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
 
     const buttons = await driver.findElements(By.css('button'));
@@ -74,16 +67,14 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should show response from bot and text from user on postback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-      await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
 
     const buttons = await driver.findElements(By.css('button'));
@@ -98,17 +89,14 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
-
+  }, timeouts.test);
 
   test('should show response from bot and no text from user on messageback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
 
     const buttons = await driver.findElements(By.css('button'));
@@ -123,16 +111,14 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should show response from bot and text from user on messageback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions', Key.RETURN);
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
 
     const buttons = await driver.findElements(By.css('button'));
@@ -147,17 +133,13 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 
   test('should not show suggested actions not destined for the user', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(botConnected(), timeouts.directLine);
-
-    const input = await driver.findElement(By.css('input[type="text"]'));
-
-    await input.sendKeys('suggested-actions others', Key.RETURN);
-    await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
+    await pageObjects.pingBot();
+    await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await pageObjects.hideCursor();
@@ -165,5 +147,5 @@ describe('suggested-actions command', async () => {
     const base64PNG = await driver.takeScreenshot();
 
     expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-  }, 60000);
+  }, timeouts.test);
 });

--- a/__tests__/suggestedActions.js
+++ b/__tests__/suggestedActions.js
@@ -139,7 +139,7 @@ describe('suggested-actions command', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
     await pageObjects.pingBot();
-    await pageObjects.sendMessageViaSendBox('suggested-actions');
+    await pageObjects.sendMessageViaSendBox('suggested-actions others');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
     await pageObjects.hideCursor();

--- a/__tests__/suggestedActions.js
+++ b/__tests__/suggestedActions.js
@@ -13,7 +13,6 @@ describe('suggested-actions command', async () => {
   test('should show correctly formatted buttons when suggested actions are displayed', async() => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -28,7 +27,6 @@ describe('suggested-actions command', async () => {
   test('should show response from bot and no text from user on imback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -50,7 +48,6 @@ describe('suggested-actions command', async () => {
   test('should show response from bot and no text from user on postback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -72,7 +69,6 @@ describe('suggested-actions command', async () => {
   test('should show response from bot and text from user on postback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -94,7 +90,6 @@ describe('suggested-actions command', async () => {
   test('should show response from bot and no text from user on messageback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -116,7 +111,6 @@ describe('suggested-actions command', async () => {
   test('should show response from bot and text from user on messageback', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions');
 
     await driver.wait(suggestedActionsShowed(), timeouts.directLine);
@@ -138,7 +132,6 @@ describe('suggested-actions command', async () => {
   test('should not show suggested actions not destined for the user', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await pageObjects.pingBot();
     await pageObjects.sendMessageViaSendBox('suggested-actions others');
 
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);

--- a/__tests__/username.js
+++ b/__tests__/username.js
@@ -8,7 +8,6 @@ import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 test('send username in activity', async () => {
   const { driver, pageObjects } = await setupWebDriver();
 
-  await pageObjects.pingBot();
   await pageObjects.sendMessageViaSendBox('user name');
 
   await driver.wait(minNumActivitiesShown(3), timeouts.directLine);

--- a/__tests__/username.js
+++ b/__tests__/username.js
@@ -1,10 +1,5 @@
-import { By, Key } from 'selenium-webdriver';
-
 import { imageSnapshotOptions, timeouts } from './constants.json';
 
-import allImagesLoaded from './setup/conditions/allImagesLoaded';
-import allOutgoingActivitiesSent from './setup/conditions/allOutgoingActivitiesSent';
-import botConnected from './setup/conditions/botConnected';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 
 // selenium-webdriver API doc:
@@ -13,12 +8,9 @@ import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
 test('send username in activity', async () => {
   const { driver, pageObjects } = await setupWebDriver();
 
-  await driver.wait(botConnected(), timeouts.directLine);
+  await pageObjects.pingBot();
+  await pageObjects.sendMessageViaSendBox('user name');
 
-  const input = await driver.findElement(By.css('input[type="text"]'));
-
-  await input.sendKeys('user name', Key.RETURN);
-  await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
   await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
 
   // Hide cursor before taking screenshot
@@ -27,4 +19,4 @@ test('send username in activity', async () => {
   const base64PNG = await driver.takeScreenshot();
 
   expect(base64PNG).toMatchImageSnapshot(imageSnapshotOptions);
-}, 60000);
+}, timeouts.test);


### PR DESCRIPTION
- Added retry logic to test setup
   - Fail after 3 (consecutive) failures
- Moved "ping bot" test to test setup, so we can retry it
   - Set `pingBotOnLoad` to `false` if bot test should not be performed, for example, offline UI tests
- Added page objects
   - `dispatchAction` to dispatch an action
   - `pingBot` to send a ping to the bot and anticipate for pong
   - `sendMessageViaSendBox` will send message and wait until it is sent
- Added `timeouts.test` to `60000`