### PR TITLE
Added sip protocol to sanitize html options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1829](https://github.com/microsoft/BotFramework-WebChat/issues/1829). Fixed long text not being synthesized by Cognitive Services by bumping to [`react-say@1.2.0`](https://github.com/compulim/react-say), by [@compulim](https://github.com/compulim) in PR [#2035](https://github.com/Microsoft/BotFramework-WebChat/pull/2035)
 -  Fix [#1982](https://github.com/Microsoft/BotFramework-WebChat/issues/1982). Move to prettier! by [@corinagum](https://github.com/corinagum) in PR [#2038](https://github.com/Microsoft/BotFramework-WebChat/pull/2038)
 -  Fix [#1429](https://github.com/Microsoft/BotFramework-WebChat/issues/1429). Added markdown string preprocessing so the renderer will respect CRLF carriage returns (\r\n), by [@tdurnford](https://github.com/tdurnford) in PR [#2055](https://github.com/Microsoft/BotFramework-WebChat/pull/2055)
--  Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize html options, by [@tdurnford](https://github.com/tdurnford) in PR [#2061](https://github.com/Microsoft/BotFramework-WebChat/pull/2061)
+-  Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize HTML options, by [@tdurnford](https://github.com/tdurnford) in PR [#2061](https://github.com/Microsoft/BotFramework-WebChat/pull/2061)
 
 ## [4.4.1] - 2019-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1829](https://github.com/microsoft/BotFramework-WebChat/issues/1829). Fixed long text not being synthesized by Cognitive Services by bumping to [`react-say@1.2.0`](https://github.com/compulim/react-say), by [@compulim](https://github.com/compulim) in PR [#2035](https://github.com/Microsoft/BotFramework-WebChat/pull/2035)
 -  Fix [#1982](https://github.com/Microsoft/BotFramework-WebChat/issues/1982). Move to prettier! by [@corinagum](https://github.com/corinagum) in PR [#2038](https://github.com/Microsoft/BotFramework-WebChat/pull/2038)
 -  Fix [#1429](https://github.com/Microsoft/BotFramework-WebChat/issues/1429). Added markdown string preprocessing so the renderer will respect CRLF carriage returns (\r\n), by [@tdurnford](https://github.com/tdurnford) in PR [#2055](https://github.com/Microsoft/BotFramework-WebChat/pull/2055)
+-  Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize html options, by [@tdurnford](https://github.com/tdurnford) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ## [4.4.1] - 2019-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1829](https://github.com/microsoft/BotFramework-WebChat/issues/1829). Fixed long text not being synthesized by Cognitive Services by bumping to [`react-say@1.2.0`](https://github.com/compulim/react-say), by [@compulim](https://github.com/compulim) in PR [#2035](https://github.com/Microsoft/BotFramework-WebChat/pull/2035)
 -  Fix [#1982](https://github.com/Microsoft/BotFramework-WebChat/issues/1982). Move to prettier! by [@corinagum](https://github.com/corinagum) in PR [#2038](https://github.com/Microsoft/BotFramework-WebChat/pull/2038)
 -  Fix [#1429](https://github.com/Microsoft/BotFramework-WebChat/issues/1429). Added markdown string preprocessing so the renderer will respect CRLF carriage returns (\r\n), by [@tdurnford](https://github.com/tdurnford) in PR [#2055](https://github.com/Microsoft/BotFramework-WebChat/pull/2055)
--  Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize html options, by [@tdurnford](https://github.com/tdurnford) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize html options, by [@tdurnford](https://github.com/tdurnford) in PR [#2061](https://github.com/Microsoft/BotFramework-WebChat/pull/2061)
 
 ## [4.4.1] - 2019-05-02
 

--- a/packages/bundle/src/__tests__/renderMarkdown.spec.js
+++ b/packages/bundle/src/__tests__/renderMarkdown.spec.js
@@ -54,4 +54,11 @@ describe('renderMarkdown', () => {
       '<pre><code>{\n  "hello": "World!"\n}\n</code></pre>\n'
     );
   });
+
+  it('should render sip protocol links correctly', () => {
+    const styleSet = { options: { markdownRespectCRLF: true } };
+    expect(renderMarkdown(`[example@test.com](sip:example@test.com)`, styleSet)).toBe(
+      '<p><a href="sip:example@test.com" target="_blank">example@test.com</a></p>\n'
+    );
+  });
 });

--- a/packages/bundle/src/renderMarkdown.js
+++ b/packages/bundle/src/renderMarkdown.js
@@ -9,6 +9,7 @@ const SANITIZE_HTML_OPTIONS = {
     a: ['href', 'name', 'target', 'title'],
     img: ['alt', 'src']
   },
+  allowedSchemes: ['http', 'https', 'ftp', 'mailto', 'sip'],
   allowedTags: [
     'a',
     'b',


### PR DESCRIPTION
Fixes #2057 

## Changelog Entry
Fix [#2057](https://github.com/Microsoft/BotFramework-WebChat/issues/2057). Added sip protocol to sanitize html options, by [@tdurnford](https://github.com/tdurnford) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)

## Specific Changes

Added the sip protocol to the default allowedSchemes in Web Chat's [sanitize html options](https://github.com/microsoft/BotFramework-WebChat/blob/f1247b9a39fe83f1622f1c70003481e7ffd5ec78/packages/bundle/src/renderMarkdown.js#L7).

```javascript 
const SANITIZE_HTML_OPTIONS = {
  ...
  allowedSchemes : ['http', 'https', 'ftp', 'mailto', 'sip'],
};
```

 ---	

 -  [x] Testing Added	
