### PR TITLE
Prime speech synthesis on microphone button click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings related prop types, by [@compulim](https://github.com/compulim) in PR [#2253](https://github.com/microsoft/BotFramework-WebChat/pull/2253)
 -  Fix [#2248](https://github.com/microsoft/BotFramework-WebChat/issues/2248). Remove download links from user-uploaded attachment without thumbnails, by [@compulim](https://github.com/compulim) in PR [#2262](https://github.com/microsoft/BotFramework-WebChat/pull/2262)
 -  Fix [#2245](https://github.com/microsoft/BotFramework-WebChat/issues/2245). Fix speech synthesis not working on Safari by priming the engine on the first microphone button click, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
+-  Fix [#1514](https://github.com/microsoft/BotFramework-WebChat/issues/1514). Added reference grammar ID when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
+-  Fix [#1515](https://github.com/microsoft/BotFramework-WebChat/issues/1515). Added dynamic phrases when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`mixin-deep@1.3.2`](https://www.npmjs.com/package/mixin-deep)
    - [`set-value@2.0.1`](https://www.npmjs.com/package/set-value)
    - [`union-value@1.0.1`](https://www.npmjs.com/package/union-value)
+- Bumps [`web-speech-cognitive-services@4.0.1-master.45e7796`](https://www.npmjs.com/package/web-speech-cognitive-services), by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 
 ### Fixed
 
@@ -58,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)
 -  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings related prop types, by [@compulim](https://github.com/compulim) in PR [#2253](https://github.com/microsoft/BotFramework-WebChat/pull/2253)
 -  Fix [#2248](https://github.com/microsoft/BotFramework-WebChat/issues/2248). Remove download links from user-uploaded attachment without thumbnails, by [@compulim](https://github.com/compulim) in PR [#2262](https://github.com/microsoft/BotFramework-WebChat/pull/2262)
--  Fix [#2245](https://github.com/microsoft/BotFramework-WebChat/issues/2245). Fix speech synthesis not working on Safari by priming the engine on the first microphone button click, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2245](https://github.com/microsoft/BotFramework-WebChat/issues/2245). Fix speech synthesis not working on Safari by priming the engine on the first microphone button click, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)
 -  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings related prop types, by [@compulim](https://github.com/compulim) in PR [#2253](https://github.com/microsoft/BotFramework-WebChat/pull/2253)
 -  Fix [#2248](https://github.com/microsoft/BotFramework-WebChat/issues/2248). Remove download links from user-uploaded attachment without thumbnails, by [@compulim](https://github.com/compulim) in PR [#2262](https://github.com/microsoft/BotFramework-WebChat/pull/2262)
+-  Fix [#2245](https://github.com/microsoft/BotFramework-WebChat/issues/2245). Fix speech synthesis not working on Safari by priming the engine on the first microphone button click, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`mixin-deep@1.3.2`](https://www.npmjs.com/package/mixin-deep)
    - [`set-value@2.0.1`](https://www.npmjs.com/package/set-value)
    - [`union-value@1.0.1`](https://www.npmjs.com/package/union-value)
-- Bumps [`web-speech-cognitive-services@4.0.1-master.45e7796`](https://www.npmjs.com/package/web-speech-cognitive-services), by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
+- Bumps [`web-speech-cognitive-services@4.0.1-master.c12f923`](https://www.npmjs.com/package/web-speech-cognitive-services), by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 
 ### Fixed
 

--- a/__tests__/setup/web/mockWebSpeech.js
+++ b/__tests__/setup/web/mockWebSpeech.js
@@ -221,6 +221,12 @@ const SPEECH_SYNTHESIS_VOICES = [
 ];
 
 class SpeechSynthesis extends EventTarget {
+  constructor() {
+    super();
+
+    this.ignoreFirstUtteranceIfEmpty = true;
+  }
+
   getVoices() {
     return SPEECH_SYNTHESIS_VOICES;
   }
@@ -238,7 +244,13 @@ class SpeechSynthesis extends EventTarget {
   }
 
   speak(utterance) {
-    speechSynthesisBroker.produce(utterance);
+    // We prime the speech engine by sending an empty utterance on start.
+    // We should ignore the first utterance if it is empty.
+    if (!this.ignoreFirstUtteranceIfEmpty || utterance.text) {
+      speechSynthesisBroker.produce(utterance);
+    }
+
+    this.ignoreFirstUtteranceIfEmpty = false;
   }
 }
 

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -7148,9 +7148,9 @@
 			}
 		},
 		"web-speech-cognitive-services": {
-			"version": "4.0.1-master.45e7796",
-			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.45e7796.tgz",
-			"integrity": "sha512-zfZ00odVk1O1gI/GigHCL6x1vSAxF1jSypRyNUFtPISuMllVmXVADWQMJCCFP6xoMiB7cK5GWS2QcWqvrf8PEw==",
+			"version": "4.0.1-master.c12f923",
+			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.c12f923.tgz",
+			"integrity": "sha512-8a5xi2DE+1dD+3MJw2MonAAzB7qOTpMwaJVZ0P77e3TPds7zYveSthldgjNo2bgaAkxwYwGadKIhIy0CeGPefg==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"base64-arraybuffer": "^0.2.0",

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1289,6 +1289,14 @@
 			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0.tgz",
 			"integrity": "sha512-rfB3dr2/yNMgJHiGCFH247RtLXkKcNwhGbI1GrXSITfyqfo12esTWDLkRLe62b0oGZxPKJZo5187BY9xORZYsg=="
 		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
 		"ajv": {
 			"version": "6.9.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
@@ -1428,6 +1436,34 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"asn1.js-rfc2560": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-5.0.0.tgz",
+			"integrity": "sha512-I3bOj/If4sMFmV6Oru93DIDvdENVKVretVpVIp5fe3MACM2HasbnMvTW1fdzbUiHcmMYI+5WfBiboHkIa4j4ew==",
+			"requires": {
+				"asn1.js-rfc5280": "^3.0.0"
+			}
+		},
+		"asn1.js-rfc5280": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-3.0.0.tgz",
+			"integrity": "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg==",
+			"requires": {
+				"asn1.js": "^5.0.0"
+			},
+			"dependencies": {
+				"asn1.js": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
+					"integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+					"requires": {
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
+					}
+				}
+			}
+		},
 		"assert": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -1477,6 +1513,11 @@
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"atob": {
 			"version": "2.1.2",
@@ -1576,6 +1617,11 @@
 			"integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
 			"dev": true
 		},
+		"base64-arraybuffer": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+			"integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+		},
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -1603,8 +1649,7 @@
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-			"dev": true
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"botframework-directlinejs": {
 			"version": "0.11.4",
@@ -2648,6 +2693,19 @@
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
+			}
+		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
@@ -4051,6 +4109,30 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
+		"https-proxy-agent": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4844,6 +4926,18 @@
 				"to-regex": "^3.0.2"
 			}
 		},
+		"microsoft-cognitiveservices-speech-sdk": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.6.0.tgz",
+			"integrity": "sha512-B1z9cOQSfQxHgjnbkx4NBj5YOHz0ymUBnXYec+thgwRsfJntKfWGJEdarvEjiHr0+UkC+ejuCaFshnHgtwgphQ==",
+			"requires": {
+				"asn1.js-rfc2560": "^5.0.0",
+				"asn1.js-rfc5280": "^3.0.0",
+				"https-proxy-agent": "^2.2.1",
+				"simple-lru-cache": "0.0.2",
+				"ws": "^6.1.2"
+			}
+		},
 		"microsoft-speech-browser-sdk": {
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/microsoft-speech-browser-sdk/-/microsoft-speech-browser-sdk-0.0.12.tgz",
@@ -4867,8 +4961,7 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -6163,10 +6256,15 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"simple-lru-cache": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+			"integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+		},
 		"simple-update-in": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.4.0.tgz",
-			"integrity": "sha512-gb8cWM8KxvF0TbBSFagp0Bw13dk5HBjBVLx8N8pXg4CcVyLiEuu3xxYHLfFEZRn+bYjMCkxjEB8upbWmAVOIyQ=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-2.1.0.tgz",
+			"integrity": "sha512-rdBChoQh4CERbQhWFbnMOG0P8VYx3vhrY4Gy4//wj8x12cydKnjzpJBpOO7QQGSssuc04jgz9zsrxczjQkEtZw=="
 		},
 		"slash": {
 			"version": "2.0.0",
@@ -7050,21 +7148,36 @@
 			}
 		},
 		"web-speech-cognitive-services": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.0.tgz",
-			"integrity": "sha512-cUe9EQPKpkCZpxj6XHL8mQv9+PPDX0eErXKtflbVuQnQ9PggXpmUQVXTu4jfK2rFxnX2i6QYnxHlEcgl6dk60g==",
+			"version": "4.0.1-master.45e7796",
+			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.45e7796.tgz",
+			"integrity": "sha512-zfZ00odVk1O1gI/GigHCL6x1vSAxF1jSypRyNUFtPISuMllVmXVADWQMJCCFP6xoMiB7cK5GWS2QcWqvrf8PEw==",
 			"requires": {
-				"@babel/runtime": "^7.1.2",
+				"@babel/runtime": "^7.5.5",
+				"base64-arraybuffer": "^0.2.0",
 				"event-as-promise": "^1.0.5",
 				"events": "^3.0.0",
-				"memoize-one": "^4.0.0",
-				"simple-update-in": "^1.2.0"
+				"memoize-one": "^5.0.5",
+				"microsoft-cognitiveservices-speech-sdk": "1.6.0",
+				"simple-update-in": "^2.1.0"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
 				"memoize-one": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-					"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
+					"integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 				}
 			}
 		},
@@ -7336,6 +7449,14 @@
 			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"requires": {
 				"mkdirp": "^0.5.1"
+			}
+		},
+		"ws": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+			"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+			"requires": {
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"xtend": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^16.8.6",
     "sanitize-html": "^1.19.0",
     "url-search-params-polyfill": "^5.0.0",
-    "web-speech-cognitive-services": "4.0.1-master.45e7796",
+    "web-speech-cognitive-services": "4.0.1-master.c12f923",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^16.8.6",
     "sanitize-html": "^1.19.0",
     "url-search-params-polyfill": "^5.0.0",
-    "web-speech-cognitive-services": "^4.0.0",
+    "web-speech-cognitive-services": "4.0.1-master.45e7796",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -1,16 +1,5 @@
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
-function injectReferenceGrammarID({ SpeechGrammarList, SpeechRecognition }, referenceGrammarID) {
-  return class extends SpeechRecognition {
-    start() {
-      this.grammars = new SpeechGrammarList();
-      this.grammars.referenceGrammar = referenceGrammarID || '';
-
-      return super.start();
-    }
-  };
-}
-
 export default async function createCognitiveServicesSpeechServicesPonyfillFactory({
   authorizationToken,
   region,
@@ -21,19 +10,22 @@ export default async function createCognitiveServicesSpeechServicesPonyfillFacto
     'Web Chat: Cognitive Services Speech Services support is currently in preview. If you encounter any problems, please file us an issue at https://github.com/microsoft/BotFramework-WebChat/issues/.'
   );
 
-  const ponyfill = await createPonyfill({
-    authorizationToken,
-    region,
-    subscriptionKey,
-    textNormalization
-  });
+  return ({ referenceGrammarID }) => {
+    const ponyfill = createPonyfill({
+      authorizationToken,
+      referenceGrammars: [`luis/${referenceGrammarID}-PRODUCTION`],
+      region,
+      subscriptionKey,
+      textNormalization
+    });
 
-  const { SpeechGrammarList, speechSynthesis, SpeechSynthesisUtterance } = ponyfill;
+    const { SpeechGrammarList, SpeechRecognition, speechSynthesis, SpeechSynthesisUtterance } = ponyfill;
 
-  return ({ referenceGrammarID }) => ({
-    SpeechGrammarList,
-    SpeechRecognition: injectReferenceGrammarID(ponyfill, referenceGrammarID),
-    speechSynthesis,
-    SpeechSynthesisUtterance
-  });
+    return {
+      SpeechGrammarList,
+      SpeechRecognition,
+      speechSynthesis,
+      SpeechSynthesisUtterance
+    };
+  };
 }

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -1,6 +1,6 @@
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
-export default async function createCognitiveServicesSpeechServicesPonyfillFactory({
+export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   authorizationToken,
   region,
   subscriptionKey,

--- a/packages/component/src/SendBox/MicrophoneButton.js
+++ b/packages/component/src/SendBox/MicrophoneButton.js
@@ -4,6 +4,7 @@
 import { Constants } from 'botframework-webchat-core';
 import { css } from 'glamor';
 import classNames from 'classnames';
+import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -29,9 +30,27 @@ const ROOT_CSS = css({
   }
 });
 
-const connectMicrophoneButton = (...selectors) =>
-  connectToWebChat(
-    ({ disabled, dictateInterims, dictateState, language, setSendBox, startDictate, stopDictate }) => ({
+const connectMicrophoneButton = (...selectors) => {
+  const primeSpeechSynthesis = memoize((speechSynthesis, SpeechSynthesisUtterance) => {
+    if (speechSynthesis && SpeechSynthesisUtterance) {
+      const utterance = new SpeechSynthesisUtterance('');
+
+      utterance.voice = speechSynthesis.getVoices()[0];
+      speechSynthesis.speak(utterance);
+    }
+  });
+
+  return connectToWebChat(
+    ({
+      disabled,
+      dictateInterims,
+      dictateState,
+      language,
+      setSendBox,
+      startDictate,
+      stopDictate,
+      webSpeechPonyfill: { speechSynthesis, SpeechSynthesisUtterance } = {}
+    }) => ({
       click: () => {
         if (dictateState === DictateState.STARTING || dictateState === DictateState.DICTATING) {
           stopDictate();
@@ -39,6 +58,8 @@ const connectMicrophoneButton = (...selectors) =>
         } else {
           startDictate();
         }
+
+        primeSpeechSynthesis(speechSynthesis, SpeechSynthesisUtterance);
       },
       dictating: dictateState === DictateState.DICTATING,
       disabled: disabled || (dictateState === DictateState.STARTING || dictateState === DictateState.STOPPING),
@@ -46,6 +67,7 @@ const connectMicrophoneButton = (...selectors) =>
     }),
     ...selectors
   );
+};
 
 const MicrophoneButton = ({ className, click, dictating, disabled, language, styleSet }) => (
   <div

--- a/packages/component/src/SendBox/MicrophoneButton.js
+++ b/packages/component/src/SendBox/MicrophoneButton.js
@@ -35,7 +35,7 @@ const connectMicrophoneButton = (...selectors) => {
     if (speechSynthesis && SpeechSynthesisUtterance) {
       const utterance = new SpeechSynthesisUtterance('');
 
-      utterance.voice = speechSynthesis.getVoices()[0];
+      [utterance.voice] = speechSynthesis.getVoices();
       speechSynthesis.speak(utterance);
     }
   });


### PR DESCRIPTION
> Fix #2245, fix #1514, fix #1515.

## Changelog Entry

-  Fix [#2245](https://github.com/microsoft/BotFramework-WebChat/issues/2245). Fix speech synthesis not working on Safari by priming the engine on the first microphone button click, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
-  Fix [#1514](https://github.com/microsoft/BotFramework-WebChat/issues/1514). Added reference grammar ID when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
-  Fix [#1515](https://github.com/microsoft/BotFramework-WebChat/issues/1515). Added dynamic phrases when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)

## Description

The `AudioContext` instance need to be primed by user gesture on Safari on iPad. Otherwise, audio clip playback will be paused indefinitely.

Also, dynamic phrases and reference grammar ID is added after bumping to latest `web-speech-cognitive-services`. Although dynamic phrases is supported, it is not used because currently, there are no fields in activity that provide suggestions or expected phrases.

## Specific Changes

When the user click on the microphone button, we will prime the speech synthesis engine by sending an empty utterance.

---

-  [x] ~Testing Added~
-  [x] Bump `web-speech-cognitive-services`, it is required for a persistent and prime-able `AudioContext` object, in [their PR #36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
