### PR TITLE
Should not stop after first spoken text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix [#1980](https://github.com/Microsoft/BotFramework-WebChat/issues/1980). Changed sendBoxTextArea styles to break words longer than the textarea, by [@tdurnford](https://github.com/tdurnford) in PR [#1986](https://github.com/Microsoft/BotFramework-WebChat/pull/1986)
 - Fix [#1969](https://github.com/Microsoft/BotFramework-WebChat/issues/1969). Move `styleSet`s related to Adaptive Cards to full bundle, by [@corinagum](https://github.com/corinagum) in PR [#1987](https://github.com/Microsoft/BotFramework-WebChat/pull/1987)
 - Fix [#1429](https://github.com/Microsoft/BotFramework-WebChat/issues/1429). Changed Markdown-it options to render newline characters correctly, by [@tdurnford](https://github.com/tdurnford) in PR [#1988](https://github.com/Microsoft/BotFramework-WebChat/pull/1988)
+- Fix [#1736](https://github.com/Microsoft/BotFramework-WebChat/issues/1736). Fixed only first activity in a batch is spoken, by [@compulim](https://github.com/compulim) in PR [#2016](https://github.com/Microsoft/BotFramework-WebChat/pull/2016)
 
 ## [4.4.1] - 2019-05-02
 

--- a/packages/core/src/sagas/startDictateAfterSpeakActivitySaga.js
+++ b/packages/core/src/sagas/startDictateAfterSpeakActivitySaga.js
@@ -5,14 +5,14 @@ import {
 } from 'redux-saga/effects';
 
 import { MARK_ACTIVITY } from '../actions/markActivity';
-import { ofID as activitiesOfID } from '../selectors/activities';
+import selectActivities from '../selectors/activities';
 import speakingActivity from '../definitions/speakingActivity';
 import startDictate from '../actions/startDictate';
 import whileConnected from './effects/whileConnected';
 import whileSpeakIncomingActivity from './effects/whileSpeakIncomingActivity';
 
 function* startDictateAfterAllActivitiesSpoken({ payload: { activityID } }) {
-  const activities = yield select(activitiesOfID(activityID));
+  const activities = yield select(selectActivities);
   const [spokenActivity] = activities;
 
   if (


### PR DESCRIPTION
Fixes #1736.

## Changelog Entry

- Fix [#1736](https://github.com/Microsoft/BotFramework-WebChat/issues/1736). Fixed only first activity in a batch is spoken, by [@compulim](https://github.com/compulim) in PR [#2016](https://github.com/Microsoft/BotFramework-WebChat/pull/2016)

## Description

In `startDictateAfterSpeakActivitySaga`, we are using a wrong selector.

Originally, we want to check if "all activities are spoken", but since we used a wrong selector, we was        checking "if the currently speaking activity is spoken". And of course it is, because we just set a flag on it.

## Specific Changes
- Instead of checking against "the currently spoken activity", we are checking against all activities
- ~Testing Added~
   - We don't have any test facility for speech right now