### PR TITLE
Ignore speech synthesis errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1515](https://github.com/microsoft/BotFramework-WebChat/issues/1515). Added dynamic phrases when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 -  Fix [#2273](https://github.com/microsoft/BotFramework-WebChat/issues/2273). Add `ScreenReaderText` component, by [@corinagum](https://github.com/corinagum) in PR [#2278](https://github.com/microsoft/BotFramework-WebChat/pull/2278)
 -  Fix [#2231](https://github.com/microsoft/BotFramework-WebChat/issues/2231). Fallback to English (US) if date time formatting failed, by [@compulim](https://github.com/compulim) in PR [#2286](https://github.com/microsoft/BotFramework-WebChat/pull/2286)
--  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors should be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)
+-  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors to be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1515](https://github.com/microsoft/BotFramework-WebChat/issues/1515). Added dynamic phrases when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 -  Fix [#2273](https://github.com/microsoft/BotFramework-WebChat/issues/2273). Add `ScreenReaderText` component, by [@corinagum](https://github.com/corinagum) in PR [#2278](https://github.com/microsoft/BotFramework-WebChat/pull/2278)
 -  Fix [#2231](https://github.com/microsoft/BotFramework-WebChat/issues/2231). Fallback to English (US) if date time formatting failed, by [@compulim](https://github.com/compulim) in PR [#2286](https://github.com/microsoft/BotFramework-WebChat/pull/2286)
--  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors should be ignored, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/microsoft/BotFramework-WebChat/issues/XXX)
+-  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors should be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#1515](https://github.com/microsoft/BotFramework-WebChat/issues/1515). Added dynamic phrases when using Cognitive Services Speech Services, by [@compulim](https://github.com/compulim) in PR [#2246](https://github.com/microsoft/BotFramework-WebChat/pull/2246)
 -  Fix [#2273](https://github.com/microsoft/BotFramework-WebChat/issues/2273). Add `ScreenReaderText` component, by [@corinagum](https://github.com/corinagum) in PR [#2278](https://github.com/microsoft/BotFramework-WebChat/pull/2278)
 -  Fix [#2231](https://github.com/microsoft/BotFramework-WebChat/issues/2231). Fallback to English (US) if date time formatting failed, by [@compulim](https://github.com/compulim) in PR [#2286](https://github.com/microsoft/BotFramework-WebChat/pull/2286)
+-  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors should be ignored, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/microsoft/BotFramework-WebChat/issues/XXX)
 
 ### Added
 

--- a/__tests__/inputHint.js
+++ b/__tests__/inputHint.js
@@ -21,7 +21,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaMicrophone('hint expecting input');
+      await pageObjects.sendMessageViaMicrophone('hint expecting');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
@@ -41,7 +41,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaMicrophone('hint expecting input');
+      await pageObjects.sendMessageViaMicrophone('hint expecting');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
@@ -59,7 +59,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaMicrophone('hint accepting input');
+      await pageObjects.sendMessageViaMicrophone('hint accepting');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
@@ -79,7 +79,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaSendBox('hint accepting input');
+      await pageObjects.sendMessageViaSendBox('hint accepting');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
@@ -97,7 +97,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaMicrophone('hint ignoring input');
+      await pageObjects.sendMessageViaMicrophone('hint ignoring');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
@@ -117,7 +117,7 @@ describe('input hint', () => {
 
       await driver.wait(uiConnected(), timeouts.directLine);
 
-      await pageObjects.sendMessageViaSendBox('hint ignoring input');
+      await pageObjects.sendMessageViaSendBox('hint ignoring');
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 

--- a/__tests__/setup/pageObjects/errorSpeechSynthesize.js
+++ b/__tests__/setup/pageObjects/errorSpeechSynthesize.js
@@ -1,0 +1,5 @@
+import executePromiseScript from './executePromiseScript';
+
+export default async function errorSpeechSynthesize(driver, reason) {
+  return await executePromiseScript(driver, reason => window.WebSpeechMock.mockErrorSynthesize(reason), reason);
+}

--- a/__tests__/setup/pageObjects/index.js
+++ b/__tests__/setup/pageObjects/index.js
@@ -3,6 +3,7 @@ import clickSendButton from './clickSendButton';
 import clickSuggestedActionButton from './clickSuggestedActionButton';
 import dispatchAction from './dispatchAction';
 import endSpeechSynthesize from './endSpeechSynthesize';
+import errorSpeechSynthesize from './errorSpeechSynthesize';
 import executePromiseScript from './executePromiseScript';
 import getNumActivitiesShown from './getNumActivitiesShown';
 import getSendBoxText from './getSendBoxText';
@@ -32,6 +33,7 @@ export default function pageObjects(driver) {
       clickSuggestedActionButton,
       dispatchAction,
       endSpeechSynthesize,
+      errorSpeechSynthesize,
       executePromiseScript,
       getNumActivitiesShown,
       getSendBoxText,

--- a/__tests__/setup/web/mockWebSpeech.js
+++ b/__tests__/setup/web/mockWebSpeech.js
@@ -309,6 +309,18 @@ window.WebSpeechMock = {
     });
   },
 
+  mockErrorSynthesize(error = 'artificial-error') {
+    return new Promise(resolve => {
+      speechSynthesisBroker.consume(utterance => {
+        utterance.dispatchEvent({ error, type: 'error' });
+
+        const { lang, pitch, rate, text, voice, volume } = utterance;
+
+        resolve({ lang, pitch, rate, text, voice, volume });
+      });
+    });
+  },
+
   mockRecognize(...args) {
     speechRecognitionBroker.produce(...args);
   },

--- a/__tests__/speech.recognition.js
+++ b/__tests__/speech.recognition.js
@@ -17,7 +17,7 @@ describe('speech recognition', () => {
       }
     });
 
-    await pageObjects.sendMessageViaMicrophone('hint expecting input');
+    await pageObjects.sendMessageViaMicrophone('hint expecting');
 
     await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
     await driver.wait(speechSynthesisUtterancePended(), timeouts.ui);

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -7106,9 +7106,9 @@
 			}
 		},
 		"web-speech-cognitive-services": {
-			"version": "4.0.1-master.ad6e780",
-			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.ad6e780.tgz",
-			"integrity": "sha512-YZw88M+yUcHtbl5li5fxLVBcu5fs2Vx6PKaxBR+oOTi1yAfCXlZM/JEueYFLf5ayu4uH6BFNVgn4sHiQVfOotw==",
+			"version": "4.0.1-master.d9fc5d3",
+			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.d9fc5d3.tgz",
+			"integrity": "sha512-mZOKH9E1g1qDQmmIvbnmjN/zBzJjJBGv+0LOw1kNIfgim2WEgTlzgb364o08cPIaokJhzD+FBMQ583Si8mmDkw==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"base64-arraybuffer": "^0.2.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -46,7 +46,7 @@
     "prop-types": "^15.7.2",
     "sanitize-html": "^1.19.0",
     "url-search-params-polyfill": "^5.0.0",
-    "web-speech-cognitive-services": "4.0.1-master.ad6e780",
+    "web-speech-cognitive-services": "4.0.1-master.d9fc5d3",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/component/src/Activity/Speak.js
+++ b/packages/component/src/Activity/Speak.js
@@ -48,7 +48,7 @@ const Speak = ({ activity, markAsSpoken, selectVoice, styleSet }) => {
 
   return (
     <React.Fragment>
-      <Say onEnd={markAsSpoken} speak={singleLine} voice={selectVoice} />
+      <Say onEnd={markAsSpoken} onError={markAsSpoken} speak={singleLine} voice={selectVoice} />
       {!!styleSet.options.showSpokenText && <SayAlt speak={singleLine} voice={selectVoice} />}
     </React.Fragment>
   );


### PR DESCRIPTION
Fixes #2298.

## Changelog Entry

### Fixed

-  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors should be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)

## Description

Today, when speech synthesis errors occurred, it blocks any other synthesis and recognition operations.

We should ignore synthesis errors to unblock other operations.

## Specific Changes

- Bump [web-speech-cognitive-services](https://npmjs.com/package/web-speech-cognitive-services) for correct reporting synthesis errors
- When synthesis errors happens in `Speak.js`, mark the speaking utterance as completed to unblock other operations

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
