### PR TITLE
Add hide ScrollToEnd button through style options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+-  Fix [#2307](https://github.com/Microsoft/BotFramework-WebChat/issues/2307). Added options to hide ScrollToEnd button, by [@nt-7](https://github.com/nt-7) in PR [#2332](https://github.com/Microsoft/BotFramework-WebChat/pull/2332)
 -  Added bubble nub and style options, by [@compulim](https://github.com/compulim), in PR [#2137](https://github.com/Microsoft/BotFramework-WebChat/pull/2137)
 -  Fix [#1808](https://github.com/microsoft/BotFramework-WebChat/issues/1808). Added documentation on activity types, by [@corinagum](https://github.com/corinagum) in PR [#2228](https://github.com/microsoft/BotFramework-WebChat/pull/2228)
 -  Make thumbnails when uploading GIF/JPEG/PNG and store it in `channelData.attachmentThumbnails`, by [@compulim](https://github.com/compulim), in PR [#2206](https://github.com/microsoft/BotFramework-WebChat/pull/2206), requires modern browsers with following features:

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -116,7 +116,7 @@ const BasicTranscript = ({
           </ul>
         </SayComposer>
       </ScrollToBottomPanel>
-      <ScrollToEndButton />
+      {!styleSet.options.hideScrollToEndButton && <ScrollToEndButton />}
     </div>
   );
 };
@@ -135,7 +135,10 @@ BasicTranscript.propTypes = {
   groupTimestamp: PropTypes.oneOfType([PropTypes.bool.isRequired, PropTypes.number.isRequired]),
   styleSet: PropTypes.shape({
     activities: PropTypes.any.isRequired,
-    activity: PropTypes.any.isRequired
+    activity: PropTypes.any.isRequired,
+    options: PropTypes.shape({
+      hideScrollToEndButton: PropTypes.bool.isRequired
+    }).isRequired
   }).isRequired,
   webSpeechPonyfill: PropTypes.shape({
     speechSynthesis: PropTypes.any.isRequired,

--- a/packages/component/src/Styles/defaultStyleOptions.js
+++ b/packages/component/src/Styles/defaultStyleOptions.js
@@ -64,6 +64,9 @@ const DEFAULT_OPTIONS = {
   rootHeight: '100%',
   rootWidth: '100%',
 
+  // Scroll to end button
+  hideScrollToEndButton: false,
+
   // Send box
   hideSendBox: false,
   hideUploadButton: false,


### PR DESCRIPTION
Add option to hide scroll button #2307 

## Description
This work will enable to hide the ScrollToEndButton ("New messages") through style options from webchat UI when scrolling.

![image](https://user-images.githubusercontent.com/20683785/63268532-5618de80-c2cf-11e9-9549-ec246ddb5bda.png)

## Example
As below, hideScrollToEndButton on styleOptions enable users to hide the ScrollToEndButton from webchat UI.

```
const styleOptions = {
    hideScrollToEndButton: false
};
window.WebChat.renderWebChat({
    directLine: window.WebChat.createDirectLine({ token }),
    styleOptions
}, document.getElementById('webchat'));
```
