### PR TITLE
Bump react-scroll-to-bottom@1.3.1

### DIFF
--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -7088,9 +7088,9 @@
       }
     },
     "react-scroll-to-bottom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-scroll-to-bottom/-/react-scroll-to-bottom-1.3.0.tgz",
-      "integrity": "sha512-pTCdgk4DNsSIy7pKK3ieKJpp/OddCvymsKbm2kaLBAnBz9i6VqnJyZSunik0kT9/RLdOmvtPFjzoehDeS9LqGw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-scroll-to-bottom/-/react-scroll-to-bottom-1.3.1.tgz",
+      "integrity": "sha512-lkQcQOkp1voJzKQSuxkOiqfSOVAQfABspLOPw75c/PiwqqKro0SnJSV3Nay0QjuV/oONfnqMDChlL1XwxdcBCw==",
       "requires": {
         "classnames": "^2.2.6",
         "glamor": "^2.20.40",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -71,7 +71,7 @@
     "react-film": "~1.1.2",
     "react-redux": "^5.0.7",
     "react-say": "^1.1.1",
-    "react-scroll-to-bottom": "~1.3.0",
+    "react-scroll-to-bottom": "~1.3.1",
     "redux": "^4.0.0",
     "sanitize-html": "^1.18.2",
     "simple-update-in": "^1.3.0"


### PR DESCRIPTION
> Fix #1697.

Bumping `react-scroll-to-bottom` to `1.3.1`, which will fix #1697. Related changes:

- [#10](https://github.com/compulim/react-scroll-to-bottom/issues/10), fix scroll animation may not ending properly
- [#13](https://github.com/compulim/react-scroll-to-bottom/issues/13), fix occasional scroll lock issue in Firefox and Chrome
- [#15](https://github.com/compulim/react-scroll-to-bottom/issues/15), fix scroll to bottom button show up on some Hi-DPI settings