### PR TITLE
Increase timeouts.directLine from 5000 to 15000

### DIFF
--- a/__tests__/constants.json
+++ b/__tests__/constants.json
@@ -5,7 +5,7 @@
     }
   },
   "timeouts": {
-    "directLine": 5000,
+    "directLine": 15000,
     "fetch": 2500,
     "navigation": 10000,
     "postActivity": 30000,


### PR DESCRIPTION
Fixes 4 tests timing out in BotFramework-WebChat-CI-PR.
