### PR TITLE
[v3] Bump dependencies for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ before_deploy:
 
 deploy:
 - provider: npm
-  api_key:
-    secure: "Mgt7i6P52nq77RdBUlcS1EBosxW6Qd6mM86A6RLQKzNJTWMW6GM0YhrqVHT6HQxrqcTRvuSHxJtOKyLoLPou2lWCZbsSy0ANb8tEJcurTF4lLvcTgMN+G5YD74F4RHRyLNW6rHDKvYvBl4iDLE6rW/B6Ew6uORMdlzJOJzjw075/7AoJIjB60f/Hf2aAx3q0wcWxlPyTqh6YD2mJ1GaiflTalxkYalr/Xh3bevrP4I2XyZV1vaCJqDZvrUVlYfSOCJRyBUSrCemkc6nkSTwdbY38L4k7ilrNgm5QfugoaKIPe600WCy4uPp0woz796rdurppsKeLmMSCKKu2mIqz1CT6mf8CR8hQAzGhKqsF0Rydjz6N/OF2XnFbtPZzu/FQJYED9H1UViUAHXsw528Ul9NSseMCVIZirRT+ysIB8Ny9oBddfRyifxnv2T9Zorm7y1V0nrmMXgCrZIvfgvOVXqij7euC4dgnOG4w0eG/Vd1EW87rskpZswV8gx/7ZsVOY/1NFDVxBi//EBSBOLctOSoZF8snT0+Duvw5Id3pXKvqm+ffI19xBe8Bua64fMg7dHWqZN/ixjTqeySBAYDPtRx/0wBSBwMIDh/Syux+fgjXpqf87HJc3vbjAXyuwPyO9mlblpm02JrZmG8Yik1krVvnLWzvqGqrmVKsLKmndn8="
+  api_key: $NPM_TOKEN
   email: "botframework@microsoft.com"
   on:
     branch: v3

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -444,9 +444,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
           "dev": true
         }
       }
@@ -1186,9 +1186,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -2162,11 +2162,18 @@
           "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
         },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
         "ms": {


### PR DESCRIPTION
Fixes vulnerabilities on `debug` and `lodash`.

## Changelog Entry

- Bump dependencies for test, by [@compulim](https://github.com/compulim] in PR [#2200](https://github.com/microsoft/BotFramework-WebChat/pull/2200)
   - [`debug@2.6.9`](https://www.npmjs.com/package/debug)
   - [`lodash@4.17.14`](https://www.npmjs.com/package/lodash)

## Description

Fix vulnerabilities for `debug` and `lodash`, which we depends on them in `test` folder.

## Specific Changes

- Run `npm audit fix`
- Manually force `vo` to use `debug@2.6.9` instead of `debug@2.2.0`
   - `vo` was not published in the last 3 years

---

-  [x] ~Testing Added~
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
