### PR TITLE
Fix CSS collisions with Bootstrap and bump memoize-one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1768](https://github.com/Microsoft/BotFramework-WebChat/issues/1768). Add style option to modify all Send Box borders, by [@corinagum](https://github.com/corinagum) in PR [#1871](https://github.com/Microsoft/BotFramework-WebChat/pull/1871)
 - Fix [#1827](https://github.com/Microsoft/BotFramework-WebChat/issues/1827). Remove renderer for unknown activities, by [@corinagum](https://github.com/corinagum) in PR [#1873](https://github.com/Microsoft/BotFramework-WebChat/pull/1873)
 - Fix [#1586](https://github.com/Microsoft/BotFramework-WebChat/issues/1586). Fix theming of suggested actions buttons, by [@corinagum](https://github.com/corinagum) in PR [#1883](https://github.com/Microsoft/BotFramework-WebChat/pull/1883)
-- Fix [#1837](https://github.com/Microsoft/BotFramework-WebChat/issues/1837), [#1643](https://github.com/Microsoft/BotFramework-WebChat/issues/1643). Fix style conflicts with bootstrap and bump `memoize-one`, by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+- Fix [#1837](https://github.com/Microsoft/BotFramework-WebChat/issues/1837), [#1643](https://github.com/Microsoft/BotFramework-WebChat/issues/1643). Fix style conflicts with bootstrap and bump `memoize-one`, by [@corinagum](https://github.com/corinagum) in PR [#1884](https://github.com/Microsoft/BotFramework-WebChat/pull/1884)
 
 ## [4.3.0] - 2019-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1768](https://github.com/Microsoft/BotFramework-WebChat/issues/1768). Add style option to modify all Send Box borders, by [@corinagum](https://github.com/corinagum) in PR [#1871](https://github.com/Microsoft/BotFramework-WebChat/pull/1871)
 - Fix [#1827](https://github.com/Microsoft/BotFramework-WebChat/issues/1827). Remove renderer for unknown activities, by [@corinagum](https://github.com/corinagum) in PR [#1873](https://github.com/Microsoft/BotFramework-WebChat/pull/1873)
 - Fix [#1586](https://github.com/Microsoft/BotFramework-WebChat/issues/1586). Fix theming of suggested actions buttons, by [@corinagum](https://github.com/corinagum) in PR [#1883](https://github.com/Microsoft/BotFramework-WebChat/pull/1883)
+- Fix [#1837](https://github.com/Microsoft/BotFramework-WebChat/issues/1837), [#1643](https://github.com/Microsoft/BotFramework-WebChat/issues/1643). Fix style conflicts with bootstrap and bump `memoize-one`, by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ## [4.3.0] - 2019-03-04
 

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -5334,9 +5334,9 @@
 			}
 		},
 		"memoize-one": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-			"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -7596,6 +7596,13 @@
 				"events": "^3.0.0",
 				"memoize-one": "^4.0.0",
 				"simple-update-in": "^1.2.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
 			}
 		},
 		"webpack": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -39,7 +39,7 @@
     "core-js": "^2.5.7",
     "markdown-it": "^8.4.2",
     "markdown-it-for-inline": "^0.1.1",
-    "memoize-one": "^4.0.2",
+    "memoize-one": "^5.0.2",
     "microsoft-speech-browser-sdk": "^0.0.12",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -4308,9 +4308,9 @@
       "optional": true
     },
     "memoize-one": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
-      "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
     },
     "micromatch": {
       "version": "3.1.10",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -48,7 +48,7 @@
     "bytes": "^3.0.0",
     "classnames": "^2.2.6",
     "glamor": "^2.20.40",
-    "memoize-one": "^3.1.1",
+    "memoize-one": "^5.0.2",
     "react-dictate-button": "^1.1.3",
     "react-film": "~1.1.2",
     "react-redux": "^5.0.7",

--- a/packages/component/src/Activity/CarouselFilmStrip.js
+++ b/packages/component/src/Activity/CarouselFilmStrip.js
@@ -157,7 +157,7 @@ const ConnectedCarouselFilmStrip = connectCarouselFilmStrip(
           </ul>
           <div
             aria-hidden={ true }
-            className="row"
+            className="webchat-row"
           >
             {(
               activity.channelData

--- a/packages/component/src/Activity/CarouselFilmStrip.js
+++ b/packages/component/src/Activity/CarouselFilmStrip.js
@@ -157,7 +157,7 @@ const ConnectedCarouselFilmStrip = connectCarouselFilmStrip(
           </ul>
           <div
             aria-hidden={ true }
-            className="webchat-row"
+            className="webchat__row"
           >
             {(
               activity.channelData

--- a/packages/component/src/Activity/StackedLayout.js
+++ b/packages/component/src/Activity/StackedLayout.js
@@ -25,7 +25,7 @@ const ROOT_CSS = css({
     flexGrow: 1,
     overflow: 'hidden',
 
-    '& > .webchat-row': {
+    '& > .webchat__row': {
       display: 'flex',
 
       '& > .bubble, & > .timestamp': {
@@ -47,7 +47,7 @@ const ROOT_CSS = css({
   '&.from-user': {
     flexDirection: 'row-reverse',
 
-    '& > .content > .webchat-row': {
+    '& > .content > .webchat__row': {
       flexDirection: 'row-reverse'
     }
   }
@@ -119,7 +119,7 @@ export default connectStackedLayout(
         <div className="content">
           {
             activity.type === 'typing' ?
-              <div className="webchat-row typing">
+              <div className="webchat__row typing">
                 {
                   children({
                     activity,
@@ -129,7 +129,7 @@ export default connectStackedLayout(
                 <div className="filler" />
               </div>
             : !!activityDisplayText &&
-              <div className="webchat-row message">
+              <div className="webchat__row message">
                 <Bubble
                   aria-label={ ariaLabel }
                   className="bubble"
@@ -150,7 +150,7 @@ export default connectStackedLayout(
           }
           {
             (activity.attachments || []).map((attachment, index) =>
-              <div className="webchat-row attachment" key={ index }>
+              <div className="webchat__row attachment" key={ index }>
                 <Bubble
                   className="attachment bubble"
                   fromUser={ fromUser }
@@ -163,7 +163,7 @@ export default connectStackedLayout(
           }
           <div
             aria-hidden={ true }
-            className="webchat-row"
+            className="webchat__row"
           >
             { showSendStatus ?
                 <SendStatus activity={ activity } className="timestamp" />

--- a/packages/component/src/Activity/StackedLayout.js
+++ b/packages/component/src/Activity/StackedLayout.js
@@ -25,7 +25,7 @@ const ROOT_CSS = css({
     flexGrow: 1,
     overflow: 'hidden',
 
-    '& > .row': {
+    '& > .webchat-row': {
       display: 'flex',
 
       '& > .bubble, & > .timestamp': {
@@ -47,7 +47,7 @@ const ROOT_CSS = css({
   '&.from-user': {
     flexDirection: 'row-reverse',
 
-    '& > .content > .row': {
+    '& > .content > .webchat-row': {
       flexDirection: 'row-reverse'
     }
   }
@@ -119,7 +119,7 @@ export default connectStackedLayout(
         <div className="content">
           {
             activity.type === 'typing' ?
-              <div className="row typing">
+              <div className="webchat-row typing">
                 {
                   children({
                     activity,
@@ -129,7 +129,7 @@ export default connectStackedLayout(
                 <div className="filler" />
               </div>
             : !!activityDisplayText &&
-              <div className="row message">
+              <div className="webchat-row message">
                 <Bubble
                   aria-label={ ariaLabel }
                   className="bubble"
@@ -150,7 +150,7 @@ export default connectStackedLayout(
           }
           {
             (activity.attachments || []).map((attachment, index) =>
-              <div className="row attachment" key={ index }>
+              <div className="webchat-row attachment" key={ index }>
                 <Bubble
                   className="attachment bubble"
                   fromUser={ fromUser }
@@ -163,7 +163,7 @@ export default connectStackedLayout(
           }
           <div
             aria-hidden={ true }
-            className="row"
+            className="webchat-row"
           >
             { showSendStatus ?
                 <SendStatus activity={ activity } className="timestamp" />

--- a/packages/component/src/Styles/StyleSet/CarouselFilmStrip.js
+++ b/packages/component/src/Styles/StyleSet/CarouselFilmStrip.js
@@ -37,7 +37,7 @@ export default function ({
         }
       },
 
-      '& > .row': {
+      '& > .webchat-row': {
         marginLeft: paddingRegular
       }
     }

--- a/packages/component/src/Styles/StyleSet/CarouselFilmStrip.js
+++ b/packages/component/src/Styles/StyleSet/CarouselFilmStrip.js
@@ -37,7 +37,7 @@ export default function ({
         }
       },
 
-      '& > .webchat-row': {
+      '& > .webchat__row': {
         marginLeft: paddingRegular
       }
     }

--- a/packages/component/src/Styles/StyleSet/StackedLayout.js
+++ b/packages/component/src/Styles/StyleSet/StackedLayout.js
@@ -8,7 +8,7 @@ export default function ({
     marginRight: paddingRegular,
 
     '& > .content': {
-      '& > .row': {
+      '& > .webchat-row': {
         '& > .bubble, & > .timestamp': {
           maxWidth: bubbleMaxWidth
         },

--- a/packages/component/src/Styles/StyleSet/StackedLayout.js
+++ b/packages/component/src/Styles/StyleSet/StackedLayout.js
@@ -8,7 +8,7 @@ export default function ({
     marginRight: paddingRegular,
 
     '& > .content': {
-      '& > .webchat-row': {
+      '& > .webchat__row': {
         '& > .bubble, & > .timestamp': {
           maxWidth: bubbleMaxWidth
         },

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -9080,9 +9080,9 @@
 			}
 		},
 		"memoize-one": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-			"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -13831,6 +13831,13 @@
 				"event-as-promise": "^1.0.3",
 				"glamor": "^2.20.40",
 				"memoize-one": "^4.0.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
 			}
 		},
 		"react-scripts": {
@@ -16646,6 +16653,11 @@
 				"simple-update-in": "^1.2.0"
 			},
 			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				},
 				"react-say": {
 					"version": "0.0.1-master.ca079e3",
 					"resolved": "https://registry.npmjs.org/react-say/-/react-say-0.0.1-master.ca079e3.tgz",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -19,7 +19,7 @@
     "glamor": "^2.20.40",
     "markdown-it": "^8.4.1",
     "markdown-it-for-inline": "^0.1.1",
-    "memoize-one": "^4.0.2",
+    "memoize-one": "^5.0.2",
     "microsoft-speech-browser-sdk": "^0.0.12",
     "on-error-resume-next": "^1.0.0",
     "react": "^16.4.1",

--- a/samples/12.customization-minimizable-web-chat/package-lock.json
+++ b/samples/12.customization-minimizable-web-chat/package-lock.json
@@ -802,6 +802,21 @@
 				"@babel/plugin-transform-typescript": "^7.1.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+				}
+			}
+		},
 		"@babel/template": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -1110,6 +1125,11 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
 			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
+		},
+		"adaptivecards": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.1.3.tgz",
+			"integrity": "sha512-UeU/w8SqkeBE1NuiI+5C1XxQJtxA/o7l5uDfDG2XCS3oKt73vfj3Bh0DRHtxyVFecoegmBNPzpRo7C6QTcxIRg=="
 		},
 		"address": {
 			"version": "1.0.3",
@@ -2336,6 +2356,100 @@
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
+		"botframework-directlinejs": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
+			"integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"rxjs": "^5.0.3"
+			}
+		},
+		"botframework-webchat": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/botframework-webchat/-/botframework-webchat-4.3.0.tgz",
+			"integrity": "sha512-63JzVHTWm5G0N711eWXCpvQ+qfakp3UM79mSsou+DLRoxkaOjTkGLUuzXD5CpNJl+iryuNq1fV2MScIuuK5Lxg==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"adaptivecards": "~1.1.2",
+				"botframework-directlinejs": "^0.11.4",
+				"botframework-webchat-component": "4.3.0",
+				"botframework-webchat-core": "4.3.0",
+				"core-js": "^2.5.7",
+				"markdown-it": "^8.4.2",
+				"markdown-it-for-inline": "^0.1.1",
+				"memoize-one": "^4.0.2",
+				"microsoft-speech-browser-sdk": "^0.0.12",
+				"react": "^16.5.0",
+				"react-dom": "^16.5.0",
+				"sanitize-html": "^1.19.0",
+				"url-search-params-polyfill": "^5.0.0",
+				"web-speech-cognitive-services": "^4.0.0",
+				"whatwg-fetch": "^3.0.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
+			}
+		},
+		"botframework-webchat-component": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/botframework-webchat-component/-/botframework-webchat-component-4.3.0.tgz",
+			"integrity": "sha512-9D9jvafAg8RO7BxHP4JaWINK8IUxAKfGwcliMPYYaSRz8CEV0cxCzuiYAMRpKoz5RijzQVKDPk8VOnW5Ut4p2g==",
+			"requires": {
+				"adaptivecards": "~1.1.2",
+				"botframework-webchat-core": "4.3.0",
+				"bytes": "^3.0.0",
+				"classnames": "^2.2.6",
+				"glamor": "^2.20.40",
+				"memoize-one": "^3.1.1",
+				"react-dictate-button": "^1.1.3",
+				"react-film": "~1.1.2",
+				"react-redux": "^5.0.7",
+				"react-say": "^1.1.1",
+				"react-scroll-to-bottom": "~1.3.1",
+				"redux": "^4.0.0",
+				"sanitize-html": "^1.18.2",
+				"simple-update-in": "^1.3.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+					"integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+				}
+			}
+		},
+		"botframework-webchat-core": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/botframework-webchat-core/-/botframework-webchat-core-4.3.0.tgz",
+			"integrity": "sha512-0FcQPTl5dYKIqrNIIEmGrzXz5xEUn9/0LfHi1Jq2tFva8GjV2xvxBy51+a/w1cgrq5cATBcMzZfoR6/Uph2Lmg==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"jsonwebtoken": "^8.3.0",
+				"math-random": "^1.0.4",
+				"mime": "^2.3.1",
+				"redux": "^4.0.0",
+				"redux-promise-middleware": "^5.1.1",
+				"redux-saga": "^0.16.0",
+				"simple-update-in": "^1.3.0"
+			},
+			"dependencies": {
+				"math-random": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+					"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+				}
+			}
+		},
+		"bowser": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+			"integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2472,6 +2586,11 @@
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
 			}
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -2788,6 +2907,11 @@
 					}
 				}
 			}
+		},
+		"classnames": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
 			"version": "4.2.1",
@@ -3189,6 +3313,15 @@
 						"supports-color": "^5.5.0"
 					}
 				}
+			}
+		},
+		"css-in-js-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+			"integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+			"requires": {
+				"hyphenate-style-name": "^1.0.2",
+				"isobject": "^3.0.1"
 			}
 		},
 		"css-loader": {
@@ -3786,6 +3919,14 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
 		"domutils": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -3854,6 +3995,14 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3892,6 +4041,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -4358,10 +4515,20 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
+		"event-as-promise": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/event-as-promise/-/event-as-promise-1.0.5.tgz",
+			"integrity": "sha512-z/WIlyou7oTvXBjm5YYjfklr2d8gUWtx8b5GAcrIs1n1D35f7NIK0CrcYSXbY3VYikG9bUan+wScPyGXL/NH4A=="
+		},
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
 			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+		},
+		"events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
 		},
 		"eventsource": {
 			"version": "0.1.6",
@@ -4897,6 +5064,27 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"figgy-pudding": {
@@ -5987,6 +6175,18 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"glamor": {
+			"version": "2.20.40",
+			"resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+			"integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+			"requires": {
+				"fbjs": "^0.8.12",
+				"inline-style-prefixer": "^3.0.6",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.5.10",
+				"through": "^2.3.8"
+			}
+		},
 		"glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -6287,6 +6487,14 @@
 			"resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
 			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
+		"hoist-non-react-statics": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+			"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+			"requires": {
+				"react-is": "^16.7.0"
+			}
+		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -6402,6 +6610,26 @@
 				"pretty-error": "^2.0.2",
 				"tapable": "^1.0.0",
 				"util.promisify": "1.0.0"
+			}
+		},
+		"htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"requires": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+				}
 			}
 		},
 		"http-deceiver": {
@@ -6732,6 +6960,11 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
+		"hyphenate-style-name": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+			"integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6846,6 +7079,15 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"inline-style-prefixer": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+			"integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+			"requires": {
+				"bowser": "^1.7.3",
+				"css-in-js-utils": "^2.0.0"
+			}
 		},
 		"inquirer": {
 			"version": "6.2.0",
@@ -7219,6 +7461,15 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -8017,6 +8268,23 @@
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
+		"jsonwebtoken": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"requires": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -8034,6 +8302,25 @@
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 			"requires": {
 				"array-includes": "^3.0.3"
+			}
+		},
+		"jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"requires": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"killable": {
@@ -8093,6 +8380,14 @@
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"linkify-it": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
+			"integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+			"requires": {
+				"uc.micro": "^1.0.1"
 			}
 		},
 		"load-json-file": {
@@ -8202,15 +8497,65 @@
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+		},
+		"lodash.mergewith": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -8320,6 +8665,23 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"markdown-it": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~1.1.1",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			}
+		},
+		"markdown-it-for-inline": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz",
+			"integrity": "sha1-Q18jFvW15o4UUM+iJC8rjVmtx18="
+		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -8340,6 +8702,11 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
 			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
 		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+		},
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -8354,9 +8721,9 @@
 			}
 		},
 		"memoize-one": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+			"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -8456,6 +8823,11 @@
 				"parse-glob": "^3.0.4",
 				"regex-cache": "^0.4.2"
 			}
+		},
+		"microsoft-speech-browser-sdk": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.12.tgz",
+			"integrity": "sha512-JYIR/WpaCyV1wk+4ff3kSJMqJFehbeApzG9CJxR+mN3z+4hFKGB/D5GaFsdN5WtRvnrekzUYSOv2nljMQb3Nwg=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",
@@ -8686,6 +9058,15 @@
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
 			"requires": {
 				"lower-case": "^1.1.1"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-forge": {
@@ -10780,6 +11161,14 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
 		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
+		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -11124,6 +11513,23 @@
 				}
 			}
 		},
+		"react-dictate-button": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.1.3.tgz",
+			"integrity": "sha512-4Od7sTAEIvPKpZbpy1tCv7qqfRNwLnZom9hrLnNvr1FIWjSOYC94ekAP8S5kevqnVaFvSqwFisCmjd3uLmvsrA==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"glamor": "^2.20.40",
+				"memoize-one": "^4.0.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
+			}
+		},
 		"react-dom": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.0.tgz",
@@ -11139,6 +11545,57 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
 			"integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ=="
+		},
+		"react-film": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/react-film/-/react-film-1.1.2.tgz",
+			"integrity": "sha512-E6wkN9Ar/uD1VquM93Gw9om4PlVVH3UsljI9H8zYMCh9sQJwRTh1kJPFC5pJl/XkYDAw7RHurHMLc7MHz8T82A==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"glamor": "^2.20.40"
+			}
+		},
+		"react-is": {
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+		},
+		"react-lifecycles-compat": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+		},
+		"react-redux": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+			"integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"hoist-non-react-statics": "^3.1.0",
+				"invariant": "^2.2.4",
+				"loose-envify": "^1.1.0",
+				"prop-types": "^15.6.1",
+				"react-is": "^16.6.0",
+				"react-lifecycles-compat": "^3.0.0"
+			}
+		},
+		"react-say": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/react-say/-/react-say-1.1.1.tgz",
+			"integrity": "sha512-R+XfFQjpwlD48miC0AAb6DZDq4h5DkKFnqQFi/83wpO73isfYx+wuPU6PodzRGP4rF+/6nibnKc2V328ifiALA==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"event-as-promise": "^1.0.3",
+				"glamor": "^2.20.40",
+				"memoize-one": "^4.0.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
+			}
 		},
 		"react-scripts": {
 			"version": "2.1.1",
@@ -11195,6 +11652,24 @@
 				"workbox-webpack-plugin": "3.6.3"
 			}
 		},
+		"react-scroll-to-bottom": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/react-scroll-to-bottom/-/react-scroll-to-bottom-1.3.1.tgz",
+			"integrity": "sha512-lkQcQOkp1voJzKQSuxkOiqfSOVAQfABspLOPw75c/PiwqqKro0SnJSV3Nay0QjuV/oONfnqMDChlL1XwxdcBCw==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"glamor": "^2.20.40",
+				"memoize-one": "^4.0.2",
+				"simple-update-in": "^1.4.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
+			}
+		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -11231,6 +11706,16 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				}
+			}
+		},
+		"readable-stream": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+			"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			}
 		},
 		"readdirp": {
@@ -11530,6 +12015,32 @@
 			"requires": {
 				"minimatch": "3.0.4"
 			}
+		},
+		"redux": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+			"integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"symbol-observable": "^1.2.0"
+			},
+			"dependencies": {
+				"symbol-observable": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+				}
+			}
+		},
+		"redux-promise-middleware": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-5.1.1.tgz",
+			"integrity": "sha512-YC1tiheU28Hgmtu5HHMLiuveLgjL1aCJWsSnwquMiZBcj5i/J9qVLt6vgOnb0Gz37y4deJ/rjiNt7l6Dh+Z8lA=="
+		},
+		"redux-saga": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.2.tgz",
+			"integrity": "sha512-iIjKnRThI5sKPEASpUvySemjzwqwI13e3qP7oLub+FycCRDysLSAOwt958niZW6LhxfmS6Qm1BzbU70w/Koc4w=="
 		},
 		"regenerate": {
 			"version": "1.4.0",
@@ -11902,6 +12413,14 @@
 				"aproba": "^1.1.1"
 			}
 		},
+		"rxjs": {
+			"version": "5.5.12",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+			"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+			"requires": {
+				"symbol-observable": "1.0.1"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -12196,6 +12715,65 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"sanitize-html": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz",
+			"integrity": "sha512-BpxXkBoAG+uKCHjoXFmox6kCSYpnulABoGcZ/R3QyY9ndXbIM5S94eOr1IqnzTG8TnbmXaxWoDDzKC5eJv7fEQ==",
+			"requires": {
+				"chalk": "^2.4.1",
+				"htmlparser2": "^3.10.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.mergewith": "^4.6.1",
+				"postcss": "^7.0.5",
+				"srcset": "^1.0.0",
+				"xtend": "^4.0.1"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.14",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							},
+							"dependencies": {
+								"supports-color": {
+									"version": "5.5.0",
+									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+									"requires": {
+										"has-flag": "^3.0.0"
+									}
+								}
+							}
+						}
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -12538,6 +13116,11 @@
 				}
 			}
 		},
+		"simple-update-in": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.4.0.tgz",
+			"integrity": "sha512-gb8cWM8KxvF0TbBSFagp0Bw13dk5HBjBVLx8N8pXg4CcVyLiEuu3xxYHLfFEZRn+bYjMCkxjEB8upbWmAVOIyQ=="
+		},
 		"sisteransi": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -12866,6 +13449,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"srcset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+			"integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+			"requires": {
+				"array-uniq": "^1.0.2",
+				"number-is-nan": "^1.0.0"
+			}
 		},
 		"sshpk": {
 			"version": "1.15.2",
@@ -13199,6 +13791,11 @@
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
+		},
+		"symbol-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
@@ -13563,6 +14160,16 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
+		"ua-parser-js": {
+			"version": "0.7.19",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -13890,6 +14497,11 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"url-search-params-polyfill": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.1.0.tgz",
+			"integrity": "sha512-yjFY7uw2xRf9e8Mg4ZVkZwtp8dMCC4cbBkEIZiTDpuSY2WJ9+Quw0wRhxncv32qaMQwmBQT+P847rO8PrFhhDA=="
+		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -14027,6 +14639,25 @@
 			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"web-speech-cognitive-services": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.0.tgz",
+			"integrity": "sha512-cUe9EQPKpkCZpxj6XHL8mQv9+PPDX0eErXKtflbVuQnQ9PggXpmUQVXTu4jfK2rFxnX2i6QYnxHlEcgl6dk60g==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"event-as-promise": "^1.0.5",
+				"events": "^3.0.0",
+				"memoize-one": "^4.0.0",
+				"simple-update-in": "^1.2.0"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+				}
 			}
 		},
 		"webidl-conversions": {

--- a/samples/12.customization-minimizable-web-chat/package.json
+++ b/samples/12.customization-minimizable-web-chat/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://microsoft.github.io/BotFramework-WebChat/12.customization-minimizable-web-chat/",
   "dependencies": {
     "botframework-webchat": ">= 0.0.0-0",
-    "memoize-one": "^4.0.2",
+    "memoize-one": "^5.0.2",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-scripts": "2.1.1"


### PR DESCRIPTION
Fixes #1837 
Fixes #1643 

- End collision of external styles like Bootstrap by changing the `.row` class in Web Chat to `.webchat__row`
- Bump `memoize-one` 