### PR TITLE
Add deployment to /latest/, in addition to /legacy/

### DIFF
--- a/scripts/deploycdn.sh
+++ b/scripts/deploycdn.sh
@@ -29,9 +29,12 @@ cp $TRAVIS_BUILD_DIR/CognitiveServices.js.map $TRAVIS_BUILD_DIR/dist
 # ~/blobxfer upload --local-path $TRAVIS_BUILD_DIR/dist --remote-path $PACKAGE_NAME/latest --storage-account $CDN_BLOB_ACCOUNT --storage-account-key $CDN_BLOB_KEY
 # fi
 
-# If on "v3" branch, deploy to "legacy" tag too
+# If on "v3" branch, deploy to "latest" and "legacy" tag too
 if [ "$TRAVIS_BRANCH" = "v3" ]
 then
+# Upload to /latest/
+~/blobxfer upload --local-path $TRAVIS_BUILD_DIR/dist --remote-path $PACKAGE_NAME/latest --storage-account $CDN_BLOB_ACCOUNT --storage-account-key $CDN_BLOB_KEY
+
 # Upload to /legacy/
 ~/blobxfer upload --local-path $TRAVIS_BUILD_DIR/dist --remote-path $PACKAGE_NAME/legacy --storage-account $CDN_BLOB_ACCOUNT --storage-account-key $CDN_BLOB_KEY
 fi


### PR DESCRIPTION
> @mingweiw this is the PR to add v3 deployment to `/latest/`.

It will deploy 9 files to `/latest/`, in addition to `/legacy/`.

- `adaptivecards-hostconfig.json`
- `botchat-fullwindow.css`
- `botchat.css`
- `botchat.js`
- `botchat.js.map`
- `botchat-es5.js`
- `botchat-es5.js.map`
- `CognitiveServices.js`
- `CognitiveServices.js.map`

It will not collide with v4 in the same URL, because v4 is deploying these 7 files.

- `stats.html`
- `webchat-es5.js`
- `webchat-instrumented-es5.js`
- `webchat-instrumented-minimal.js`
- `webchat-instrumented.js`
- `webchat-minimal.js`
- `webchat.js`