### PR TITLE
Ibiza: Move aria-label of file upload button from `<button>` to `<label>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Accessibility: Fix [#1802](https://github.com/Microsoft/BotFramework-WebChat/issues/1802) "Upload file" button is not narrated in non-`en-US` environment, by [@compulim](https://github.com/compulim) in PR [#1804](https://github.com/Microsoft/BotFramework-WebChat/pulls/1804)
+- Accessibility: Fix [#1802](https://github.com/Microsoft/BotFramework-WebChat/issues/1802) "Upload file" button is not narrated in non-`en-US` environment, by [@compulim](https://github.com/compulim) in PR [#1804](https://github.com/Microsoft/BotFramework-WebChat/pull/1804)
 
 ## [0.11.4-ibiza.279522f] - 2019-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
+- Accessibility: Fix [#1802](https://github.com/Microsoft/BotFramework-WebChat/issues/1802) "Upload file" button is not narrated in non-`en-US` environment, by [@compulim](https://github.com/compulim) in PR [#1804](https://github.com/Microsoft/BotFramework-WebChat/pulls/1804)
 
+## [0.11.4-ibiza.279522f] - 2019-03-05
+
+### Changed
 - Bumps to [`botframework-directlinejs@0.11.2`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1700](https://github.com/Microsoft/BotFramework-WebChat/pull/1700)
 
 ## [0.11.4-ibiza.46df236] - 2019-02-05

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -112,6 +112,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
         return (
             <div className={ className }>
                 <label
+                    aria-label={ this.props.strings.uploadFile }
                     className="wc-upload"
                     onKeyPress={ evt => this.handleUploadButtonKeyPress(evt) }
                     tabIndex={ 0 }
@@ -126,7 +127,6 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                         ref={ input => this.fileInput = input }
                         multiple
                         onChange={ () => this.onChangeFile() }
-                        aria-label={ this.props.strings.uploadFile }
                         role="button"
                     />
                 </label>


### PR DESCRIPTION
Tested on Edge 44.17763.1.0 with `<html lang="en">` and `<html lang="en-US">`.

Previously, the "Upload file" button is only narrated on `en-US`, but not `en`.