### PR TITLE
Timeouts increased for 4 tests.

### DIFF
--- a/__tests__/cardActionMiddleware.js
+++ b/__tests__/cardActionMiddleware.js
@@ -64,15 +64,15 @@ test('card action "signin"', async () => {
     }
   });
 
-  await driver.wait(uiConnected(), timeouts.directLine);
+  await driver.wait(uiConnected(), timeouts.postActivity);
   await pageObjects.sendMessageViaSendBox('oauth', { waitForSend: true });
 
-  await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+  await driver.wait(minNumActivitiesShown(2), timeouts.postActivity);
   const openUrlButton = await driver.findElement(By.css('[role="log"] ul > li button'));
 
   await openUrlButton.click();
-  await driver.wait(minNumActivitiesShown(4), timeouts.directLine);
-  await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
+  await driver.wait(minNumActivitiesShown(4), timeouts.postActivity);
+  await driver.wait(allOutgoingActivitiesSent(), timeouts.postActivity);
 
   // When the "Sign in" button is clicked, the focus move to it, need to blur it.
   await driver.executeScript(() => {

--- a/__tests__/carousel.js
+++ b/__tests__/carousel.js
@@ -15,10 +15,10 @@ describe('carousel without avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver();
 
-    await driver.wait(uiConnected(), timeouts.directLine);
+    await driver.wait(uiConnected(), timeouts.postActivity);
     await pageObjects.sendMessageViaSendBox('carousel', { waitForSend: true });
 
-    await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+    await driver.wait(minNumActivitiesShown(2), timeouts.postActivity);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);
@@ -115,10 +115,10 @@ describe('carousel with avatar initials', () => {
   test('4 attachments and no message', async () => {
     const { driver, pageObjects } = await setupWebDriver({ props: WEB_CHAT_PROPS });
 
-    await driver.wait(uiConnected(), timeouts.directLine);
+    await driver.wait(uiConnected(), timeouts.postActivity);
     await pageObjects.sendMessageViaSendBox('carousel', { waitForSend: true });
 
-    await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+    await driver.wait(minNumActivitiesShown(2), timeouts.postActivity);
     await driver.wait(allImagesLoaded(), timeouts.fetch);
 
     expect(await driver.takeScreenshot()).toMatchImageSnapshot(imageSnapshotOptions);

--- a/__tests__/markdown.js
+++ b/__tests__/markdown.js
@@ -14,7 +14,7 @@ test('hero card', async () => {
   await pageObjects.sendMessageViaSendBox('herocard', { waitForSend: true });
 
   await driver.wait(allImagesLoaded(), timeouts.fetch);
-  await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+  await driver.wait(minNumActivitiesShown(2), timeouts.postActivity);
   // Wait for transcript to scroll to bottom
   await driver.sleep(1000);
 


### PR DESCRIPTION
These 4 tests were timing out at 5000 ms. I "hacked" it by setting the timeout to 30000 ms. I.e. changed from timeouts.directline to timeouts.postActivity. That fixed the timeout errors in the build.

I assume you would prefer a nicer way to set the timeouts than this. For example, define a new constant, timeouts.directLineLong = 30000.

Let me know what you would like and I will fix it.

Thanks.
--Bruce