### PR TITLE
Expecting input should only turn on microphone if via microphone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2134](https://github.com/microsoft/BotFramework-WebChat/issues/2134). Added `azure-pipelines.yml` for embed package, by [@compulim](https://github.com/compulim) in PR [#2135](https://github.com/microsoft/BotFramework-WebChat/pull/2135)
 -  Fix [#2106](https://github.com/microsoft/BotFramework-WebChat/issues/2016). Fix `AdaptiveCardHostConfig` warning associated with the `CommonCard` component, by [@tdurnford](https://github.com/tdurnford) in PR [#2108](https://github.com/microsoft/BotFramework-WebChat/pull/2108)
 -  Fix [#1872](https://github.com/microsoft/BotFramework-WebChat/issues/1872). Fixed `observeOnce` to unsubscribe properly, by [@compulim](https://github.com/compulim) in PR [#2140](https://github.com/microsoft/BotFramework-WebChat/pull/2140)
--  Fix [#2022](https://github.com/microsoft/BotFramework-WebChat/issues/2022). Fixed `"expectingInput"` in `inputHint` is not respected, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum) in PR [#2149](https://github.com/microsoft/BotFramework-WebChat/pull/2149)
+-  Fix [#2022](https://github.com/microsoft/BotFramework-WebChat/issues/2022). Fixed `"expectingInput"` in `inputHint` is not respected, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum) in PR [#2149](https://github.com/microsoft/BotFramework-WebChat/pull/2149) and PR [#2166](https://github.com/microsoft/BotFramework-WebChat/pull/2166)
 
 ### Samples
 

--- a/__tests__/inputHint.js
+++ b/__tests__/inputHint.js
@@ -1,0 +1,165 @@
+import { timeouts } from './constants.json';
+
+import isRecognizingSpeech from './setup/pageObjects/isRecognizingSpeech';
+import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
+import speechSynthesisPending from './setup/conditions/speechSynthesisPending';
+import uiConnected from './setup/conditions/uiConnected';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+describe('input hint', () => {
+  describe('of expectingInput', async () => {
+    test('should turn on microphone if initiated via microphone', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaMicrophone('hint expecting input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      await driver.wait(speechSynthesisPending(), timeouts.ui);
+      await pageObjects.startSpeechSynthesize();
+      await pageObjects.endSpeechSynthesize();
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeTruthy();
+    });
+
+    test('should not turn on microphone if initiated via typing', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaMicrophone('hint expecting input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+  });
+
+  describe('of acceptingInput', async () => {
+    test('should not turn on microphone if initiated via microphone', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaMicrophone('hint accepting input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      await driver.wait(speechSynthesisPending(), timeouts.ui);
+      await pageObjects.startSpeechSynthesize();
+      await pageObjects.endSpeechSynthesize();
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+
+    test('should not turn on microphone if initiated via typing', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaSendBox('hint accepting input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+  });
+
+  describe('of ignoringInput', async () => {
+    test('should turn off microphone if initiated via microphone', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaMicrophone('hint ignoring input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      await driver.wait(speechSynthesisPending(), timeouts.ui);
+      await pageObjects.startSpeechSynthesize();
+      await pageObjects.endSpeechSynthesize();
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+
+    test('should turn off microphone if initiated via typing', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaSendBox('hint ignoring input');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+  });
+
+  describe('of undefined', async () => {
+    test('should not turn on microphone if initiated via microphone', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaMicrophone('hint undefined');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      await driver.wait(speechSynthesisPending(), timeouts.ui);
+      await pageObjects.startSpeechSynthesize();
+      await pageObjects.endSpeechSynthesize();
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+
+    test('should not turn on microphone if initiated via typing', async () => {
+      const { driver, pageObjects } = await setupWebDriver({
+        props: {
+          webSpeechPonyfillFactory: () => window.WebSpeechMock
+        }
+      });
+
+      await driver.wait(uiConnected(), timeouts.directLine);
+
+      await pageObjects.sendMessageViaSendBox('hint undefined');
+
+      await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+      expect(isRecognizingSpeech(driver)).resolves.toBeFalsy();
+    });
+  });
+});

--- a/__tests__/setup/pageObjects/index.js
+++ b/__tests__/setup/pageObjects/index.js
@@ -7,6 +7,7 @@ import hasPendingSpeechSynthesisUtterance from './hasPendingSpeechSynthesisUtter
 import isRecognizingSpeech from './isRecognizingSpeech';
 import pingBot from './pingBot';
 import putSpeechRecognitionResult from './putSpeechRecognitionResult';
+import sendMessageViaMicrophone from './sendMessageViaMicrophone';
 import sendMessageViaSendBox from './sendMessageViaSendBox';
 import startSpeechSynthesize from './startSpeechSynthesize';
 
@@ -30,6 +31,7 @@ export default function pageObjects(driver) {
       isRecognizingSpeech,
       pingBot,
       putSpeechRecognitionResult,
+      sendMessageViaMicrophone,
       sendMessageViaSendBox,
       startSpeechSynthesize
     },

--- a/__tests__/setup/pageObjects/sendMessageViaMicrophone.js
+++ b/__tests__/setup/pageObjects/sendMessageViaMicrophone.js
@@ -1,0 +1,16 @@
+import { timeouts } from '../../constants.json';
+import allOutgoingActivitiesSent from '../conditions/allOutgoingActivitiesSent';
+import getMicrophoneButton from './getMicrophoneButton';
+import putSpeechRecognitionResult from './putSpeechRecognitionResult';
+import speechRecognitionStarted from '../conditions/speechRecognitionStarted';
+
+export default async function sendMessageViaMicrophone(driver, text, { waitForSend = true } = {}) {
+  const microphoneButton = await getMicrophoneButton(driver);
+
+  await microphoneButton.click();
+
+  await driver.wait(speechRecognitionStarted(), timeouts.ui);
+  await putSpeechRecognitionResult(driver, 'recognize', text);
+
+  waitForSend && (await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine));
+}

--- a/__tests__/setup/pageObjects/sendMessageViaSendBox.js
+++ b/__tests__/setup/pageObjects/sendMessageViaSendBox.js
@@ -4,7 +4,7 @@ import { timeouts } from '../../constants.json';
 import allOutgoingActivitiesSent from '../conditions/allOutgoingActivitiesSent';
 import getSendBoxTextBox from './getSendBoxTextBox';
 
-export default async function sendMessageViaSendBox(driver, text, { waitForSend = true }) {
+export default async function sendMessageViaSendBox(driver, text, { waitForSend = true } = {}) {
   const input = await getSendBoxTextBox(driver);
 
   await input.sendKeys(text, Key.RETURN);

--- a/__tests__/speech.js
+++ b/__tests__/speech.js
@@ -1,12 +1,8 @@
-import { imageSnapshotOptions, timeouts } from './constants.json';
+import { timeouts } from './constants.json';
 
-import allOutgoingActivitiesSent from './setup/conditions/allOutgoingActivitiesSent.js';
 import minNumActivitiesShown from './setup/conditions/minNumActivitiesShown';
-import speechRecognitionStarted, {
-  negate as speechRecognitionNotStarted
-} from './setup/conditions/speechRecognitionStarted';
+import { negate as speechRecognitionNotStarted } from './setup/conditions/speechRecognitionStarted';
 import speechSynthesisPending, { negate as speechSynthesisNotPending } from './setup/conditions/speechSynthesisPending';
-import uiConnected from './setup/conditions/uiConnected';
 
 // selenium-webdriver API doc:
 // https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
@@ -14,36 +10,6 @@ import uiConnected from './setup/conditions/uiConnected';
 jest.setTimeout(timeouts.test);
 
 describe('speech recognition', () => {
-  test('should send on successful recognition', async () => {
-    const { driver, pageObjects } = await setupWebDriver({
-      props: {
-        webSpeechPonyfillFactory: () => window.WebSpeechMock
-      }
-    });
-
-    await driver.wait(uiConnected(), timeouts.directLine);
-
-    const microphoneButton = await pageObjects.getMicrophoneButton();
-
-    await microphoneButton.click();
-
-    await driver.wait(speechRecognitionStarted(), timeouts.ui);
-    await pageObjects.putSpeechRecognitionResult('recognize', 'Hello, World!');
-    await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
-    await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
-    await driver.wait(speechSynthesisPending(), timeouts.ui);
-
-    const utterance = await pageObjects.startSpeechSynthesize();
-
-    expect(utterance).toHaveProperty(
-      'text',
-      `Unknown command: I don't know Hello, World!. You can say \"help\" to learn more.`
-    );
-
-    await pageObjects.endSpeechSynthesize();
-    await driver.wait(speechRecognitionStarted(), timeouts.ui);
-  });
-
   test('should not start recognition after typing on keyboard while synthesizing', async () => {
     const { driver, pageObjects } = await setupWebDriver({
       props: {
@@ -51,14 +17,9 @@ describe('speech recognition', () => {
       }
     });
 
-    const microphoneButton = await pageObjects.getMicrophoneButton();
+    await pageObjects.sendMessageViaMicrophone('Hello, World!');
 
-    await microphoneButton.click();
-
-    await driver.wait(speechRecognitionStarted(), timeouts.ui);
-    await pageObjects.putSpeechRecognitionResult('recognize', 'Hello, World!');
     await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
-    await driver.wait(allOutgoingActivitiesSent(), timeouts.directLine);
     await driver.wait(speechSynthesisPending(), timeouts.ui);
 
     const utterance = await pageObjects.startSpeechSynthesize();

--- a/packages/core/src/sagas/speakActivityAndStartDictateOnIncomingActivityFromOthersSaga.js
+++ b/packages/core/src/sagas/speakActivityAndStartDictateOnIncomingActivityFromOthersSaga.js
@@ -19,7 +19,7 @@ function* speakActivityAndStartDictateOnIncomingActivityFromOthers({ userID }) {
       yield put(markActivity(activity, 'speak', true));
     }
 
-    if (activity.inputHint === 'expectingInput' || (shouldSpeak && activity.inputHint !== 'ignoringInput')) {
+    if (shouldSpeak && activity.inputHint === 'expectingInput') {
       yield put(startDictate());
     } else if (activity.inputHint === 'ignoringInput') {
       yield put(stopDictate());


### PR DESCRIPTION
Fixes #2022.

## Changelog Entry

-  Fix [#2022](https://github.com/microsoft/BotFramework-WebChat/issues/2022). Fixed `"expectingInput"` in `inputHint` is not respected, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum) in PR [#2149](https://github.com/microsoft/BotFramework-WebChat/pull/2149) and PR [#2166](https://github.com/microsoft/BotFramework-WebChat/pull/2166)

## Description

Please follow this table to determines when microphone should turn on based on `activity.inputHint`.

| Input hint      | Previously via | Should turn on microphone     |
| --------------- | -------------- | ----------------------------- |
| Expecting input | Microphone     | Yes                           |
| Expecting input | Keyboard       | No                            |
| Accepting input | Microphone     | No                            |
| Accepting input | Keyboard       | No                            |
| Ignoring input  | Microphone     | No, should explictly turn off |
| Ignoring input  | Keyboard       | No, should explictly turn off |
| Undefined       | Microphone     | No                            |
| Undefined       | Keyboard       | No                            |

## Specific Changes

- Modified `speakActivityAndStartDictateOnIncomingActivityFromOthersSaga.js` to only turn on microphone if `inputHint === expectingInput` and previously on microphone
- Removed a test from `__tests__/speech.js` because of behavior change and is covered by new test

---

-  [x] Testing Added

