### PR TITLE
Link to sample fix

### DIFF
--- a/samples/15.d.backchannel-send-welcome-event/README.md
+++ b/samples/15.d.backchannel-send-welcome-event/README.md
@@ -103,7 +103,7 @@ Here is the finished `index.html`:
 
 # Further reading
 
-[`15.b.incoming-activity-event`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/15.a.incoming-activity-event) is a sample that will fire JavaScript event on all incoming activities.
+[`15.b.incoming-activity-event`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/15.b.incoming-activity-event) is a sample that will fire JavaScript event on all incoming activities.
 
 ## Full list of Web Chat hosted samples
 


### PR DESCRIPTION
## Description

Quick documentation fix - incorrect link to Incoming activity event sample (from 'a' to 'b').

## Specific Changes

- link to incoming activity event sample was corrected