### PR TITLE
Add ability to style suggested action flippers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add [#1524](https://github.com/Microsoft/BotFramework-WebChat/issues/1524) Offline UI connecting for the first time, by [@corinagum](https://github.com/corinagum), in PR [#1866](https://github.com/Microsoft/BotFramework-WebChat/pull/1866)
 - Fix [#1768](https://github.com/Microsoft/BotFramework-WebChat/issues/1768). Add style option to modify all Send Box borders, by [@corinagum](https://github.com/corinagum) in PR [#1871](https://github.com/Microsoft/BotFramework-WebChat/pull/1871)
 - Fix [#1827](https://github.com/Microsoft/BotFramework-WebChat/issues/1827). Remove renderer for unknown activities, by [@corinagum](https://github.com/corinagum) in PR [#1873](https://github.com/Microsoft/BotFramework-WebChat/pull/1873)
-- Fix [#1586](https://github.com/Microsoft/BotFramework-WebChat/issues/1586). Fix theming of suggested actions buttons, by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- Fix [#1586](https://github.com/Microsoft/BotFramework-WebChat/issues/1586). Fix theming of suggested actions buttons, by [@corinagum](https://github.com/corinagum) in PR [#1883](https://github.com/Microsoft/BotFramework-WebChat/pull/1883)
 
 ## [4.3.0] - 2019-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add [#1524](https://github.com/Microsoft/BotFramework-WebChat/issues/1524) Offline UI connecting for the first time, by [@corinagum](https://github.com/corinagum), in PR [#1866](https://github.com/Microsoft/BotFramework-WebChat/pull/1866)
 - Fix [#1768](https://github.com/Microsoft/BotFramework-WebChat/issues/1768). Add style option to modify all Send Box borders, by [@corinagum](https://github.com/corinagum) in PR [#1871](https://github.com/Microsoft/BotFramework-WebChat/pull/1871)
 - Fix [#1827](https://github.com/Microsoft/BotFramework-WebChat/issues/1827). Remove renderer for unknown activities, by [@corinagum](https://github.com/corinagum) in PR [#1873](https://github.com/Microsoft/BotFramework-WebChat/pull/1873)
+- Fix [#1586](https://github.com/Microsoft/BotFramework-WebChat/issues/1586). Fix theming of suggested actions buttons, by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ## [4.3.0] - 2019-03-04
 

--- a/packages/component/src/Styles/StyleSet/SuggestedActions.js
+++ b/packages/component/src/Styles/StyleSet/SuggestedActions.js
@@ -1,8 +1,37 @@
 export default function createSuggestedActionsStyle({
-  paddingRegular
+  paddingRegular,
+  transcriptOverlayButtonBackground,
+  transcriptOverlayButtonBackgroundOnDisabled,
+  transcriptOverlayButtonBackgroundOnFocus,
+  transcriptOverlayButtonBackgroundOnHover,
+  transcriptOverlayButtonColor,
+  transcriptOverlayButtonColorOnDisabled,
+  transcriptOverlayButtonColorOnFocus,
+  transcriptOverlayButtonColorOnHover
 }) {
   return {
     paddingLeft: paddingRegular / 2,
-    paddingRight: paddingRegular / 2
+    paddingRight: paddingRegular / 2,
+
+    '& button > div.slider > div': {
+      backgroundColor: transcriptOverlayButtonBackground,
+      color: transcriptOverlayButtonColor,
+      outline: 0
+    },
+
+    '& button:disabled > div.slider > div': {
+      backgroundColor: transcriptOverlayButtonBackgroundOnDisabled,
+      color: transcriptOverlayButtonColorOnDisabled
+    },
+
+    '& button:focus > div.slider > div': {
+      backgroundColor: transcriptOverlayButtonBackgroundOnFocus,
+      color: transcriptOverlayButtonColorOnFocus
+    },
+
+    '& button:hover > div.slider > div': {
+      backgroundColor: transcriptOverlayButtonBackgroundOnHover,
+      color: transcriptOverlayButtonColorOnHover
+    }
   };
 }

--- a/packages/component/src/Styles/defaultStyleSetOptions.js
+++ b/packages/component/src/Styles/defaultStyleSetOptions.js
@@ -79,7 +79,7 @@ const DEFAULT_OPTIONS = {
   // Timestamp
   timestampColor: DEFAULT_SUBTLE,
 
-  // Transcript overlay buttons (e.g. carousel and scroll to bottom)
+  // Transcript overlay buttons (e.g. carousel and suggested action flippers, scroll to bottom, etc.)
   transcriptOverlayButtonBackground: 'rgba(0, 0, 0, .6)',
   transcriptOverlayButtonBackgroundOnFocus: 'rgba(0, 0, 0, .8)',
   transcriptOverlayButtonBackgroundOnHover: 'rgba(0, 0, 0, .8)',


### PR DESCRIPTION
Fix #1586 
Add the ability to customize the appearance of suggested action flippers.
Note that these options also affect the carousel flippers and scroll to bottom buttons.

```
   styleOptions: {
     transcriptOverlayButtonBackground: 'magenta',
     transcriptOverlayButtonColor: 'blue'
   }
```
![image](https://user-images.githubusercontent.com/14900841/55758775-90fb3380-5a0c-11e9-8d67-fc54fcabf811.png)
