### PR TITLE
Fix wrong shape on propTypes.tapAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2193](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix Adaptive Card/attachments do not get read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2150](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix timestamps read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)
+-  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings regarding prop types, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2193](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix Adaptive Card/attachments do not get read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2150](https://github.com/microsoft/BotFramework-WebChat/issues/2193). Fix timestamps read by Narrator, by [@corinagum](https://github.com/corinagum) in PR [#2226](https://github.com/microsoft/BotFramework-WebChat/pull/2226)
 -  Fix [#2240](https://github.com/microsoft/BotFramework-WebChat/issues/2240). Fix microphone button should be re-enabled after error, by [@compulim](https://github.com/compulim) in PR [#2241](https://github.com/microsoft/BotFramework-WebChat/pull/2241)
--  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings regarding prop types, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings related prop types, by [@compulim](https://github.com/compulim) in PR [#2253](https://github.com/microsoft/BotFramework-WebChat/pull/2253)
 
 ### Added
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
@@ -193,7 +193,10 @@ AdaptiveCardRenderer.propTypes = {
   styleSet: PropTypes.shape({
     adaptiveCardRenderer: PropTypes.any.isRequired
   }).isRequired,
-  tapAction: PropTypes.func
+  tapAction: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    value: PropTypes.string
+  })
 };
 
 AdaptiveCardRenderer.defaultProps = {

--- a/packages/component/src/Attachment/TypingActivity.js
+++ b/packages/component/src/Attachment/TypingActivity.js
@@ -7,7 +7,7 @@ import TypingAnimation from './Assets/TypingAnimation';
 
 const TypingActivity = ({ language, styleSet }) => (
   <div className={styleSet.typingActivity}>
-    <TypingAnimation ariaLabel={localize('TypingIndicator', language)} />
+    <TypingAnimation aria-label={localize('TypingIndicator', language)} />
   </div>
 );
 
@@ -18,4 +18,4 @@ TypingActivity.propTypes = {
   }).isRequired
 };
 
-export default connectToWebChat(({ styleSet }) => ({ styleSet }))(TypingActivity);
+export default connectToWebChat(({ language, styleSet }) => ({ language, styleSet }))(TypingActivity);

--- a/packages/component/src/ErrorBox.js
+++ b/packages/component/src/ErrorBox.js
@@ -25,4 +25,4 @@ ErrorBox.propTypes = {
   }).isRequired
 };
 
-export default connectToWebChat(({ styleSet }) => ({ styleSet }))(ErrorBox);
+export default connectToWebChat(({ language, styleSet }) => ({ language, styleSet }))(ErrorBox);


### PR DESCRIPTION
Fixes #2250.

Also need to fix `card broken` command.

![image](https://user-images.githubusercontent.com/1622400/62252165-e4700380-b3a6-11e9-9234-bc0567a0a8f9.png)

![image](https://user-images.githubusercontent.com/1622400/62252615-38c7b300-b3a8-11e9-96c6-2f493aa2adfd.png)

## Changelog Entry

-  Fix [#2250](https://github.com/microsoft/BotFramework-WebChat/issues/2250). Fix React warnings related prop types, by [@compulim](https://github.com/compulim) in PR [#2253](https://github.com/microsoft/BotFramework-WebChat/pull/2253)

## Description

Wrong `propTypes` on `AdaptiveCardRenderer.js`.

## Specific Changes

- Modify `AdaptiveCardsRenderer.propTypes.tapAction`

---

-  [x] ~Testing Added~
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
