### PR TITLE
Fix MicrophoneButton style

### DIFF
--- a/packages/component/src/SendBox/MicrophoneButton.js
+++ b/packages/component/src/SendBox/MicrophoneButton.js
@@ -16,6 +16,7 @@ const { DictateState } = Constants;
 
 const ROOT_CSS = css({
   display: 'flex',
+  height: '100%',
 
   '& > .sr-only': {
     color: 'transparent',


### PR DESCRIPTION
## Fixes #2007 Misalignment of speech button
https://github.com/microsoft/BotFramework-WebChat/issues/2007

## Behavior after fixed
![image](https://user-images.githubusercontent.com/20683785/58184268-bf4a7f00-7ceb-11e9-9c1a-ce2fad4478ad.png)
![image](https://user-images.githubusercontent.com/20683785/58184650-7cd57200-7cec-11e9-96d9-96ffe6e4aeec.png)

## Behavior before fixed
![image](https://user-images.githubusercontent.com/20683785/58184329-ddb07a80-7ceb-11e9-8557-d02dabaccecc.png)
![image](https://user-images.githubusercontent.com/20683785/58184574-557ea500-7cec-11e9-9b1f-c382e208e9a8.png)

## Description
I fixed Issues #2007 .
Specifically, I added "height: '100%'," to MicrophoneButton.js as well as SendBoxButton.js.

### Reference : SendBoxButton.js
![image](https://user-images.githubusercontent.com/20683785/58184687-8ced5180-7cec-11e9-8ea2-9e5e128421c5.png)

```
return {
    backgroundColor: 'Transparent',
    border: 0,
    height: '100%',
```