### PR TITLE
iOS : Clear "leftover text" post mobile dictation on iOS

### DIFF
--- a/packages/component/src/SendBox/TextBox.js
+++ b/packages/component/src/SendBox/TextBox.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { Context as TypeFocusSinkContext } from '../Utils/TypeFocusSink';
 import { localize } from '../Localization/Localize';
 import connectToWebChat from '../connectToWebChat';
+import { POST_ACTIVITY_PENDING } from '../../../core/src/actions/postActivity';
 
 const ROOT_CSS = css({
   display: 'flex',
@@ -17,12 +18,24 @@ const ROOT_CSS = css({
 
 const connectSendTextBox = (...selectors) =>
   connectToWebChat(
-    ({ disabled, focusSendBox, language, scrollToEnd, sendBoxValue, setSendBox, stopDictate, submitSendBox }) => ({
+    ({
+      disabled,
+      focusSendBox,
+      language,
+      scrollToEnd,
+      sendBoxValue,
+      setSendBox,
+      stopDictate,
+      submitSendBox,
+      store
+    }) => ({
       disabled,
       language,
       onChange: ({ target: { value } }) => {
-        setSendBox(value);
-        stopDictate();
+        if (store.getState().lastAction !== POST_ACTIVITY_PENDING) {
+          setSendBox(value);
+          stopDictate();
+        }
       },
       onKeyPress: event => {
         const { key, shiftKey } = event;

--- a/packages/component/src/SendBox/TextBox.js
+++ b/packages/component/src/SendBox/TextBox.js
@@ -5,8 +5,8 @@ import React from 'react';
 
 import { Context as TypeFocusSinkContext } from '../Utils/TypeFocusSink';
 import { localize } from '../Localization/Localize';
-import connectToWebChat from '../connectToWebChat';
 import { POST_ACTIVITY_PENDING } from '../../../core/src/actions/postActivity';
+import connectToWebChat from '../connectToWebChat';
 
 const ROOT_CSS = css({
   display: 'flex',
@@ -26,8 +26,8 @@ const connectSendTextBox = (...selectors) =>
       sendBoxValue,
       setSendBox,
       stopDictate,
-      submitSendBox,
-      store
+      store,
+      submitSendBox
     }) => ({
       disabled,
       language,

--- a/packages/core/src/reducer.ts
+++ b/packages/core/src/reducer.ts
@@ -6,6 +6,7 @@ import connectivityStatus from './reducers/connectivityStatus';
 import dictateInterims from './reducers/dictateInterims';
 import dictateState from './reducers/dictateState';
 import language from './reducers/language';
+import lastAction from './reducers/lastAction';
 import readyState from './reducers/readyState';
 import referenceGrammarID from './reducers/referenceGrammarID';
 import sendBoxValue from './reducers/sendBoxValue';
@@ -13,7 +14,6 @@ import sendTimeout from './reducers/sendTimeout';
 import sendTypingIndicator from './reducers/sendTypingIndicator';
 import shouldSpeakIncomingActivity from './reducers/shouldSpeakIncomingActivity';
 import suggestedActions from './reducers/suggestedActions';
-import lastAction from './reducers/lastAction';
 
 export default combineReducers({
   activities,
@@ -22,6 +22,7 @@ export default combineReducers({
   dictateInterims,
   dictateState,
   language,
+  lastAction,
   readyState,
   referenceGrammarID,
   sendBoxValue,
@@ -29,7 +30,6 @@ export default combineReducers({
   sendTypingIndicator,
   shouldSpeakIncomingActivity,
   suggestedActions,
-  lastAction,
 
   // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
   sendTyping: sendTypingIndicator

--- a/packages/core/src/reducer.ts
+++ b/packages/core/src/reducer.ts
@@ -13,6 +13,7 @@ import sendTimeout from './reducers/sendTimeout';
 import sendTypingIndicator from './reducers/sendTypingIndicator';
 import shouldSpeakIncomingActivity from './reducers/shouldSpeakIncomingActivity';
 import suggestedActions from './reducers/suggestedActions';
+import lastAction from './reducers/lastAction';
 
 export default combineReducers({
   activities,
@@ -28,6 +29,7 @@ export default combineReducers({
   sendTypingIndicator,
   shouldSpeakIncomingActivity,
   suggestedActions,
+  lastAction,
 
   // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
   sendTyping: sendTypingIndicator

--- a/packages/core/src/reducers/lastAction.js
+++ b/packages/core/src/reducers/lastAction.js
@@ -1,9 +1,11 @@
 /* eslint-disable default-case */
+
 import { POST_ACTIVITY_FULFILLED, POST_ACTIVITY_PENDING, POST_ACTIVITY_REJECTED } from '../actions/postActivity';
 
 const DEFAULT_STATE = '';
 
 // eslint-disable-next-line no-unused-vars
+
 export default function(state = DEFAULT_STATE, { payload, type }) {
   switch (type) {
     case POST_ACTIVITY_FULFILLED:

--- a/packages/core/src/reducers/lastAction.js
+++ b/packages/core/src/reducers/lastAction.js
@@ -1,0 +1,16 @@
+/* eslint-disable default-case */
+import { POST_ACTIVITY_FULFILLED, POST_ACTIVITY_PENDING, POST_ACTIVITY_REJECTED } from '../actions/postActivity';
+
+const DEFAULT_STATE = '';
+
+// eslint-disable-next-line no-unused-vars
+export default function(state = DEFAULT_STATE, { payload, type }) {
+  switch (type) {
+    case POST_ACTIVITY_FULFILLED:
+    case POST_ACTIVITY_PENDING:
+    case POST_ACTIVITY_REJECTED:
+      state = type;
+  }
+
+  return state;
+}


### PR DESCRIPTION
## Description

Post Dictation when we click on Send Button, the textbox never gets cleared. This happens specifically on iOS. 

Steps: 
1) Use dictation to add the text to textbox
2) Click on Send Button
3) You will observe the Textbox doesn't get cleared. This is only observedon iOS

My Analysis:
1) When we click on sendButton, it called SubmitSendBox action and soon after that it called SetSendBox to clear the textbox
2) In SendButton component, we call a focusIndex() so that textbox remains in focus after Submit. This focusIndex() on iOS triggers onChange() in Textbox component even before the activity is submitted.

## Specific Changes

Don't call onchange untill the activity is fulfilled/posted

