### PR TITLE
Ibiza: Fix incoming activities are not narrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Accessibility: Fix [#1805](https://github.com/Microsoft/BotFramework-WebChat/issues/1805), incoming activities are not narrative, by [@compulim](https://github.com/compulim) in PR [#1806](https://github.com/Microsoft/BotFramework-WebChat/pulls/1806)
+
+## [0.11.4-ibiza.279522f] - 2019-03-05
+
 ### Changed
 
 - Bumps to [`botframework-directlinejs@0.11.2`](https://npmjs.com/package/botframework-directlinejs/), by [@compulim](https://github.com/compulim) in PR [#1700](https://github.com/Microsoft/BotFramework-WebChat/pull/1700)

--- a/src/History.tsx
+++ b/src/History.tsx
@@ -155,10 +155,9 @@ export class HistoryView extends React.Component<HistoryProps, {}> {
             <div
                 className={ groupsClassName }
                 ref={ div => this.scrollMe = div || this.scrollMe }
-                role="log"
                 tabIndex={ 0 }
             >
-                <div className="wc-message-group-content" ref={ div => { if (div) this.scrollContent = div }}>
+                <div aria-live="polite" className="wc-message-group-content" ref={ div => { if (div) this.scrollContent = div }} role="list">
                     { content }
                 </div>
             </div>
@@ -281,7 +280,7 @@ export class WrappedActivity extends React.Component<WrappedActivityProps, {}> {
         );
 
         return (
-            <div data-activity-id={ this.props.activity.id } className={ wrapperClassName } onClick={ this.props.onClickActivity }>
+            <div data-activity-id={ this.props.activity.id } className={ wrapperClassName } onClick={ this.props.onClickActivity } role="listitem">
                 <div className={ 'wc-message wc-message-from-' + who } ref={ div => this.messageDiv = div }>
                     <div className={ contentClassName }>
                         <svg className="wc-message-callout">


### PR DESCRIPTION
> Fix #1805.

Incoming activities are not narrated by `role="log"`, changed to `role="list"` and `aria-live="polite"`.