### PR TITLE
Security: lodash version 4.17.10 references bumped to 4.17.11.

### DIFF
--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -179,7 +179,7 @@
       "requires": {
         "@babel/types": "^7.1.3",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -1434,7 +1434,7 @@
         "@babel/types": "^7.1.3",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1487,7 +1487,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -3056,7 +3056,7 @@
       "requires": {
         "chalk": "^2.4.1",
         "date-fns": "^1.23.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "read-pkg": "^4.0.1",
         "rxjs": "6.2.2",
         "spawn-command": "^0.0.2-1",
@@ -5339,13 +5339,13 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash.clonedeep": {


### PR DESCRIPTION
Response to security alert https://github.com/microsoft/BotFramework-WebChat/network/alerts
https://github.com/microsoft/BotFramework-WebChat/network/alert/packages/component/package-lock.json/lodash/open
