### PR TITLE
Trimming sendBoxValue on enter key submit: issue 2328

### DIFF
--- a/packages/component/src/SendBox/TextBox.js
+++ b/packages/component/src/SendBox/TextBox.js
@@ -45,6 +45,7 @@ const connectSendTextBox = (...selectors) =>
         // E.g. if the connection is bad, sending the message essentially do nothing but just clearing the send box
 
         if (sendBoxValue) {
+          setSendBox(sendBoxValue.trim());
           scrollToEnd();
           submitSendBox();
         }


### PR DESCRIPTION
Bug fix for "Sending questions with trailing spaces using enter fails to trim(). - fix included #2328"
https://github.com/microsoft/BotFramework-WebChat/issues/2328

Fixes #2328

## Changelog Entry

 <!-- Please paste your new entry from CHANGELOG.MD here -->

## Description

Added .trim() to submissions or questions via the enter key

file: BotFramework-WebChat/packages/component/src/SendBox/TextBox.js
Line 34 needs to be added to the red if condition shown below:
![image](https://user-images.githubusercontent.com/5471548/63201692-fbbc1b80-c04b-11e9-8620-bf279b86d133.png)
