### PR TITLE
Fix Speech speaking the title, subtitle, and text of cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1926](https://github.com/microsoft/BotFramework-WebChat/issues/1926). Fixed scroll stickiness issue when submitting an Adaptive Card form with suggested actions opened, by [@compulim](https://github.com/compulim) in PR [#2107](https://github.com/microsoft/BotFramework-WebChat/pull/2107)
 -  Fix [#2106](https://github.com/Microsoft/BotFramework-WebChat/issues/2016). Fix AdaptiveCardHostConfig warning associated with the CommonCard component, by [@tdurnford](https://github.com/tdurnford) in PR [#2108](https://github.com/Microsoft/BotFramework-WebChat/pull/2108)
 -  Fix [#2110](https://github.com/Microsoft/BotFramework-WebChat/issues/2110). Fixed sendBox input/textarea background color issue, by [@tdurnford](https://github.com/johndoe) in PR [#2111](https://github.com/Microsoft/BotFramework-WebChat/pull/2111)
--  Fix [#2104](https://github.com/Microsoft/BotFramework-WebChat/issues/2104). Remove deprecated `/master/webchat**.js links from samples, by [@corinagum](https://github.com/corinagum) in PR [#2105](https://github.com/Microsoft/BotFramework-WebChat/pull/2105)
+-  Fix [#2104](https://github.com/Microsoft/BotFramework-WebChat/issues/2104). Remove deprecated `/master/webchat\*\*.js links from samples, by [@corinagum](https://github.com/corinagum) in PR [#2105](https://github.com/Microsoft/BotFramework-WebChat/pull/2105)
+-  Fix [#1863](https://github.com/Microsoft/BotFramework-WebChat/issues/1863). Remove title, subtitle, and text of cards from being spoken by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Samples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2106](https://github.com/Microsoft/BotFramework-WebChat/issues/2016). Fix AdaptiveCardHostConfig warning associated with the CommonCard component, by [@tdurnford](https://github.com/tdurnford) in PR [#2108](https://github.com/Microsoft/BotFramework-WebChat/pull/2108)
 -  Fix [#2110](https://github.com/Microsoft/BotFramework-WebChat/issues/2110). Fixed sendBox input/textarea background color issue, by [@tdurnford](https://github.com/johndoe) in PR [#2111](https://github.com/Microsoft/BotFramework-WebChat/pull/2111)
 -  Fix [#2104](https://github.com/Microsoft/BotFramework-WebChat/issues/2104). Remove deprecated `/master/webchat\*\*.js links from samples, by [@corinagum](https://github.com/corinagum) in PR [#2105](https://github.com/Microsoft/BotFramework-WebChat/pull/2105)
--  Fix [#1863](https://github.com/Microsoft/BotFramework-WebChat/issues/1863). Remove title, subtitle, and text of cards from being spoken by [@corinagum](https://github.com/corinagum) in PR [#XXX](https://github.com/Microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#1863](https://github.com/Microsoft/BotFramework-WebChat/issues/1863). Remove title, subtitle, and text of cards from being spoken by [@corinagum](https://github.com/corinagum) in PR [#2118](https://github.com/Microsoft/BotFramework-WebChat/pull/2118)
 
 ### Samples
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
@@ -90,7 +90,6 @@ export default class AdaptiveCardBuilder {
         textblock[prop] = template[prop];
       }
 
-      this.card.speak += `${text} `;
       textblock.text = text;
 
       container.addItem(textblock);

--- a/packages/component/src/Activity/Speak.js
+++ b/packages/component/src/Activity/Speak.js
@@ -39,13 +39,8 @@ const Speak = ({ activity, markAsSpoken, selectVoice, styleSet }) => {
   const lines = [speak || text];
 
   attachments.forEach(({ content: { speak } = {}, contentType }) => {
-    switch (contentType) {
-      case 'application/vnd.microsoft.card.adaptive':
-        lines.push(speak);
-        break;
-
-      default:
-        break;
+    if (contentType === 'application/vnd.microsoft.card.adaptive') {
+      lines.push(speak);
     }
   });
 

--- a/packages/component/src/Activity/Speak.js
+++ b/packages/component/src/Activity/Speak.js
@@ -38,24 +38,10 @@ const Speak = ({ activity, markAsSpoken, selectVoice, styleSet }) => {
 
   const lines = [speak || text];
 
-  attachments.forEach(({ content: { speak, subtitle, text, title } = {}, contentType }) => {
+  attachments.forEach(({ content: { speak } = {}, contentType }) => {
     switch (contentType) {
       case 'application/vnd.microsoft.card.adaptive':
         lines.push(speak);
-        break;
-
-      case 'application/vnd.microsoft.card.animation':
-      case 'application/vnd.microsoft.card.audio':
-      case 'application/vnd.microsoft.card.video':
-      case 'application/vnd.microsoft.card.hero':
-      case 'application/vnd.microsoft.card.thumbnail':
-        lines.push(title);
-        lines.push(subtitle);
-        lines.push(text);
-        break;
-
-      case 'application/vnd.microsoft.card.receipt':
-        lines.push(title);
         break;
 
       default:

--- a/samples/01.a.getting-started-full-bundle/README.md
+++ b/samples/01.a.getting-started-full-bundle/README.md
@@ -48,7 +48,7 @@ We'll start by adding the CDN to the head of a blank `index.html` template.
 ```
 
 > This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed. https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
-Next, the code to render Web Chat must be added to the body. Note that MockBot uses **tokens** rather than the **Direct Line secret**.
+> Next, the code to render Web Chat must be added to the body. Note that MockBot uses **tokens** rather than the **Direct Line secret**.
 
 > It is **never recommended** to put the Direct Line secret in the browser or client app. To learn more about secrets and tokens for Direct Line, visit [this tutorial on authentication](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication).
 

--- a/samples/03.b.host-with-angular/README.md
+++ b/samples/03.b.host-with-angular/README.md
@@ -38,9 +38,7 @@ We'll start by adding the CDN to the head of our Angular application's `index.ht
 …
 ```
 
-
-  > This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed. https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
-
+> This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed. https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
 
 To create a WebChat container, create an empty `div` in the component's template file and assign it a template variable to reference it from this component's `.ts` file.
 


### PR DESCRIPTION
## Changelog Entry
-  Fix [#1863](https://github.com/Microsoft/BotFramework-WebChat/issues/1863). Remove title, subtitle, and text of cards from being spoken by [@corinagum](https://github.com/corinagum) in PR [#2118](https://github.com/Microsoft/BotFramework-WebChat/pull/2118)

## Description

In v3 of Web Chat, Speech did not read out title, subtitle, and text of cards. This fix brings parity back to that version. Previously, Speech in v4 would speak all three and cause 'doubling' of spoken text.


-  [ ] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
No testing added since this is a speech change.