### PR TITLE
Bump botframework-directlinejs@0.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@types/bluebird": {
       "version": "3.5.21",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.21.tgz",
@@ -738,10 +746,11 @@
       "dev": true
     },
     "botframework-directlinejs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.10.0.tgz",
-      "integrity": "sha512-J8a2Hp2qEmehIgAsxvW6v8YsVyqzbdfAvX7ugxWw/vEB579xwFCDQ8A1GYwlFiFsUfBeeFet5XROSI55ELfUKA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
+      "integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
       "requires": {
+        "@babel/runtime": "^7.3.1",
         "rxjs": "^5.0.3"
       }
     },
@@ -5242,6 +5251,11 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.13.0.tgz",
       "integrity": "sha1-NbJsLNu3HkmbMcqZYdoFgcKXOQk="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regex-cache": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "adaptivecards": "1.0.0",
     "bluebird": "^3.5.1",
-    "botframework-directlinejs": "^0.10.0",
+    "botframework-directlinejs": "^0.11.4",
     "core-js": "2.4.1",
     "jspeech": "^0.1.1",
     "markdown-it": "8.3.1",

--- a/src/AdaptiveCardContainer.tsx
+++ b/src/AdaptiveCardContainer.tsx
@@ -1,6 +1,6 @@
 import { Action, AdaptiveCard, HostConfig, IValidationError, OpenUrlAction, SubmitAction } from 'adaptivecards';
 import { IAction, IAdaptiveCard, IOpenUrlAction, IShowCardAction, ISubmitAction } from 'adaptivecards/lib/schema';
-import { CardAction } from 'botframework-directlinejs/built/directLine';
+import { CardActionTypes } from 'botframework-directlinejs/built/directLine';
 import * as MarkdownIt from 'markdown-it';
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
@@ -26,8 +26,10 @@ export interface State {
     errors?: string[];
 }
 
-export interface BotFrameworkCardAction extends CardAction {
+export interface BotFrameworkCardAction {
     __isBotFrameworkCardAction: boolean;
+    type: CardActionTypes;
+    value: any;
 }
 
 const markdownIt = new MarkdownIt({

--- a/src/CardBuilder.tsx
+++ b/src/CardBuilder.tsx
@@ -55,7 +55,7 @@ export class AdaptiveCardBuilder {
     private static addCardAction(cardAction: CardAction, includesOAuthButtons?: boolean) {
         if (cardAction.type === 'imBack' || cardAction.type === 'postBack') {
             const action = new SubmitAction();
-            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...cardAction };
+            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, type: cardAction.type, value: cardAction.value };
 
             action.data = botFrameworkCardAction;
             action.title = cardAction.title;
@@ -64,7 +64,7 @@ export class AdaptiveCardBuilder {
         } else if (cardAction.type === 'signin' && includesOAuthButtons) {
             // Create a button specific for OAuthCard 'signin' actions (cardAction.type == signin and button action is Action.Submit)
             const action = new SubmitAction();
-            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...cardAction };
+            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, type: cardAction.type, value: cardAction.value };
 
             action.data = botFrameworkCardAction;
             action.title = cardAction.title;
@@ -72,7 +72,7 @@ export class AdaptiveCardBuilder {
             return action;
         } else {
             const action = new OpenUrlAction();
-            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, ...cardAction };
+            const botFrameworkCardAction: BotFrameworkCardAction = { __isBotFrameworkCardAction: true, type: cardAction.type, value: cardAction.value };
 
             action.title = cardAction.title;
             action.url = cardAction.type === 'call' ? 'tel:' + cardAction.value : cardAction.value;


### PR DESCRIPTION
Verified the following features in Chrome, Edge and IE11.

- Can send a message
- Can upload an attachment
- Work between REST and Web Socket (verified traffic)
- OAuth sign in
- Verified `x-ms-bot-agent`
- Verified `bingsports` card with `openUrl` support

DLJS has a breaking change on schema. We adopted [this PR](https://github.com/Microsoft/BotFramework-WebChat/commit/ab596bcdac2c2634d37c506364d055ac52050d75) from Ibiza build for the change.

@vincec-msft @mingweiw this is the PR for bumping DirectLineJS in Web Chat v3.