### PR TITLE
[High Priority] Bump to 4.5.3-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.5.2-0",
+  "version": "4.5.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.5.2-0",
+  "version": "4.5.3-0",
   "private": true,
   "files": [
     "lib/**/*"


### PR DESCRIPTION
`4.5.2` is released on CDN and NPM. It's time to move to `4.5.3-0`. 😉 