### PR TITLE
Move composer and `connectToWebChat` to React hooks and functional component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308), notably
+-  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
    -  [`@babel/*@7.5.4`](https://www.npmjs.com/package/@babel/core)
    -  [`jest@24.8.0`](https://www.npmjs.com/package/jest)
    -  [`lerna@3.15.0`](https://www.npmjs.com/package/lerna)
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  `playground`: Remove [`react`](https://www.npmjs.com/package/react) and [`react-dom`](https://www.npmjs.com/package/react-dom) from `dependencies`
    -  `samples/*`: Move to production version of Web Chat, and bump to [`react@16.8.6`](https://www.npmjs.com/package/react) and [`react-dom@16.8.6`](https://www.npmjs.com/package/react-dom)
 -  Moved the typing indicator to the send box and removed the typing indicator logic from the sagas, by [@tdurnford](https://github.com/tdurnford), in PR [#2321](https://github.com/microsoft/BotFramework-WebChat/pull/2321)
--  `component`: Move to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
+-  `component`: Move `Composer` to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#XXX](https://github.com/compulim/BotFramework-WebChat/pull/XXX), notably
+-  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308), notably
    -  [`@babel/*@7.5.4`](https://www.npmjs.com/package/@babel/core)
    -  [`jest@24.8.0`](https://www.npmjs.com/package/jest)
    -  [`lerna@3.15.0`](https://www.npmjs.com/package/lerna)
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  `playground`: Remove [`react`](https://www.npmjs.com/package/react) and [`react-dom`](https://www.npmjs.com/package/react-dom) from `dependencies`
    -  `samples/*`: Move to production version of Web Chat, and bump to [`react@16.8.6`](https://www.npmjs.com/package/react) and [`react-dom@16.8.6`](https://www.npmjs.com/package/react-dom)
 -  Moved the typing indicator to the send box and removed the typing indicator logic from the sagas, by [@tdurnford](https://github.com/tdurnford), in PR [#2321](https://github.com/microsoft/BotFramework-WebChat/pull/2321)
--  `component`: Move to React hooks and functional components, by [@compulim](https://github.com), in PR [#XXX](https://github.com/compulim/BotFramework-WebChat/pull/XXX)
+-  `component`: Move to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182), notably
+-  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#XXX](https://github.com/compulim/BotFramework-WebChat/pull/XXX), notably
    -  [`@babel/*@7.5.4`](https://www.npmjs.com/package/@babel/core)
    -  [`jest@24.8.0`](https://www.npmjs.com/package/jest)
    -  [`lerna@3.15.0`](https://www.npmjs.com/package/lerna)
+   -  [`react-redux@7.1.0`](https://www.npmjs.com/package/react-redux)
    -  [`typescript@3.5.3`](https://www.npmjs.com/package/typescript)
    -  [`webpack@4.35.3`](https://www.npmjs.com/package/webpack)
 -  `*`: Bumps [`@babel/runtime@7.5.4`](https://www.npmjs.com/package/@babel/runtime), by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182)
@@ -63,6 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  `playground`: Remove [`react`](https://www.npmjs.com/package/react) and [`react-dom`](https://www.npmjs.com/package/react-dom) from `dependencies`
    -  `samples/*`: Move to production version of Web Chat, and bump to [`react@16.8.6`](https://www.npmjs.com/package/react) and [`react-dom@16.8.6`](https://www.npmjs.com/package/react-dom)
 -  Moved the typing indicator to the send box and removed the typing indicator logic from the sagas, by [@tdurnford](https://github.com/tdurnford), in PR [#2321](https://github.com/microsoft/BotFramework-WebChat/pull/2321)
+-  `component`: Move to React hooks and functional components, by [@compulim](https://github.com), in PR [#XXX](https://github.com/compulim/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -4398,23 +4398,27 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-redux": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.0.tgz",
+      "integrity": "sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.1.0",
+        "@babel/runtime": "^7.4.5",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        }
       }
     },
     "react-say": {

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15.7.2",
     "react-dictate-button": "^1.1.3",
     "react-film": "1.2.1-master.db29968",
-    "react-redux": "^5.1.1",
+    "react-redux": "7",
     "react-say": "^1.2.0",
     "react-scroll-to-bottom": "~1.3.2",
     "redux": "^4.0.4",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15.7.2",
     "react-dictate-button": "^1.1.3",
     "react-film": "1.2.1-master.db29968",
-    "react-redux": "7",
+    "react-redux": "^7.1.0",
     "react-say": "^1.2.0",
     "react-scroll-to-bottom": "~1.3.2",
     "redux": "^4.0.4",

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -5,11 +5,10 @@ import {
   FunctionContext as ScrollToBottomFunctionContext
 } from 'react-scroll-to-bottom';
 
-import { connect } from 'react-redux';
+import { connect, Provider } from 'react-redux';
 import { css } from 'glamor';
-import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useMemo, useEffect } from 'react';
 
 import {
   clearSuggestedActions,
@@ -43,11 +42,9 @@ import createStyleSet from './Styles/createStyleSet';
 import Dictation from './Dictation';
 import mapMap from './Utils/mapMap';
 import observableToPromise from './Utils/observableToPromise';
-import shallowEquals from './Utils/shallowEquals';
+import WebChatReduxContext from './WebChatReduxContext';
 
-// Flywheel object
-const EMPTY_ARRAY = [];
-
+// List of Redux actions factory we are hoisted as Web Chat functions
 const DISPATCHERS = {
   clearSuggestedActions,
   markActivity,
@@ -113,12 +110,6 @@ function createFocusSendBoxLogic({ sendBoxRef }) {
   };
 }
 
-function createStyleSetLogic({ styleOptions, styleSet }) {
-  return {
-    styleSet: styleSetToClassNames(styleSet || createStyleSet(styleOptions))
-  };
-}
-
 // TODO: [P3] Take this deprecation code out when releasing on or after 2019 December 11
 function patchPropsForAvatarInitials({ botAvatarInitials, userAvatarInitials, ...props }) {
   // This code will take out "botAvatarInitials" and "userAvatarInitials" from props
@@ -147,7 +138,90 @@ function patchPropsForAvatarInitials({ botAvatarInitials, userAvatarInitials, ..
   };
 }
 
-function createLogic(props) {
+const Composer = ({
+  activityRenderer,
+  attachmentRenderer,
+  botAvatarInitials,
+  cardActionMiddleware,
+  children,
+  directLine,
+  disabled,
+  dispatch,
+  grammars,
+  groupTimestamp,
+  locale,
+  referenceGrammarID,
+  renderMarkdown,
+  scrollToEnd,
+  sendBoxRef,
+  sendTimeout,
+  sendTyping,
+  sendTypingIndicator,
+  styleOptions,
+  styleSet,
+  userAvatarInitials,
+  userID,
+  username,
+  webSpeechPonyfillFactory
+}) => {
+  useEffect(() => {
+    dispatch(setLanguage(locale));
+  }, [dispatch, locale]);
+
+  useEffect(() => {
+    dispatch(setSendTimeout(sendTimeout));
+  }, [dispatch, sendTimeout]);
+
+  useEffect(() => {
+    if (typeof sendTyping === 'undefined') {
+      dispatch(setSendTypingIndicator(!!sendTypingIndicator));
+    } else {
+      // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
+      console.warn(
+        'Web Chat: "sendTyping" has been renamed to "sendTypingIndicator". Please use "sendTypingIndicator" instead. This deprecation migration will be removed on or after January 13 2020.'
+      );
+
+      dispatch(setSendTypingIndicator(!!sendTyping));
+    }
+  }, [dispatch, sendTyping, sendTypingIndicator]);
+
+  useEffect(() => {
+    // TODO: [P3] disconnect() is an async call (pending -> fulfilled), we need to wait, or change it to reconnect()
+    dispatch(disconnect());
+    dispatch(createConnectAction({ directLine, userID, username }));
+  }, [dispatch, directLine, userID, username]);
+
+  const cardActionContext = useMemo(() => createCardActionLogic({ cardActionMiddleware, directLine, dispatch }), [
+    cardActionMiddleware,
+    directLine,
+    dispatch
+  ]);
+
+  const focusSendBoxContext = useMemo(() => createFocusSendBoxLogic({ sendBoxRef }), [sendBoxRef]);
+
+  const patchedStyleOptions = useMemo(
+    () => patchPropsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }),
+    [botAvatarInitials, styleOptions, userAvatarInitials]
+  );
+
+  const styleSetContext = useMemo(
+    () => ({
+      styleOptions: patchedStyleOptions,
+      styleSet: styleSetToClassNames(styleSet || createStyleSet(patchedStyleOptions))
+    }),
+    [botAvatarInitials, userAvatarInitials, patchedStyleOptions, styleSet]
+  );
+
+  const hoistedDispatchers = useMemo(
+    () => mapMap(DISPATCHERS, dispatcher => (...args) => dispatch(dispatcher.apply(this, args))),
+    [dispatch]
+  );
+
+  const webSpeechPonyfill = useMemo(
+    () => webSpeechPonyfillFactory && webSpeechPonyfillFactory({ referenceGrammarID }),
+    [referenceGrammarID, webSpeechPonyfillFactory]
+  );
+
   // This is a heavy function, and it is expected to be only called when there is a need to recreate business logic, e.g.
   // - User ID changed, causing all send* functions to be updated
   // - send
@@ -159,149 +233,52 @@ function createLogic(props) {
   // 2. Filter out profanity
 
   // TODO: [P4] Revisit all members of context
-  props = patchPropsForAvatarInitials(props);
+  const context = useMemo(
+    () => ({
+      ...cardActionContext,
+      ...focusSendBoxContext,
+      ...styleSetContext,
+      ...hoistedDispatchers,
+      activityRenderer,
+      attachmentRenderer,
+      disabled,
+      grammars: grammars || EMPTY_ARRAY,
+      groupTimestamp,
+      renderMarkdown,
+      scrollToEnd,
+      webSpeechPonyfill
+    }),
+    [
+      activityRenderer,
+      attachmentRenderer,
+      cardActionContext,
+      disabled,
+      focusSendBoxContext,
+      grammars,
+      groupTimestamp,
+      hoistedDispatchers,
+      renderMarkdown,
+      scrollToEnd,
+      styleSetContext,
+      webSpeechPonyfill
+    ]
+  );
 
-  return {
-    ...props,
-    ...createCardActionLogic(props),
-    ...createFocusSendBoxLogic(props),
-    ...createStyleSetLogic(props)
-  };
-}
+  return (
+    <Context.Provider value={context}>
+      {typeof children === 'function' ? children(context) : children}
+      <Dictation />
+    </Context.Provider>
+  );
+};
 
-function dispatchSetLanguageFromProps({ dispatch, locale }) {
-  dispatch(setLanguage(locale));
-}
-
-function dispatchSetSendTimeoutFromProps({ dispatch, sendTimeout }) {
-  dispatch(setSendTimeout(sendTimeout));
-}
-
-function dispatchSetSendTypingIndicatorFromProps({ dispatch, sendTyping, sendTypingIndicator }) {
-  if (typeof sendTyping === 'undefined') {
-    dispatch(setSendTypingIndicator(!!sendTypingIndicator));
-  } else {
-    // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
-    console.warn(
-      'Web Chat: "sendTyping" has been renamed to "sendTypingIndicator". Please use "sendTypingIndicator" instead. This deprecation migration will be removed on or after January 13 2020.'
-    );
-    dispatch(setSendTypingIndicator(!!sendTyping));
-  }
-}
-
-class Composer extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.createContextFromProps = memoize(createLogic, shallowEquals);
-
-    this.createWebSpeechPonyfill = memoize(
-      (webSpeechPonyfillFactory, referenceGrammarID) =>
-        webSpeechPonyfillFactory && webSpeechPonyfillFactory({ referenceGrammarID })
-    );
-
-    this.mergeContext = memoize((...contexts) => Object.assign({}, ...contexts), shallowEquals);
-
-    this.state = {
-      hoistedDispatchers: mapMap(DISPATCHERS, dispatcher => (...args) => props.dispatch(dispatcher.apply(this, args)))
-    };
-  }
-
-  UNSAFE_componentWillMount() {
-    const { props } = this;
-    const { directLine, userID, username } = props;
-
-    dispatchSetLanguageFromProps(props);
-    dispatchSetSendTimeoutFromProps(props);
-    dispatchSetSendTypingIndicatorFromProps(props);
-
-    props.dispatch(createConnectAction({ directLine, userID, username }));
-  }
-
-  componentDidUpdate(prevProps) {
-    const { props } = this;
-    const { directLine, locale, sendTimeout, sendTyping, sendTypingIndicator, userID, username } = props;
-
-    if (prevProps.locale !== locale) {
-      dispatchSetLanguageFromProps(props);
-    }
-
-    if (prevProps.sendTimeout !== sendTimeout) {
-      dispatchSetSendTimeoutFromProps(props);
-    }
-
-    if (
-      !prevProps.sendTypingIndicator !== !sendTypingIndicator ||
-      // TODO: [P3] Take this deprecation code out when releasing on or after January 13 2020
-      !prevProps.sendTyping !== !sendTyping
-    ) {
-      dispatchSetSendTypingIndicatorFromProps(props);
-    }
-
-    if (prevProps.directLine !== directLine || prevProps.userID !== userID || prevProps.username !== username) {
-      // TODO: [P3] disconnect() is an async call (pending -> fulfilled), we need to wait, or change it to reconnect()
-      props.dispatch(disconnect());
-      props.dispatch(createConnectAction({ directLine, userID, username }));
-    }
-  }
-
-  render() {
-    const {
-      props: {
-        activityRenderer,
-        attachmentRenderer,
-        children,
-
-        // TODO: [P2] Add disable interactivity
-        disabled,
-
-        grammars,
-        groupTimestamp,
-        referenceGrammarID,
-        renderMarkdown,
-        scrollToEnd,
-        store,
-        userID: _userID, // Ignoring eslint no-unused-vars: we just want to remove userID and username from propsForLogic
-        username: _username, // Ignoring eslint no-unused-vars: we just want to remove userID and username from propsForLogic
-        webSpeechPonyfillFactory,
-        ...propsForLogic
-      },
-      state
-    } = this;
-
-    const contextFromProps = this.createContextFromProps(propsForLogic);
-
-    const context = this.mergeContext(
-      contextFromProps,
-      state.hoistedDispatchers,
-
-      // TODO: [P4] Should we normalize empties here? Or should we let it thru?
-      //       If we let it thru, the code below become simplified and the user can plug in whatever they want for context, via Composer.props
-      {
-        activityRenderer,
-        attachmentRenderer,
-        groupTimestamp,
-        disabled,
-        grammars: grammars || EMPTY_ARRAY,
-        renderMarkdown,
-        scrollToEnd,
-        store,
-        webSpeechPonyfill: this.createWebSpeechPonyfill(webSpeechPonyfillFactory, referenceGrammarID)
-      }
-    );
-
-    // TODO: [P3] Check how many times we do re-render context
-
-    return (
-      <Context.Provider value={context}>
-        {typeof children === 'function' ? children(context) : children}
-        <Dictation />
-      </Context.Provider>
-    );
-  }
-}
-
-const ConnectedComposer = connect(({ referenceGrammarID }) => ({ referenceGrammarID }))(props => (
+// TODO: [P1] When react-redux support useSelector with custom context, we should move to that architecture to simplify our code.
+const ConnectedComposer = connect(
+  ({ referenceGrammarID }) => ({ referenceGrammarID }),
+  null,
+  null,
+  { context: WebChatReduxContext }
+)(props => (
   <ScrollToBottomComposer>
     <ScrollToBottomFunctionContext.Consumer>
       {({ scrollToEnd }) => <Composer scrollToEnd={scrollToEnd} {...props} />}
@@ -310,19 +287,15 @@ const ConnectedComposer = connect(({ referenceGrammarID }) => ({ referenceGramma
 ));
 
 // We will create a Redux store if it was not passed in
-class ConnectedComposerWithStore extends React.Component {
-  constructor(props) {
-    super(props);
+const ConnectedComposerWithStore = ({ store, ...props }) => {
+  const memoizedStore = useMemo(() => store || createStore(), [store]);
 
-    this.createMemoizedStore = memoize(() => createStore());
-  }
-
-  render() {
-    const { props } = this;
-
-    return <ConnectedComposer {...props} store={props.store || this.createMemoizedStore()} />;
-  }
-}
+  return (
+    <Provider context={WebChatReduxContext} store={memoizedStore}>
+      <ConnectedComposer {...props} />
+    </Provider>
+  );
+};
 
 ConnectedComposerWithStore.defaultProps = {
   store: undefined

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -231,8 +231,6 @@ const Composer = ({
   // - User ID changed, causing all send* functions to be updated
   // - send
 
-  // TODO: [P4] We should break this into smaller pieces using memoization function, so we don't recreate styleSet if userID is changed
-
   // TODO: [P3] We should think about if we allow the user to change onSendBoxValueChanged/sendBoxValue, e.g.
   // 1. Turns text into UPPERCASE
   // 2. Filter out profanity
@@ -326,7 +324,7 @@ ConnectedComposerWithStore.propTypes = {
 
 export default ConnectedComposerWithStore;
 
-// TODO: [P3] We should consider moving some props to Redux store
+// TODO: [P3] We should consider moving some data from Redux store to props
 //       Although we use `connectToWebChat` to hide the details of accessor of Redux store,
 //       we should clean up the responsibility between Context and Redux store
 //       We should decide which data is needed for React but not in other environment such as CLI/VSCode

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -8,7 +8,7 @@ import {
 import { connect, Provider } from 'react-redux';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
-import React, { useMemo, useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import {
   clearSuggestedActions,
@@ -259,15 +259,15 @@ const Composer = ({
       webSpeechPonyfill
     }),
     [
-      cardActionContext,
-      focusSendBoxContext,
-      hoistedDispatchers,
       activityRenderer,
       attachmentRenderer,
+      cardActionContext,
       directLine,
       disabled,
+      focusSendBoxContext,
       grammars,
       groupTimestamp,
+      hoistedDispatchers,
       renderMarkdown,
       scrollToEnd,
       sendBoxRef,

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -44,7 +44,7 @@ import mapMap from './Utils/mapMap';
 import observableToPromise from './Utils/observableToPromise';
 import WebChatReduxContext from './WebChatReduxContext';
 
-// List of Redux actions factory we are hoisted as Web Chat functions
+// List of Redux actions factory we are hoisting as Web Chat functions
 const DISPATCHERS = {
   clearSuggestedActions,
   markActivity,

--- a/packages/component/src/WebChatReduxContext.js
+++ b/packages/component/src/WebChatReduxContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext();

--- a/packages/component/src/connectToWebChat.js
+++ b/packages/component/src/connectToWebChat.js
@@ -31,6 +31,7 @@ export default function connectToWebChat(...selectors) {
   const combinedSelector = combineSelectors(...selectors);
 
   // TODO: [P1] Instead of exposing Redux store via props, we should consider exposing via Context.
+  //       We should also hide dispatch function.
   return Component => {
     const ConnectedComponent = connect(
       (state, { context, ...ownProps }) => combinedSelector({ ...state, ...context }, ownProps),

--- a/packages/component/src/connectToWebChat.js
+++ b/packages/component/src/connectToWebChat.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import React from 'react';
 
 import Context from './Context';
+import WebChatReduxContext from './WebChatReduxContext';
 
 function removeUndefinedValues(map) {
   return Object.keys(map).reduce((result, key) => {
@@ -29,15 +30,19 @@ function combineSelectors(...selectors) {
 export default function connectToWebChat(...selectors) {
   const combinedSelector = combineSelectors(...selectors);
 
+  // TODO: [P1] Instead of exposing Redux store via props, we should consider exposing via Context.
   return Component => {
-    const ConnectedComponent = connect((state, { context, _, ...ownProps }) =>
-      combinedSelector({ ...state, ...context }, ownProps)
+    const ConnectedComponent = connect(
+      (state, { context, ...ownProps }) => combinedSelector({ ...state, ...context }, ownProps),
+      null,
+      null,
+      {
+        context: WebChatReduxContext
+      }
     )(Component);
 
     const WebChatConnectedComponent = props => (
-      <Context.Consumer>
-        {context => <ConnectedComponent {...props} context={context} store={context.store} />}
-      </Context.Consumer>
+      <Context.Consumer>{context => <ConnectedComponent {...props} context={context} />}</Context.Consumer>
     );
 
     return WebChatConnectedComponent;


### PR DESCRIPTION
## Changelog Entry

### Changed

-  `*`: Bumps all dev dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2182](https://github.com/microsoft/BotFramework-WebChat/pull/2182) and PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308), notably
   -  [`react-redux@7.1.0`](https://www.npmjs.com/package/react-redux)
-  `component`: Move to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)

## Description

Use React hooks for composer and `connectToWebChat`.

This paves the way for moving to `useSelector` et al. from `react-redux`. We are waiting for [this PR from `react-redux`](https://github.com/reduxjs/react-redux/pull/1309) to go production.

## Specific Changes

- Bumps to [`react-redux@7.1.0`](https://npmjs.com/packages/react-redux)
- `Composer.js` would use React hooks with simplified memoization function
- Updates to our multiple store strategy: instead of passing `store` as prop, we are passing a [custom React context](https://react-redux.js.org/using-react-redux/accessing-store#providing-custom-context)

---

-  [x] ~Testing Added~
   -  No new features has been introduced

