### PR TITLE
Use undefined for createWebSpeechPonyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1974](https://github.com/Microsoft/BotFramework-WebChat/issues/1974). Update `/docs/` folder to `/media/` and delete unused images, by [@corinagum](https://github.com/corinagum) in PR [#1975](https://github.com/Microsoft/BotFramework-WebChat/pull/1975)
 - Fix [#1969](https://github.com/Microsoft/BotFramework-WebChat/issues/1969). Move `styleSet`s related to Adaptive Cards to full bundle, by [@corinagum](https://github.com/corinagum) in PR [#1987](https://github.com/Microsoft/BotFramework-WebChat/pull/1987)
 - Fix [#1429](https://github.com/Microsoft/BotFramework-WebChat/issues/1429). Changed Markdown-it options to render newline characters correctly, by [@tdurnford](https://github.com/tdurnford) in PR [#1988](https://github.com/Microsoft/BotFramework-WebChat/pull/1988)
+- Fix [#2008](https://github.com/Microsoft/BotFramework-WebChat/issues/2008). Fixed playground due to recent eslint changes, by [@compulim](https://github.com/compulim) in PR [#2009](https://github.com/Microsoft/BotFramework-WebChat/pull/2009)
 
 ## [4.4.1] - 2019-05-02
 

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -106,6 +106,7 @@ class Dictation extends React.Component {
 
 Dictation.defaultProps = {
   disabled: false,
+  onError: undefined,
   webSpeechPonyfill: undefined
 };
 
@@ -113,7 +114,7 @@ Dictation.propTypes = {
   dictateState: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
   language: PropTypes.string.isRequired,
-  onError: PropTypes.func.isRequired,
+  onError: PropTypes.func,
   setDictateInterims: PropTypes.func.isRequired,
   setDictateState: PropTypes.func.isRequired,
   setSendBox: PropTypes.func.isRequired,

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -107,7 +107,7 @@ export default class extends React.Component {
       userAvatarInitials: 'WC',
       userID,
       username: 'Web Chat user',
-      webSpeechPonyfillFactory: null
+      webSpeechPonyfillFactory: undefined
     };
   }
 
@@ -263,7 +263,7 @@ export default class extends React.Component {
         <ReactWebChat
           activityMiddleware={ this.activityMiddleware }
           attachmentMiddleware={ this.attachmentMiddleware }
-          className={ WEB_CHAT_CSS }
+          className={ WEB_CHAT_CSS + '' }
           groupTimestamp={ groupTimestamp === 'default' ? undefined : groupTimestamp === 'false' ? false : +groupTimestamp }
           directLine={ directLine }
           disabled={ disabled }


### PR DESCRIPTION
Fixes #2008.

## Changelog Entry

- Fix [#2008](https://github.com/Microsoft/BotFramework-WebChat/issues/2008). Fixed playground due to recent eslint changes, by [@compulim](https://github.com/compulim) in PR [#2009](https://github.com/Microsoft/BotFramework-WebChat/pull/2009)

## Description

We are sending `null` to `webSpeechPonyfillFactory`. We should send `undefined`, or consider modifying our production code to accept falsy values.

## Specific Changes

- Fix `webSpeechPonyfillFactory` should not sending `null`, but `undefined`
- [x] ~Testing Added~

<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
