### PR TITLE
Fix observeOnce to unsubscribe properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1863](https://github.com/Microsoft/BotFramework-WebChat/issues/1863). Remove title, subtitle, and text of cards from being spoken by [@corinagum](https://github.com/corinagum) in PR [#2118](https://github.com/Microsoft/BotFramework-WebChat/pull/2118)
 -  Fix [#2134](https://github.com/Microsoft/BotFramework-WebChat/issues/2134). Added `azure-pipelines.yml` for embed package, by [@compulim](https://github.com/compulim) in PR [#2135](https://github.com/Microsoft/BotFramework-WebChat/pull/2135)
 -  Fix [#2106](https://github.com/Microsoft/BotFramework-WebChat/issues/2016). Fix `AdaptiveCardHostConfig` warning associated with the `CommonCard` component, by [@tdurnford](https://github.com/tdurnford) in PR [#2108](https://github.com/Microsoft/BotFramework-WebChat/pull/2108)
+-  Fix [#1872](https://github.com/Microsoft/BotFramework-WebChat/issues/1872). Fixed `observeOnce` to unsubscribe properly, by [@compulim](https://github.com/compulim) in PR [#2140](https://github.com/Microsoft/BotFramework-WebChat/pull/2140)
 
 ### Samples
 

--- a/packages/core/src/__tests__/observeOnce.spec.js
+++ b/packages/core/src/__tests__/observeOnce.spec.js
@@ -1,0 +1,71 @@
+import { runSaga } from 'redux-saga';
+import { all, call } from 'redux-saga/effects';
+
+import observeOnce from '../sagas/effects/observeOnce';
+
+describe('observeOnce', () => {
+  let inputOutput;
+  let observable;
+  let onError;
+  let onNext;
+  let unsubscribe;
+
+  beforeEach(() => {
+    unsubscribe = jest.fn();
+    observable = {
+      subscribe: jest.fn((...args) => {
+        onNext = args[0];
+        onError = args[1];
+
+        return {
+          unsubscribe
+        };
+      })
+    };
+
+    inputOutput = {
+      subscribe() {
+        return () => {};
+      }
+    };
+  });
+
+  test('should unsubscribe after first next', () =>
+    new Promise((resolve, reject) => {
+      runSaga(inputOutput, function*() {
+        try {
+          const [result] = yield all([observeOnce(observable), call(() => onNext('Hello, World!'))]);
+
+          expect(observable.subscribe).toHaveBeenCalledTimes(1);
+          expect(result).toBe('Hello, World!');
+          expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }));
+
+  test('should unsubscribe and throw after first error', () =>
+    new Promise((resolve, reject) => {
+      runSaga(inputOutput, function*() {
+        try {
+          try {
+            yield all([observeOnce(observable), call(() => onError(new Error('Hello, World!')))]);
+
+            reject('Should not succeed');
+          } catch (err) {
+            expect(() => {
+              throw err;
+            }).toThrow('Hello, World!');
+            expect(unsubscribe).toHaveBeenCalledTimes(1);
+          }
+
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }));
+});

--- a/packages/core/src/__tests__/observeOnce.spec.js
+++ b/packages/core/src/__tests__/observeOnce.spec.js
@@ -6,6 +6,7 @@ import observeOnce from '../sagas/effects/observeOnce';
 describe('observeOnce', () => {
   let inputOutput;
   let observable;
+  let onComplete;
   let onError;
   let onNext;
   let unsubscribe;
@@ -16,6 +17,7 @@ describe('observeOnce', () => {
       subscribe: jest.fn((...args) => {
         onNext = args[0];
         onError = args[1];
+        onComplete = args[2];
 
         return {
           unsubscribe
@@ -61,6 +63,23 @@ describe('observeOnce', () => {
             }).toThrow('Hello, World!');
             expect(unsubscribe).toHaveBeenCalledTimes(1);
           }
+
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }));
+
+  test('should unsubscribe after complete', () =>
+    new Promise((resolve, reject) => {
+      runSaga(inputOutput, function*() {
+        try {
+          const [result] = yield all([observeOnce(observable), call(() => onComplete())]);
+
+          expect(observable.subscribe).toHaveBeenCalledTimes(1);
+          expect(result).toBeUndefined();
+          expect(unsubscribe).toHaveBeenCalledTimes(1);
 
           resolve();
         } catch (err) {

--- a/packages/core/src/__tests__/observeOnce.spec.js
+++ b/packages/core/src/__tests__/observeOnce.spec.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [0, 1, 2] }] */
+
 import { runSaga } from 'redux-saga';
 import { all, call } from 'redux-saga/effects';
 
@@ -15,9 +17,7 @@ describe('observeOnce', () => {
     unsubscribe = jest.fn();
     observable = {
       subscribe: jest.fn((...args) => {
-        onNext = args[0];
-        onError = args[1];
-        onComplete = args[2];
+        [onNext, onError, onComplete] = args;
 
         return {
           unsubscribe
@@ -27,7 +27,7 @@ describe('observeOnce', () => {
 
     inputOutput = {
       subscribe() {
-        return () => {};
+        return () => 0;
       }
     };
   });
@@ -56,7 +56,7 @@ describe('observeOnce', () => {
           try {
             yield all([observeOnce(observable), call(() => onError(new Error('Hello, World!')))]);
 
-            reject('Should not succeed');
+            reject(new Error('Should not succeed'));
           } catch (err) {
             expect(() => {
               throw err;

--- a/packages/core/src/sagas/effects/observeOnce.js
+++ b/packages/core/src/sagas/effects/observeOnce.js
@@ -8,7 +8,7 @@ export default function observeOnceEffect(observable) {
       return yield call(
         () =>
           new Promise((resolve, reject) => {
-            subscription = observable.subscribe(resolve, reject);
+            subscription = observable.subscribe(resolve, reject, resolve);
           })
       );
     } finally {

--- a/packages/core/src/sagas/effects/observeOnce.js
+++ b/packages/core/src/sagas/effects/observeOnce.js
@@ -8,13 +8,11 @@ export default function observeOnceEffect(observable) {
       return yield call(
         () =>
           new Promise((resolve, reject) => {
-            observable.subscribe(resolve, reject);
+            subscription = observable.subscribe(resolve, reject);
           })
       );
     } finally {
-      if (subscription) {
-        subscription.unsubscribe();
-      }
+      subscription && subscription.unsubscribe();
     }
   });
 }


### PR DESCRIPTION
Fixes #1872.

## Changelog Entry

-  Fix [#1872](https://github.com/Microsoft/BotFramework-WebChat/issues/1872). Fixed `observeOnce` to unsubscribe properly, by [@compulim](https://github.com/compulim) in PR [#2140](https://github.com/Microsoft/BotFramework-WebChat/pull/2140)

## Description

Our `observeOnce` saga effect does not unsubscribe itself from the observable. New code added to unsubscribe after first `onNext`, `onError`, or `onCompleted`.

## Specific Changes

Modified `packages/core/src/sagas/effects/observeOnce.js` to unsubscribe regardless of conditions.

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
