### PR TITLE
Fix Azure locale in embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added handling of reconnection, by [@compulim](https://github.com/compulim), in PR [#1880](https://github.com/Microsoft/BotFramework-WebChat/pull/1880)
+- Added embed page, by [@compulim](https://github.com/compulim), in PR [#1910](https://github.com/Microsoft/BotFramework-WebChat/pull/1910) and PR [#1928](https://github.com/Microsoft/BotFramework-WebChat/pull/1928)
 
 ### Fixed
 - Fix [#1423](https://github.com/Microsoft/BotFramework-WebChat/issues/1423). Added sample for hosting WebChat in Angular, by [@omarsourour](https://github.com/omarsourour) in PR [#1813](https://github.com/Microsoft/BotFramework-WebChat/pull/1813)

--- a/packages/embed/src/locale.js
+++ b/packages/embed/src/locale.js
@@ -1,4 +1,6 @@
 // Supported Azure language as of 2019-04-25
+// The first part is language (localization), the second part is regional format (internationalization)
+
 // en.en-us
 // cs.cs-cz
 // de.de-de

--- a/packages/embed/src/locale.js
+++ b/packages/embed/src/locale.js
@@ -1,28 +1,93 @@
-const AZURE_LOCALE_PATTERN = /^([a-z]{2})(-([a-z]+))?\.([a-z]{2})-([a-z]{2})$/;
-const JAVASCRIPT_LOCALE_PATTERN = /^([a-z]{2})(-([A-Za-z]+))?$/;
+// Supported Azure language as of 2019-04-25
+// en.en-us
+// cs.cs-cz
+// de.de-de
+// es.es-es
+// fr.fr-fr
+// hu.hu-hu
+// it.it-it
+// ja.ja-jp
+// ko.ko-kr
+// nl.nl-nl
+// pl.pl-pl
+// pt-br.pt-br
+// pt-pt.pt-pt
+// ru.ru-ru
+// sv.sv-se
+// tr.tr-tr
+// zh-hans.zh-cn
+// zh-hant.zh-tw
+
+const AZURE_LOCALE_PATTERN = /^(([a-z]{2})(-[a-z]{2,})?)\.([a-z]{2})/;
+const JAVASCRIPT_LOCALE_PATTERN = /^([a-z]{2})-([A-Z]{2,})?$/;
+
+const AZURE_LOCALE_MAPPING = {
+  cs: 'cs-CZ',
+  de: 'de-DE',
+  en: 'en-US',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  hu: 'hu-HU',
+  it: 'it-IT',
+  ja: 'ja-JP',
+  ko: 'ko-KR',
+  nl: 'nl-NL',
+  pl: 'pl-PL',
+  'pt-br': 'pt-BR',
+  'pt-pt': 'pt-PT',
+  ru: 'ru-RU',
+  sv: 'sv-SE',
+  tr: 'tr-TR',
+  'zh-hans': 'zh-HANS',
+  'zh-hant': 'zh-HANT'
+};
 
 function normalize(language) {
   const azureLocaleMatch = AZURE_LOCALE_PATTERN.exec(language);
   const javaScriptLocaleMatch = JAVASCRIPT_LOCALE_PATTERN.exec(language);
+  let result;
 
   if (javaScriptLocaleMatch) {
-    return language;
+    result = language;
   } else if (azureLocaleMatch) {
-    return `${ azureLocaleMatch[4] }-${ azureLocaleMatch[5].toUpperCase() }`;
-  } else {
-    return 'en';
+    result = AZURE_LOCALE_MAPPING[azureLocaleMatch[1]];
   }
+
+  return result || 'en-US';
 }
 
 function toAzureLocale(language) {
+  switch (language) {
+    case 'fr':
+      // This is for Firefox, which default French to "fr" instead of "fr-FR".
+      return 'fr.fr-fr';
+
+    case 'pt-BR':
+      return 'pt-br.pt-br';
+
+    case 'pt-PT':
+      return 'pt-pt.pt-pt';
+
+    case 'zh-CN':
+    case 'zh-SG':
+      return `zh-hans.${ language.toLowerCase() }`;
+
+    case 'zh-HANS':
+      return 'zh-hans.zh-cn';
+
+    case 'zh-HANT':
+      return 'zh-hant.zh-tw';
+
+    case 'zh-HK':
+    case 'zh-MO':
+    case 'zh-TW':
+      return `zh-hant.${ language.toLowerCase() }`;
+  }
+
   const match = JAVASCRIPT_LOCALE_PATTERN.exec(language);
 
   if (match) {
-    if (match[2]) {
-      return `${ match[1] }.${ match[1] }-${ match[3].toLowerCase() }`;
-    } else {
-      return match[1];
-    }
+    return `${ match[1] }.${ match[1] }-${ match[2].toLowerCase() }`;
   }
 }
 

--- a/packages/embed/src/locale.spec.js
+++ b/packages/embed/src/locale.spec.js
@@ -65,11 +65,11 @@ test('Normalizing "tr.tr-tr"', () => {
 });
 
 test('Normalizing "zh-hans.zh-cn"', () => {
-  expect(normalize('zh-hans.zh-cn')).toBe('zh-Hans');
+  expect(normalize('zh-hans.zh-cn')).toBe('zh-HANS');
 });
 
 test('Normalizing "zh-hant.zh-tw"', () => {
-  expect(normalize('zh-hant.zh-tw')).toBe('zh-Hant');
+  expect(normalize('zh-hant.zh-tw')).toBe('zh-HANT');
 });
 
 test('Normalizing "en.zh-hk" should become "en-US"', () => {

--- a/packages/embed/src/locale.spec.js
+++ b/packages/embed/src/locale.spec.js
@@ -4,16 +4,81 @@ test('Normalizing "en.en-us"', () => {
   expect(normalize('en.en-us')).toBe('en-US');
 });
 
-test('Normalize "ja.ja-jp"', () => {
+test('Normalizing "cs.cs-cz"', () => {
+  expect(normalize('cs.cs-cz')).toBe('cs-CZ');
+});
+
+test('Normalizing "de.de-de"', () => {
+  expect(normalize('de.de-de')).toBe('de-DE');
+});
+
+test('Normalizing "es.es-es"', () => {
+  expect(normalize('es.es-es')).toBe('es-ES');
+});
+
+test('Normalizing "fr.fr-fr"', () => {
+  expect(normalize('fr.fr-fr')).toBe('fr-FR');
+});
+
+test('Normalizing "hu.hu-hu"', () => {
+  expect(normalize('hu.hu-hu')).toBe('hu-HU');
+});
+
+test('Normalizing "it.it-it"', () => {
+  expect(normalize('it.it-it')).toBe('it-IT');
+});
+
+test('Normalizing "ja.ja-jp"', () => {
   expect(normalize('ja.ja-jp')).toBe('ja-JP');
 });
 
-test('Normalize "zh-hant.zh-hk"', () => {
-  expect(normalize('zh-hant.zh-hk')).toBe('zh-HK');
+test('Normalizing "ko.ko-kr"', () => {
+  expect(normalize('ko.ko-kr')).toBe('ko-KR');
+});
+
+test('Normalizing "nl.nl-nl"', () => {
+  expect(normalize('nl.nl-nl')).toBe('nl-NL');
+});
+
+test('Normalizing "pl.pl-pl"', () => {
+  expect(normalize('pl.pl-pl')).toBe('pl-PL');
+});
+
+test('Normalizing "pt-br.pt-br"', () => {
+  expect(normalize('pt-br.pt-br')).toBe('pt-BR');
+});
+
+test('Normalizing "pt-pt.pt-pt"', () => {
+  expect(normalize('pt-pt.pt-pt')).toBe('pt-PT');
+});
+
+test('Normalizing "ru.ru-ru"', () => {
+  expect(normalize('ru.ru-ru')).toBe('ru-RU');
+});
+
+test('Normalizing "sv.sv-se"', () => {
+  expect(normalize('sv.sv-se')).toBe('sv-SE');
+});
+
+test('Normalizing "tr.tr-tr"', () => {
+  expect(normalize('tr.tr-tr')).toBe('tr-TR');
+});
+
+test('Normalizing "zh-hans.zh-cn"', () => {
+  expect(normalize('zh-hans.zh-cn')).toBe('zh-Hans');
+});
+
+test('Normalizing "zh-hant.zh-tw"', () => {
+  expect(normalize('zh-hant.zh-tw')).toBe('zh-Hant');
+});
+
+test('Normalizing "en.zh-hk" should become "en-US"', () => {
+  expect(normalize('en.zh-hk')).toBe('en-US');
+
 });
 
 test('Normalizing "en"', () => {
-  expect(normalize('en')).toBe('en');
+  expect(normalize('en')).toBe('en-US');
 });
 
 test('Normalizing "zh-HK"', () => {
@@ -21,19 +86,51 @@ test('Normalizing "zh-HK"', () => {
 });
 
 test('Normalizing "*"', () => {
-  expect(normalize('*')).toBe('en');
+  expect(normalize('*')).toBe('en-US');
 });
 
 test('Convert "en-US" to Azure locale', () => {
   expect(toAzureLocale('en-US')).toBe('en.en-us');
 });
 
-test('Convert "en" to Azure locale', () => {
-  expect(toAzureLocale('en')).toBe('en');
+test('Convert "fr" to Azure locale', () => {
+  expect(toAzureLocale('fr')).toBe('fr.fr-fr');
+});
+
+test('Convert "pt-BR" to Azure locale', () => {
+  expect(toAzureLocale('pt-BR')).toBe('pt-br.pt-br');
+});
+
+test('Convert "pt-PT" to Azure locale', () => {
+  expect(toAzureLocale('pt-PT')).toBe('pt-pt.pt-pt');
+});
+
+test('Convert "zh-CN" to Azure locale', () => {
+  expect(toAzureLocale('zh-CN')).toBe('zh-hans.zh-cn');
+});
+
+test('Convert "zh-Hant" to Azure locale', () => {
+  expect(toAzureLocale('zh-Hant')).toBe('zh-hant.zh-tw');
+});
+
+test('Convert "zh-Hans" to Azure locale', () => {
+  expect(toAzureLocale('zh-Hans')).toBe('zh-hans.zh-cn');
 });
 
 test('Convert "zh-HK" to Azure locale', () => {
-  expect(toAzureLocale('zh-HK')).toBe('zh.zh-hk');
+  expect(toAzureLocale('zh-HK')).toBe('zh-hant.zh-hk');
+});
+
+test('Convert "zh-MO" to Azure locale', () => {
+  expect(toAzureLocale('zh-MO')).toBe('zh-hant.zh-mo');
+});
+
+test('Convert "zh-SG" to Azure locale', () => {
+  expect(toAzureLocale('zh-SG')).toBe('zh-hans.zh-sg');
+});
+
+test('Convert "zh-TW" to Azure locale', () => {
+  expect(toAzureLocale('zh-TW')).toBe('zh-hant.zh-tw');
 });
 
 test('Convert "*" to Azure locale', () => {

--- a/packages/embed/src/locale.spec.js
+++ b/packages/embed/src/locale.spec.js
@@ -109,12 +109,12 @@ test('Convert "zh-CN" to Azure locale', () => {
   expect(toAzureLocale('zh-CN')).toBe('zh-hans.zh-cn');
 });
 
-test('Convert "zh-Hant" to Azure locale', () => {
-  expect(toAzureLocale('zh-Hant')).toBe('zh-hant.zh-tw');
+test('Convert "zh-HANT" to Azure locale', () => {
+  expect(toAzureLocale('zh-HANT')).toBe('zh-hant.zh-tw');
 });
 
-test('Convert "zh-Hans" to Azure locale', () => {
-  expect(toAzureLocale('zh-Hans')).toBe('zh-hans.zh-cn');
+test('Convert "zh-HANS" to Azure locale', () => {
+  expect(toAzureLocale('zh-HANS')).toBe('zh-hans.zh-cn');
 });
 
 test('Convert "zh-HK" to Azure locale', () => {


### PR DESCRIPTION
Azure locale is like `en.en-us`, or `zh-hant.zh-hk`.

The first part is language (localization), and the second part is regional format (internationalization).

We should only use the first part and ignore the second part. But this is tricky because 80% of the time, the first part is not in the `en-US` format. So we need to custom mapping for them.

To be cultural neutral, we prefer `zh-HANS` instead of `zh-CN`.