### PR TITLE
Fix microphone button not re-enabled after error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1954](https://github.com/microsoft/BotFramework-WebChat/issues/1954). Estimate clock skew and adjust timestamp for outgoing activity, by [@compulim](https://github.com/compulim) in PR [#2208](https://github.com/microsoft/BotFramework-WebChat/pull/2208)
 -  Fix [#2193](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix Adaptive Card/attachments do not get read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2150](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix timestamps read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
-
+-  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1954](https://github.com/microsoft/BotFramework-WebChat/issues/1954). Estimate clock skew and adjust timestamp for outgoing activity, by [@compulim](https://github.com/compulim) in PR [#2208](https://github.com/microsoft/BotFramework-WebChat/pull/2208)
 -  Fix [#2193](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix Adaptive Card/attachments do not get read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2150](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix timestamps read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
--  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)
 
 ### Added
 

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -6,7 +6,7 @@ import React from 'react';
 import connectToWebChat from './connectToWebChat';
 
 const {
-  DictateState: { DICTATING, IDLE, STARTING }
+  DictateState: { DICTATING, IDLE, STARTING, STOPPING }
 } = Constants;
 
 class Dictation extends React.Component {
@@ -57,7 +57,7 @@ class Dictation extends React.Component {
   handleError(event) {
     const { dictateState, onError, setDictateState, stopDictate } = this.props;
 
-    if (dictateState === DICTATING || dictateState === STARTING) {
+    if (dictateState === DICTATING || dictateState === STARTING || dictateState === STOPPING) {
       setDictateState(IDLE);
       stopDictate();
 

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -57,12 +57,10 @@ class Dictation extends React.Component {
   handleError(event) {
     const { dictateState, onError, setDictateState, stopDictate } = this.props;
 
-    if (dictateState === DICTATING || dictateState === STARTING || dictateState === STOPPING) {
-      setDictateState(IDLE);
-      stopDictate();
+    dictateState !== IDLE && setDictateState(IDLE);
+    (dictateState === DICTATING || dictateState === STARTING) && stopDictate();
 
-      onError && onError(event);
-    }
+    onError && onError(event);
   }
 
   render() {


### PR DESCRIPTION
Fixes #2240.

## Changelog Entry

-  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)

## Description

Microphone button is permanently disabled after receiving and error from speech engine. The error could be:

- Muted microphone
- No recognizable speech
- Network error

Instead, the microphone button should not be permanently disabled.

## Specific Changes

- Set `dictateState` to `IDLE` even if currently is `STOPPING`

---

-  [x] ~Testing Added~
   - Tests are not added, we will do it in #2158
