### PR TITLE
Remove a layer of URLSearchParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added handling of reconnection, by [@compulim](https://github.com/compulim), in PR [#1880](https://github.com/Microsoft/BotFramework-WebChat/pull/1880)
-- Added embed page, by [@compulim](https://github.com/compulim), in PR [#1910](https://github.com/Microsoft/BotFramework-WebChat/pull/1910) and PR [#1928](https://github.com/Microsoft/BotFramework-WebChat/pull/1928)
+- Added embed page, by [@compulim](https://github.com/compulim), in PR [#1910](https://github.com/Microsoft/BotFramework-WebChat/pull/1910), PR [#1928](https://github.com/Microsoft/BotFramework-WebChat/pull/1928) and PR [#1938](https://github.com/Microsoft/BotFramework-WebChat/pull/1938)
 
 ### Fixed
 - Fix [#1423](https://github.com/Microsoft/BotFramework-WebChat/issues/1423). Added sample for hosting WebChat in Angular, by [@omarsourour](https://github.com/omarsourour) in PR [#1813](https://github.com/Microsoft/BotFramework-WebChat/pull/1813)

--- a/packages/embed/src/urlBuilder.js
+++ b/packages/embed/src/urlBuilder.js
@@ -18,9 +18,7 @@ function embedTelemetryURL(botId, { secret, token }, points) {
   return `/embed/${ botId }/telemetry?${ urlSearchParams.toString() }`
 }
 
-function legacyEmbedURL(botId, params) {
-  const urlSearchParams = new URLSearchParams(params);
-
+function legacyEmbedURL(botId, urlSearchParams) {
   return `/embed/${ botId }?${ urlSearchParams.toString() }`;
 }
 

--- a/packages/embed/src/urlBuilder.spec.js
+++ b/packages/embed/src/urlBuilder.spec.js
@@ -29,7 +29,7 @@ test('Create embed telemetry URL with secret only', () => {
 });
 
 test('Create legacy embed URL', () => {
-  const actual = legacyEmbedURL('webchat-mockbot', { s: 'secret' });
+  const actual = legacyEmbedURL('webchat-mockbot', new URLSearchParams({ s: 'secret' }));
 
   expect(actual).toBe('/embed/webchat-mockbot?s=secret');
 });


### PR DESCRIPTION
Edge fails if `new URLSearchParams(new URLSearchParams())`, but Chrome and Firefox passed.

We should remove the extra `new URLSearchParams()` here.