### PR TITLE
Update SHA384 for 4.4.2

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -59,7 +59,7 @@
     },
     "4.4.2": {
       "assets": [
-        ["https://cdn.botframework.com/botframework-webchat/4.4.2/webchat-es5.js", "sha384-ms+OSSlqKObm3YTIuz8IFhO4HKuUIsnbyghOAUv31I8zkxxSU+I6pqkFCZLOh6SU"]
+        ["https://cdn.botframework.com/botframework-webchat/4.4.2/webchat-es5.js", "sha384-OVlkIuXqwOpo64U0xDauCpLy6R05bzT3H0PwWx/vONPtzvYMO3jhtWxlPT2aV93F"]
       ],
       "deprecation": "We are deprecating this version of Web Chat. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2021-07-10.",
       "private": true,


### PR DESCRIPTION
We were using a wrong SHA384 for the servicing plan.

The original one was from `webchat.js` instead of `webchat-es5.js`.

To verify the SHA384, run this:

```sh
curl https://cdn.botframework.com/botframework-webchat/4.4.2/webchat-es5.js | openssl dgst -sha384 -binary | openssl base64 -A
```

It should return `OVlkIuXqwOpo64U0xDauCpLy6R05bzT3H0PwWx/vONPtzvYMO3jhtWxlPT2aV93F`.