### PR TITLE
Add documentation for speech features

### DIFF
--- a/SPEECH.md
+++ b/SPEECH.md
@@ -55,7 +55,7 @@ To prevent leaking your subscription key, you should build/host a server which u
 
 ### Integrating Web Chat into your page
 
-This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"]Sample: [Integrating with Cognitive Services Speech Services].
+This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Sample: Integrating with Cognitive Services Speech Services].
 
 > To bring more focus to the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production environment.
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -49,15 +49,15 @@ To use Cognitive Services in Web Chat, you will need to add minimal setup code t
 
 You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page][Try Cognitive Services] to obtain a subscription key.
 
-To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services].
+To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Cognitive Services resource in a production environment.*
 
-> To use the [voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
+> To use [new voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
 
 ### Integrating Web Chat into your page
 
 This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Integrating with Cognitive Services Speech Services sample].
 
-> To bring more focus around the integration, we simplified from the original sample code by using subscription key instead of authorization token. You should always use authorization token for production systems.
+> To bring more focus for the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production systems.
 
 ```js
 const {

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -127,9 +127,9 @@ In the following code, voice is selected based on the language of the synthesizi
 
 ### Custom Speech
 
-Custom Speech is a trained model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or name of person.
+Custom Speech is a trained recognition model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or name of person.
 
-First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech].
+First, you need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech].
 
 After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
 
@@ -151,13 +151,13 @@ You will then need to modify your integration code as below.
 
 ### Custom Voice
 
-Custom Voice is a trained model for providing your user with an unique voice when performing text-to-speech.
+Custom Voice is a trained synthesis model for providing your user with an unique synthesized voice when performing text-to-speech.
 
-First, you will need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project][Get started with Custom Voice].
+First, you need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project][Get started with Custom Voice].
 
 After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
 
-You will then need to modify your integration code as below. The `selectVoice` function will always choose the voice of your trained model.
+You will then need to modify your integration code as below. The `selectVoice` function will be used to choose which trained synthesis model to use.
 
 ```diff
   renderWebChat({
@@ -174,9 +174,11 @@ You will then need to modify your integration code as below. The `selectVoice` f
   }, document.getElementById('webchat'));
 ```
 
+> Note: if you send SSML instead of plain text, make sure the voice model is correctly selected in your SSML.
+
 ### Text-to-speech audio format
 
-To conserve bandwidth, you can set the text-to-speech audio format to a format that consume less bandwidth by modifying your integration code as below.
+To conserve bandwidth, you can set the text-to-speech audio format to one that consume less bandwidth by modifying your integration code as below.
 
 ```diff
   renderWebChat({

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -81,6 +81,15 @@ After adding the ponyfill factory, you should be able to see microphone button i
 
 These features are for improving the overall user experiences.
 
+- [Selecting different voice](#selecting-difference-voice)
+- [Custom Speech](#custom-speech)
+- [Custom Voice](#custom-voice)
+- [Text-to-speech audio format](#text-to-speech-audio-format)
+- [Inverse text normalization option](#inverse-text-normalization-option)
+- [Disabling telemetry](#disabling-telemetry)
+- [Using authorization token](#using-authorization-token)
+- [Using two subscription keys for speech-to-text and text-to-speech](#using-two-subscription-keys-for-speech-to-text-and-text-to-speech)
+
 ### Selecting different voice
 
 (TBD)
@@ -155,7 +164,7 @@ To conserve bandwidth, you can set the text-to-speech audio format to a format t
 
 Please refer to [this article for list of supported audio formats](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs).
 
-### Inverse text normalization options
+### Inverse text normalization option
 
 Inverse text normalization (a.k.a. ITN), is an option to modify how the engine is normalizing text. For example, when the end-user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (ITN).
 
@@ -228,9 +237,9 @@ In our sample, we are using subscription key. If you prfer to use authorization 
 
 The function passed to `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not handled in this sample code. You should add caching based on the validity of the token.
 
-### Using two different subscription key for speech-to-text and text-to-speech
+### Using two subscription keys for speech-to-text and text-to-speech
 
-If you need to use two different Cognitive Services subscription, one for speech-to-text and one for text-to-speech, you can create two ponyfills and merge them together as another ponyfill.
+In some cases, you may need to use two different Cognitive Services subscription, one for speech-to-text and one for text-to-speech. You could create two ponyfills and merge them together as another ponyfill.
 
 ```diff
 + const speechToTextPonyfillFactory = await createCognitiveServicesSpeechServicesPonyfillFactory({

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -52,7 +52,7 @@ To prevent leaking your subscription key, you should build/host a server which u
 
 This integration code is excerpted from a [sample named "Integrating with Cognitive Services Speech Services"](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js).
 
-> To focus on the integration code, we simplified from the original by using subscription key instead of authorization token. You should always use authorization token for production systems.
+> To bring more focus around the integration, we simplified from the original sample code by using subscription key instead of authorization token. You should always use authorization token for production systems.
 
 ```js
 const {
@@ -73,17 +73,17 @@ renderWebChat({
 }, document.getElementById('webchat'));
 ```
 
-After adding the ponyfill factory, you should be able to see microphone button in Web Chat.
+After adding the ponyfill factory, you should be able to see a microphone button in Web Chat.
 
 ## Additional features
 
-These features are for improving the overall user experiences.
+These features are for improving the overall user experiences while using speech in Web Chat.
 
-- [Selecting different voice](#selecting-difference-voice)
+- [Selecting different voice](#selecting-different-voice)
 - [Custom Speech](#custom-speech)
 - [Custom Voice](#custom-voice)
 - [Text-to-speech audio format](#text-to-speech-audio-format)
-- [Inverse text normalization option](#inverse-text-normalization-option)
+- [Text normalization options](#text-normalization-options)
 - [Disabling telemetry](#disabling-telemetry)
 - [Using authorization token](#using-authorization-token)
 - [Using two subscription keys for speech-to-text and text-to-speech](#using-two-subscription-keys-for-speech-to-text-and-text-to-speech)
@@ -100,7 +100,7 @@ First, you will need to set up a Custom Speech project. Please follow [this arti
 
 After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
 
-You will then modify your integration code as below.
+You will then need to modify your integration code as below.
 
 ```diff
   renderWebChat({
@@ -124,7 +124,7 @@ First, you will need to set up a Custom Voice project. Please follow [this artic
 
 After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
 
-You will then modify your integration code as below.
+You will then need to modify your integration code as below.
 
 ```diff
   renderWebChat({
@@ -140,7 +140,7 @@ You will then modify your integration code as below.
   }, document.getElementById('webchat'));
 ```
 
-(TBD)
+(TBD for selecting voice)
 
 ### Text-to-speech audio format
 
@@ -162,13 +162,13 @@ To conserve bandwidth, you can set the text-to-speech audio format to a format t
 
 Please refer to [this article for list of supported audio formats](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs).
 
-### Inverse text normalization option
+### Text normalization options
 
-Inverse text normalization (a.k.a. ITN), is an option to modify how the engine is normalizing text. For example, when the end-user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (ITN).
+Text normalization is an option to modify how the speech engine is normalizing text. For example, when the user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (inverse text normalization, or ITN).
 
 You can read more about [various text normalization options in this article](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/rest-speech-to-text.md#response-parameters).
 
-You will modify your integration code as below.
+You will need to modify your integration code as below.
 
 ```diff
   renderWebChat({
@@ -184,7 +184,7 @@ You will modify your integration code as below.
   }, document.getElementById('webchat'));
 ```
 
-> You can pass `"display"` (default), `"itn"`, `"lexical"`, and `"maskeditn"`.
+> Supported text normalization options are `"display"` (default), `"itn"`, `"lexical"`, and `"maskeditn"`.
 
 ### Disabling telemetry
 
@@ -206,7 +206,7 @@ By default, [Azure Cognitive Services are collecting telemetry for service perfo
 
 ### Using authorization token
 
-In our sample, we are using subscription key. If you prfer to use authorization token, you can pass a Promise function that could be potentially a network call.
+In our sample, we are using subscription key. If you are using authorization token, you can pass a `Promise` function that could be potentially a network call.
 
 ```diff
   async function fetchAuthorizationToken() {
@@ -233,11 +233,11 @@ In our sample, we are using subscription key. If you prfer to use authorization 
   }, document.getElementById('webchat'));
 ```
 
-The function passed to `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not handled in this sample code. You should add caching based on the validity of the token.
+The function passed to `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not provided in this sample code. You should add caching based on the validity of the token.
 
 ### Using two subscription keys for speech-to-text and text-to-speech
 
-In some cases, you may need to use two different Cognitive Services subscription, one for speech-to-text and one for text-to-speech. You could create two ponyfills and merge them together as another ponyfill.
+In some cases, you may be using two different Cognitive Services subscriptions, one for speech-to-text and another one for text-to-speech. You could create two ponyfills and merge them together as another ponyfill.
 
 ```diff
 + const speechToTextPonyfillFactory = await createCognitiveServicesSpeechServicesPonyfillFactory({

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -97,6 +97,14 @@ These features are for improving the overall user experiences while using speech
 
 Different voice can be selected based on the synthesizing activity.
 
+By default, we will use the following order to determine which voice to use. And if available, we prefer deep neural network-based voices than traditional voices.
+
+- Locale specified in the activity
+- Display language of Web Chat
+- Browser language
+- "en-US"
+- The first available voice
+
 In the following code, voice is selected based on the language of the synthesizing activity. If the activity is in Cantonese (zh-HK), we will select the voice with keyword "TracyRUS". Otherwise, we will select the voice with keyword "Jessa24kRUS".
 
 ```diff

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -15,18 +15,21 @@ Internet Explorer 11 does not meet the basic requirements for both speech recogn
 ### Speech-to-text requirements
 
 - [WebRTC API support] in browser
-   - All modern browsers, excluding Internet Explorer 11
-- Hosted over HTTPS
-- User permission explicitly given for microphone access
+   - All modern browsers on desktop and mobile platform
+   - With the exception of apps or third-party browsers on iOS
+- Must be hosted over HTTPS
+- User permission explicitly granted for microphone access
 
 #### Special considerations for iOS
 
-Safari is the only browser that support WebRTC API on iOS. Both Chrome and Edge on iOS does not support WebRTC API. Moreover, native apps built using `WKWebView` do not support WebRTC API. Apps based on Cordova/PhoneGap and [React Native WebView](https://github.com/react-native-community/react-native-webview) might need additional plug-ins to support WebRTC API.
+Safari is the only browser that support WebRTC API on iOS.
+
+Chrome, Edge and native apps built using `WKWebView` does not support WebRTC API. Apps based on Cordova/PhoneGap and [React Native WebView](https://github.com/react-native-community/react-native-webview) might need additional plug-ins or custom code to support WebRTC API.
 
 ### Text-to-speech requirements
 
 - [Web Audio API support] in browser
-   - All modern browsers, excluding Internet Explorer 11
+   - All modern browsers on desktop and mobile platform
 
 #### Special considerations for Safari on Mac OS and iOS
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -252,7 +252,8 @@ In our sample, we are using subscription key. If you are using authorization tok
     }),
     language: 'en-US',
     webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
-+     // Note we are passing the function, but not the result of the function call, there is no () behind it
++     // Note we are passing the function, but not the result of the function call, there is no () appended to it.
++     // This function will be called every time the authorization token is being used.
 +     authorizationToken: fetchAuthorizationToken,
       region: 'YOUR_REGION',
 -     subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -215,7 +215,7 @@ You will need to modify your integration code as below.
 
 ### Disabling telemetry
 
-By default, [Azure Cognitive Services are collecting telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, modify the code as below.
+By default, [Azure Cognitive Services will collect telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, modify the code as below.
 
 ```diff
   renderWebChat({

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -50,7 +50,7 @@ To prevent leaking your subscription key, you should build/host a server which u
 
 ### Integrating Web Chat into your page
 
-This integration code is excerpted from a [sample named "Integrating with Cognitive Services Speech Services"](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js).
+This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js).
 
 > To bring more focus around the integration, we simplified from the original sample code by using subscription key instead of authorization token. You should always use authorization token for production systems.
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -6,19 +6,19 @@ We assume you have already set up a bot and have Web Chat running on a page.
 
 > Sample code in this article are optimized for modern browsers. You may need to use a [transpiler](https://en.wikipedia.org/wiki/Source-to-source_compiler) (e.g. [Babel](https://babeljs.io/)) to target broader range of browsers.
 
-## Browser requirements
+## Requirements
 
 In order to use speech functionality in Web Chat, browser would need to provide minimum media capabilities, including recording from microphone and playing audio clips.
 
-Internet Explorer 11 does not meet the basic requirements for both speech recognition and synthesis.
+Internet Explorer 11 does not meet the basic requirements for both speech recognition and speech synthesis.
 
 ### Speech-to-text requirements
 
-- [WebRTC API support] in browser
+- Browser must [support WebRTC API][WebRTC API support]
    - All modern browsers on desktop and mobile platform
-   - With the exception of apps or third-party browsers on iOS
-- Must be hosted over HTTPS
-- User permission explicitly granted for microphone access
+   - With the exception of third-party apps or browsers on iOS
+- Web page must be hosted over HTTPS
+- User must explicitly grant permission for microphone access
 
 #### Special considerations for iOS
 
@@ -28,7 +28,7 @@ Chrome, Edge and native apps built using `WKWebView` does not support WebRTC API
 
 ### Text-to-speech requirements
 
-- [Web Audio API support] in browser
+- Browser must [support Web Audio API][Web Audio API support]
    - All modern browsers on desktop and mobile platform
 
 #### Special considerations for Safari on Mac OS and iOS
@@ -323,8 +323,8 @@ Using this approach, you can also combine two polyfills of different types. For 
 ## Related articles
 
 - [Try Cognitive Services]
-- [Web Audio API support]
-- [WebRTC API Support]
+- [Web Audio API support][Browsers which support Web Audio API]
+- [WebRTC API Support][Browsers which support WebRTC API]
 - [Get started with Custom Voice]
 - [What is Custom Speech]
 - [Sample: Integrating with Cognitive Services Speech Services]

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -51,7 +51,7 @@ You will need to obtain a subscription key for your Azure Cognitive Services sub
 
 To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization tokens, and only send the authorization token to the client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Azure resources in a production environment.*
 
-> To use [new voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
+> To use [new voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region or [other supported regions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/regions#standard-and-neural-voices).
 
 ### Integrating Web Chat into your page
 
@@ -84,6 +84,7 @@ After adding the ponyfill factory, you should be able to see a microphone button
 
 These features are for improving the overall user experiences while using speech in Web Chat.
 
+- [Using Speech Synthesis Markup Language](#using-speech-synthesis-markup-language)
 - [Selecting voice](#selecting-voice)
 - [Custom Speech](#custom-speech)
 - [Custom Voice](#custom-voice)
@@ -92,6 +93,32 @@ These features are for improving the overall user experiences while using speech
 - [Disabling telemetry](#disabling-telemetry)
 - [Using authorization token](#using-authorization-token)
 - [Using two subscription keys for speech-to-text and text-to-speech](#using-two-subscription-keys-for-speech-to-text-and-text-to-speech)
+
+### Using Speech Synthesis Markup Language
+
+Instead of synthesizing text, Web Chat can also synthesize [Speech Synthesis Markup Language] (or SSML). [Cognitive Services supports SSML 1.0 with "mstts" extensions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup).
+
+When the bot send the activity, simply the SSML in the `speak` property.
+
+```xml
+<speak
+  version="1.0"
+  xmlns="https://www.w3.org/2001/10/synthesis"
+  xmlns:mstts="https://www.w3.org/2001/mstts"
+  xml:lang="en-US"
+>
+  <voice name="en-US-JessaNeural">
+    <mstts:express-as type="cheerful">That'd be just amazing!</mstts:express-as>
+  </voice>
+  <voice name="zh-HK-TracyRUS">
+    <prosody pitch="+150%">太神奇啦！</prosody>
+  </voice>
+</speak>
+```
+
+> The SSML code snippet above is using neural voice "JessaNeural" for expression, which is only supported in some regions.
+
+With "mstts" extension, you can also [add speaking style](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup#adjust-speaking-styles) (e.g. cheerful) and [background audio](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup#add-background-audio) to your synthesized speech.
 
 ### Selecting voice
 
@@ -102,7 +129,7 @@ By default, we will use the following order to determine which voice to use. And
 - Locale specified in the activity
 - Display language of Web Chat
 - Browser language
-- "en-US"
+- English (US)
 - The first available voice
 
 In the following code, voice is selected based on the language of the synthesizing activity. If the activity is in Cantonese (zh-HK), we will select the voice with keyword "TracyRUS". Otherwise, we will select the voice with keyword "Jessa24kRUS".
@@ -325,6 +352,7 @@ Using this approach, you can also combine two polyfills of different types. For 
 - [Try Cognitive Services]
 - [List of browsers which support Web Audio API][Web Audio API support]
 - [List of browsers which support WebRTC API][WebRTC API Support]
+- [Speech Synthesis Markup Language (SSML)][Speech Synthesis Markup Language]
 - [Get started with Custom Voice]
 - [What is Custom Speech]
 - [Sample: Integrating with Cognitive Services Speech Services]
@@ -333,8 +361,9 @@ Using this approach, you can also combine two polyfills of different types. For 
 [Authenticate requests to Azure Cognitive Services]: https://docs.microsoft.com/en-us/azure/cognitive-services/authentication
 [Get started with Custom Voice]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice
 [Sample: Integrating with Cognitive Services Speech Services]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js
-[Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
 [Sample: Using hybrid speech engine]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.f.hybrid-speech
+[Speech Synthesis Markup Language]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup)
+[Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
 [Web Audio API support]: https://caniuse.com/#feat=audio-api
 [WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
 [What is Custom Speech]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -1,0 +1,269 @@
+# Using Cognitive Services Speech Services
+
+This guide is for integrating speech-to-text and text-to-speech functionality of Azure Cognitive Services.
+
+We assume you have already set up a bot and have Web Chat running on a page.
+
+> Sample code in this article are optimized for modern browsers. You may need to use a transpiler  (e.g. [Babel](https://babeljs.io/)) to target broader range of browsers.
+
+## Browser requirements
+
+In order to use speech functionality in Web Chat, browser would need to provide minimum media capabilities, including recording from microphone and playing audio clips.
+
+### Speech-to-text
+
+Speech-to-text requires:
+
+- [WebRTC support](https://caniuse.com/#feat=rtcpeerconnection) in browser
+   - All modern browsers, excludes Internet Explorer 11
+- Hosted over HTTPS
+- User permission given for microphone access
+
+On iOS, Safari is the only browser that support WebRTC. Both Chrome and Edge on iOS does not support WebRTC. Moreover, native apps built using `WKWebView` do not support WebRTC. This would include apps built using Cordova/PhoneGap and React Native.
+
+### Text-to-speech
+
+Text-to-speech requires:
+
+- [Web Audio API support](https://caniuse.com/#feat=audio-api) in browser
+   - All modern browsers, excludes Internet Explorer 11
+
+#### Special considerations for Safari
+
+> This includes both Safari on Mac OS and iOS.
+
+To play an audio clip, Safari requires additional permission granted implicitly by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played.
+
+Web Chat will play a very short and silent audio clip when the user tap on the send button. This will enable Web Chat to play any audio clip during the browser session. If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari.
+
+In order to workaround with this requirement, you can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance.
+
+## Setting up Web Chat
+
+Web Chat is bundled with Web Speech API adapter for Cognitive Services.
+
+### Setting up your Azure subscription
+
+You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page](https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech) to obtain a subscription key.
+
+To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication).
+
+> To use the latest neural speech voice, you might need to have a subscription in "West US 2" region.
+
+### Integrating Web Chat into your page
+
+This integration code is excerpted from a [sample named "Integrating with Cognitive Services Speech Services"](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js).
+
+> To focus on the integration code, we simplified from the original by using subscription key instead of authorization token. You should always use authorization token for production systems.
+
+```js
+const {
+  createCognitiveServicesSpeechServicesPonyfillFactory,
+  createDirectLine,
+  renderWebChat
+} = window.WebChat;
+
+renderWebChat({
+  directLine: createDirectLine({
+    secret: 'YOUR_DIRECT_LINE_SECRET'
+  }),
+  language: 'en-US',
+  webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+    region: 'YOUR_REGION',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  })
+}, document.getElementById('webchat'));
+```
+
+After adding the ponyfill factory, you should be able to see microphone button in Web Chat.
+
+## Additional features
+
+These features are for improving the overall user experiences.
+
+### Selecting different voice
+
+(TBD)
+
+### Custom Speech
+
+Custom Speech is a trained model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or people names.
+
+First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech).
+
+After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
+
+You will then modify your integration code as below.
+
+```diff
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+      region: 'YOUR_REGION',
++     speechRecognitionEndpointId: 'YOUR_ENDPOINT_ID',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+    })
+  }, document.getElementById('webchat'));
+```
+
+### Custom Voice
+
+Custom Voice is a trained model for providing your user with an unique voice when performing text-to-speech.
+
+First, you will need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice).
+
+After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
+
+You will then modify your integration code as below.
+
+```diff
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+      region: 'YOUR_REGION',
++     speechSynthesisDeploymentId: 'YOUR_DEPLOYMENT_ID',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+    })
+  }, document.getElementById('webchat'));
+```
+
+(TBD)
+
+### Text-to-speech audio format
+
+To conserve bandwidth, you can set the text-to-speech audio format to a format that consume less bandwidth by modifying your integration code as below.
+
+```diff
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+      region: 'YOUR_REGION',
++     speechSynthesisOutputFormat: 'audio-24khz-48kbitrate-mono-mp3',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+    })
+  }, document.getElementById('webchat'));
+```
+
+Please refer to [this article for list of supported audio formats](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs).
+
+### Inverse text normalization options
+
+Inverse text normalization (a.k.a. ITN), is an option to modify how the engine is normalizing text. For example, when the end-user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (ITN).
+
+You can read more about [various text normalization options in this article](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/rest-speech-to-text.md#response-parameters).
+
+You will modify your integration code as below.
+
+```diff
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+      region: 'YOUR_REGION',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',
++     textNormalization: 'itn'
+    })
+  }, document.getElementById('webchat'));
+```
+
+> You can pass `"display"` (default), `"itn"`, `"lexical"`, and `"maskeditn"`.
+
+### Disabling telemetry
+
+By default, [Azure Cognitive Services are collecting telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, modify the code as below.
+
+```diff
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
++     enableTelemtry: false,
+      region: 'YOUR_REGION',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',
+    })
+  }, document.getElementById('webchat'));
+```
+
+### Using authorization token
+
+In our sample, we are using subscription key. If you prfer to use authorization token, you can pass a Promise function that could be potentially a network call.
+
+```diff
+  async function fetchAuthorizationToken() {
+    const res = await fetch('/api/speechtoken');
+
+    if (res.ok) {
+      return await res.text();
+    } else {
+      throw new Error('Failed to retrieve authorization token for Cognitive Services.');
+    }
+  }
+
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
++     // Note we are passing the function, but not the result of the function call, there is no () behind it
++     authorizationToken: fetchAuthorizationToken,
+      region: 'YOUR_REGION',
+-     subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',
+    })
+  }, document.getElementById('webchat'));
+```
+
+The function passed to `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not handled in this sample code. You should add caching based on the validity of the token.
+
+### Using two different subscription key for speech-to-text and text-to-speech
+
+If you need to use two different Cognitive Services subscription, one for speech-to-text and one for text-to-speech, you can create two ponyfills and merge them together as another ponyfill.
+
+```diff
++ const speechToTextPonyfillFactory = await createCognitiveServicesSpeechServicesPonyfillFactory({
++   region: 'YOUR_STT_REGION',
++   subscriptionKey: 'YOUR_STT_SUBSCRIPTION_KEY',
++ });
+
++ const textToSpeechPonyfillFactory = await createCognitiveServicesSpeechServicesPonyfillFactory({
++   region: 'YOUR_TTS_REGION',
++   subscriptionKey: 'YOUR_TTS_SUBSCRIPTION_KEY',
++ });
+
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
+-   webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+-     region: 'YOUR_REGION',
+-     subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',
+-   })
+    webSpeechPonyfillFactory: options => {
+      const { SpeechGrammarList, SpeechRecognition } = speechToTextPonyfillFactory(options);
+      const { speechSynthesis, SpeechSynthesisUtterance } = textToSpeechPonyfillFactory(options);
+
+      return {
+        SpeechGrammarList,
+        SpeechRecognition,
+        speechSynthesis,
+        SpeechSynthesisUtterance
+      };
+    }
+  }, document.getElementById('webchat'));
+```
+
+> Note: it is correct that `speechSynthesis` is in camel-casing, while others are in Pascal-casing.

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -222,7 +222,7 @@ To select different text normalization option, you will need to modify your inte
 
 ### Disabling telemetry
 
-By default, [Azure Cognitive Services will collect telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, modify the code as below.
+By default, [Azure Cognitive Services will collect telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, please modify the code as below.
 
 ```diff
   renderWebChat({
@@ -240,7 +240,7 @@ By default, [Azure Cognitive Services will collect telemetry for service perform
 
 ### Using authorization token
 
-In our sample, we are using subscription key. If you are using authorization token, you can pass a `Promise` function that could be potentially a network call.
+For simplicity, in our sample, we are using subscription key. If you need to use authorization token, you can pass a `Promise` function to the `authorizationToken` property. And the function could potentially be a network call to your token server.
 
 ```diff
   async function fetchAuthorizationToken() {

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -79,7 +79,7 @@ After adding the ponyfill factory, you should be able to see a microphone button
 
 These features are for improving the overall user experiences while using speech in Web Chat.
 
-- [Selecting different voice](#selecting-different-voice)
+- [Selecting voice](#selecting-voice)
 - [Custom Speech](#custom-speech)
 - [Custom Voice](#custom-voice)
 - [Text-to-speech audio format](#text-to-speech-audio-format)
@@ -88,9 +88,37 @@ These features are for improving the overall user experiences while using speech
 - [Using authorization token](#using-authorization-token)
 - [Using two subscription keys for speech-to-text and text-to-speech](#using-two-subscription-keys-for-speech-to-text-and-text-to-speech)
 
-### Selecting different voice
+### Selecting voice
 
-(TBD)
+Different voice can be selected based on the synthesizing activity.
+
+In the following code, voice is selected based on the language of the synthesizing activity. If the activity is in Cantonese, we will select the voice with keyword "TracyRUS". Otherwise, we will select the voice with keyword "Jessa24kRUS".
+
+```diff
+  const {
+    createCognitiveServicesSpeechServicesPonyfillFactory,
+    createDirectLine,
+    renderWebChat
+  } = window.WebChat;
+
+  renderWebChat({
+    directLine: createDirectLine({
+      secret: 'YOUR_DIRECT_LINE_SECRET'
+    }),
+    language: 'en-US',
++   selectVoice: (voices, activity) => {
++     if (activity.locale === 'zh-HK') {
++       return voices.find(({ name }) => /TracyRUS/iu.test(name));
++     } else {
++       return voices.find(({ name }) => /Jessa24kRUS/iu.test(name));
++     }
++   }
+    webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
+      region: 'YOUR_REGION',
+      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+    })
+  }, document.getElementById('webchat'));
+```
 
 ### Custom Speech
 
@@ -124,7 +152,7 @@ First, you will need to set up a Custom Voice project. Please follow [this artic
 
 After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
 
-You will then need to modify your integration code as below.
+You will then need to modify your integration code as below. The `selectVoice` function will always choose the voice of your trained model.
 
 ```diff
   renderWebChat({
@@ -132,6 +160,7 @@ You will then need to modify your integration code as below.
       secret: 'YOUR_DIRECT_LINE_SECRET'
     }),
     language: 'en-US',
++   selectVoice: () => ({ voiceURI: 'YOUR_VOICE_MODEL_NAME' }),
     webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
       region: 'YOUR_REGION',
 +     speechSynthesisDeploymentId: 'YOUR_DEPLOYMENT_ID',
@@ -139,8 +168,6 @@ You will then need to modify your integration code as below.
     })
   }, document.getElementById('webchat'));
 ```
-
-(TBD for selecting voice)
 
 ### Text-to-speech audio format
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -337,4 +337,4 @@ Using this approach, you can also combine two polyfills of different types. For 
 [Sample: Using hybrid speech engine]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.f.hybrid-speech
 [Web Audio API support]: https://caniuse.com/#feat=audio-api
 [WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
-[What is Custom Speech]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech)
+[What is Custom Speech]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -4,53 +4,55 @@ This guide is for integrating speech-to-text and text-to-speech functionality of
 
 We assume you have already set up a bot and have Web Chat running on a page.
 
-> Sample code in this article are optimized for modern browsers. You may need to use a transpiler  (e.g. [Babel](https://babeljs.io/)) to target broader range of browsers.
+> Sample code in this article are optimized for modern browsers. You may need to use a [transpiler](https://en.wikipedia.org/wiki/Source-to-source_compiler) (e.g. [Babel](https://babeljs.io/)) to target broader range of browsers.
 
 ## Browser requirements
 
 In order to use speech functionality in Web Chat, browser would need to provide minimum media capabilities, including recording from microphone and playing audio clips.
 
-### Speech-to-text
+Internet Explorer 11 does not meet the basic requirements for both speech recognition and synthesis.
 
-Speech-to-text requires:
+### Speech-to-text requirements
 
-- [WebRTC support](https://caniuse.com/#feat=rtcpeerconnection) in browser
+- [WebRTC API support] in browser
    - All modern browsers, excluding Internet Explorer 11
 - Hosted over HTTPS
 - User permission explicitly given for microphone access
 
-On iOS, Safari is the only browser that support WebRTC. Both Chrome and Edge on iOS does not support WebRTC. Moreover, native apps built using `WKWebView` do not support WebRTC. This would include apps built using Cordova/PhoneGap and React Native.
+#### Special considerations for iOS
 
-### Text-to-speech
+Safari is the only browser that support WebRTC API on iOS. Both Chrome and Edge on iOS does not support WebRTC API. Moreover, native apps built using `WKWebView` do not support WebRTC API. Apps based on Cordova/PhoneGap and [React Native WebView](https://github.com/react-native-community/react-native-webview) might need additional plug-ins to support WebRTC API.
 
-Text-to-speech requires:
+### Text-to-speech requirements
 
-- [Web Audio API support](https://caniuse.com/#feat=audio-api) in browser
+- [Web Audio API support] in browser
    - All modern browsers, excluding Internet Explorer 11
 
 #### Special considerations for Safari on Mac OS and iOS
 
-To play an audio clip, Safari requires additional permission granted *implicitly* by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played.
+Safari requires additional permission granted *implicitly* by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played during the browser session.
 
-Web Chat will play a very short and silent audio clip when the user tap on the send button. This will enable Web Chat to play any audio clip during the browser session. If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari.
+When the user tap on the microphone button for the first time, Web Chat will play a very short and silent audio clip. This will enable Web Chat to play any audio clip synthesized from bot messages.
 
-In order to workaround with this requirement, you can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance.
+If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari for audio playback. Thus, bot messages will not be synthesized.
+
+You can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance and unblock Safari.
 
 ## Setting up Web Chat
 
-Web Chat is bundled with Web Speech API adapter for Cognitive Services.
+To use Cognitive Services in Web Chat, you will need to add minimal setup code to wire them up with your subscription.
 
 ### Setting up your Azure subscription
 
-You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page](https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech) to obtain a subscription key.
+You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page][Try Cognitive Services] to obtain a subscription key.
 
-To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication).
+To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services].
 
 > To use the [voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
 
 ### Integrating Web Chat into your page
 
-This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js).
+This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Integrating with Cognitive Services Speech Services sample].
 
 > To bring more focus around the integration, we simplified from the original sample code by using subscription key instead of authorization token. You should always use authorization token for production systems.
 
@@ -124,7 +126,7 @@ In the following code, voice is selected based on the language of the synthesizi
 
 Custom Speech is a trained model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or people names.
 
-First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech).
+First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech?].
 
 After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
 
@@ -148,7 +150,7 @@ You will then need to modify your integration code as below.
 
 Custom Voice is a trained model for providing your user with an unique voice when performing text-to-speech.
 
-First, you will need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice).
+First, you will need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project][Get started with Custom Voice].
 
 After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
 
@@ -302,3 +304,19 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 ```
 
 > Note: it is correct that `speechSynthesis` is in camel-casing, while others are in Pascal-casing.
+
+## Related articles
+
+- [Web Audio API support]
+- [WebRTC API Support]
+- [Integrating with Cognitive Services Speech Services sample]
+- [Get started with Custom Voice]
+- [What is Custom Speech?]
+
+[Authenticate requests to Azure Cognitive Services]: https://docs.microsoft.com/en-us/azure/cognitive-services/authentication
+[Get started with Custom Voice]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice
+[Integrating with Cognitive Services Speech Services sample]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js
+[Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
+[Web Audio API support]: https://caniuse.com/#feat=audio-api
+[WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
+[What is Custom Speech?]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech)

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -198,11 +198,11 @@ Please refer to [this article for list of supported audio formats](https://docs.
 
 ### Text normalization options
 
-Text normalization is an option to modify how the speech engine is normalizing text. For example, when the user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (inverse text normalization, or ITN).
+Text normalization is an option to modify how the speech engine normalize texts. For example, when the user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (inverse text normalization, or ITN).
 
 You can read more about [various text normalization options in this article](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/rest-speech-to-text.md#response-parameters).
 
-You will need to modify your integration code as below.
+To select different text normalization option, you will need to modify your integration code as below.
 
 ```diff
   renderWebChat({

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -323,8 +323,8 @@ Using this approach, you can also combine two polyfills of different types. For 
 ## Related articles
 
 - [Try Cognitive Services]
-- [Web Audio API support][Browsers which support Web Audio API]
-- [WebRTC API Support][Browsers which support WebRTC API]
+- [List of browsers which support Web Audio API][Web Audio API support]
+- [List of browsers which support WebRTC API][WebRTC API Support]
 - [Get started with Custom Voice]
 - [What is Custom Speech]
 - [Sample: Integrating with Cognitive Services Speech Services]

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -4,58 +4,58 @@ This guide is for integrating speech-to-text and text-to-speech functionality of
 
 We assume you have already set up a bot and have Web Chat running on a page.
 
-> Sample code in this article are optimized for modern browsers. You may need to use a [transpiler](https://en.wikipedia.org/wiki/Source-to-source_compiler) (e.g. [Babel](https://babeljs.io/)) to target broader range of browsers.
+> Sample code in this article is optimized for modern browsers. You may need to use a [transpiler](https://en.wikipedia.org/wiki/Source-to-source_compiler) (e.g. [Babel](https://babeljs.io/)) to target a broader range of browsers.
 
 ## Requirements
 
-In order to use speech functionality in Web Chat, browser would need to provide minimum media capabilities, including recording from microphone and playing audio clips.
+In order to use the speech functionality in Web Chat, the browser needs to provide minimal media capabilities, including recording from microphone and playing audio clips.
 
 Internet Explorer 11 does not meet the basic requirements for both speech recognition and speech synthesis.
 
 ### Speech-to-text requirements
 
 - Browser must [support WebRTC API][WebRTC API support]
-   - All modern browsers on desktop and mobile platform
-   - With the exception of third-party apps or browsers on iOS
+   - Available on most modern browsers on desktop and mobile platform
+   - WebRTC will not work on third-party apps or browsers on iOS
 - Web page must be hosted over HTTPS
 - User must explicitly grant permission for microphone access
 
 #### Special considerations for iOS
 
-Safari is the only browser that support WebRTC API on iOS.
+Safari is the only browser that supports WebRTC API on iOS.
 
-Chrome, Edge and native apps built using `WKWebView` does not support WebRTC API. Apps based on Cordova/PhoneGap and [React Native WebView](https://github.com/react-native-community/react-native-webview) might need additional plug-ins or custom code to support WebRTC API.
+Chrome, Edge and native apps built using `WKWebView` do not support WebRTC API. Apps based on Cordova/PhoneGap and [React Native WebView](https://github.com/react-native-community/react-native-webview) might need additional plugins or custom code to support WebRTC API.
 
 ### Text-to-speech requirements
 
 - Browser must [support Web Audio API][Web Audio API support]
-   - All modern browsers on desktop and mobile platform
+   - Available on all modern browsers on desktop and mobile platform
 
 #### Special considerations for Safari on Mac OS and iOS
 
 Safari requires additional permission granted *implicitly* by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played during the browser session.
 
-When the user tap on the microphone button for the first time, Web Chat will play a very short and silent audio clip. This will enable Web Chat to play any audio clip synthesized from bot messages.
+When the user taps on the microphone button for the first time, Web Chat will play a very short and silent audio clip. This will enable Web Chat to play any audio clip synthesized from bot messages.
 
-If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari for audio playback. Thus, bot messages will not be synthesized.
+If you customize Web Chat to perform any text-to-speech operations before user gestures, Web Chat will be blocked by Safari for audio playback. Thus, bot messages will not be synthesized.
 
-You can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance to unblock Safari.
+You can present a splash screen with a tap-to-continue button, which will ready the engine by sending an empty utterance to unblock Safari.
 
 ## Setting up Web Chat
 
-To use Cognitive Services in Web Chat, you will need to add minimal setup code to wire them up with your subscription.
+To use Cognitive Services in Web Chat, you will need to add minimal setup code to set up Web Chat with your Cognitive Services subscription.
 
 ### Setting up your Azure subscription
 
 You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page][Try Cognitive Services] to obtain a subscription key.
 
-To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization tokens, and only send the authorization token to the client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Azure resources in a production environment.*
+To prevent exposing your subscription key, you should build/host a server that uses your subscription key to generate authorization tokens, and only send the authorization token to the client. You can find more information about authorization tokens on the [Cognitive Services Authentication documentation][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Azure resources in a production environment.*
 
 > To use [new voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region or [other supported regions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/regions#standard-and-neural-voices).
 
 ### Integrating Web Chat into your page
 
-This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Sample: Integrating with Cognitive Services Speech Services].
+This integration code is excerpted from the sample named ["Integrating with Cognitive Services Speech Services"][Sample: Integrating with Cognitive Services Speech Services].
 
 > To bring more focus to the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production environment.
 
@@ -78,11 +78,11 @@ renderWebChat({
 }, document.getElementById('webchat'));
 ```
 
-After adding the ponyfill factory, you should be able to see a microphone button in Web Chat.
+After adding the ponyfill factory, you should be able to see the microphone button in Web Chat, which indicates that speech is enabled.
 
 ## Additional features
 
-These features are for improving the overall user experiences while using speech in Web Chat.
+These features are for improving the overall user experience while using speech in Web Chat.
 
 - [Using Speech Synthesis Markup Language](#using-speech-synthesis-markup-language)
 - [Selecting voice](#selecting-voice)
@@ -98,7 +98,7 @@ These features are for improving the overall user experiences while using speech
 
 Instead of synthesizing text, Web Chat can also synthesize [Speech Synthesis Markup Language] (or SSML). [Cognitive Services supports SSML 1.0 with "mstts" extensions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup).
 
-When the bot send the activity, simply the SSML in the `speak` property.
+When the bot sends the activity, simply the SSML in the `speak` property.
 
 ```xml
 <speak
@@ -122,9 +122,9 @@ With "mstts" extension, you can also [add speaking style](https://docs.microsoft
 
 ### Selecting voice
 
-Different voice can be selected based on the synthesizing activity.
+Different voices can be selected based on the synthesizing activity.
 
-By default, we will use the following order to determine which voice to use. And if available, we prefer deep neural network-based voices than traditional voices.
+By default, we will use the following order to determine which voice to use. If available, we prioritize deep neural network-based voices over traditional voices.
 
 - Locale specified in the activity
 - Display language of Web Chat
@@ -162,11 +162,11 @@ In the following code, voice is selected based on the language of the synthesizi
 
 ### Custom Speech
 
-Custom Speech is a trained recognition model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or name of person.
+Custom Speech is a trained recognition model that improves recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademark words or the name of a person.
 
-First, you need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech].
+First, you need to set up a Custom Speech project. Please follow the article on [creating a new Custom Speech project][What is Custom Speech].
 
-After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
+After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save your "Endpoint ID".
 
 You will then need to modify your integration code as below.
 
@@ -188,9 +188,9 @@ You will then need to modify your integration code as below.
 
 Custom Voice is a trained synthesis model for providing your user with an unique synthesized voice when performing text-to-speech.
 
-First, you need to set up a Custom Voice project. Please follow [this article to create a new Custom Voice project][Get started with Custom Voice].
+First, you need to set up a Custom Voice project. Please follow the article on [creating a new Custom Voice project][Get started with Custom Voice].
 
-After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and "Endpoint URL".
+After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and your "Endpoint URL".
 
 You will then need to modify your integration code as below. The `selectVoice` function will be used to choose which trained synthesis model to use.
 
@@ -213,7 +213,7 @@ You will then need to modify your integration code as below. The `selectVoice` f
 
 ### Text-to-speech audio format
 
-To conserve bandwidth, you can set the text-to-speech audio format to one that consume less bandwidth by modifying your integration code as below.
+To conserve bandwidth, you can set the text-to-speech audio format to one that consumes less bandwidth by modifying your integration code as below:
 
 ```diff
   renderWebChat({
@@ -229,15 +229,15 @@ To conserve bandwidth, you can set the text-to-speech audio format to one that c
   }, document.getElementById('webchat'));
 ```
 
-Please refer to [this article for list of supported audio formats](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs).
+Please refer to the following list of [supported audio formats](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs).
 
 ### Text normalization options
 
-Text normalization is an option to modify how the speech engine normalize texts. For example, when the user say, "I would like to order 2 4-piece of chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (inverse text normalization, or ITN).
+Text normalization is an ability to modify how the speech engine normalizes text. For example, when the user says, "I would like to order 2 4-piece chicken nuggets." It could be recognized as "two four piece" (default) or "2 four piece" (inverse text normalization, or ITN).
 
-You can read more about [various text normalization options in this article](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/rest-speech-to-text.md#response-parameters).
+You can read more about [various text normalization options](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/rest-speech-to-text.md#response-parameters).
 
-To select different text normalization option, you will need to modify your integration code as below.
+To select different text normalization options, you will need to modify your integration code as below:
 
 ```diff
   renderWebChat({
@@ -257,7 +257,7 @@ To select different text normalization option, you will need to modify your inte
 
 ### Disabling telemetry
 
-By default, [Azure Cognitive Services will collect telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, please modify the code as below.
+By default, [Azure Cognitive Services will collect telemetry for service performance](https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry). If you prefer to disable telemetry, please modify the code as below:
 
 ```diff
   renderWebChat({
@@ -275,7 +275,7 @@ By default, [Azure Cognitive Services will collect telemetry for service perform
 
 ### Using authorization token
 
-For simplicity, in our sample, we are using subscription key. If you need to use authorization token, you can pass a `Promise` function to the `authorizationToken` property. And the function could potentially be a network call to your token server.
+This sample uses a subscription key for simplicity. If you need to use authorization token, you can pass a `Promise` function to the `authorizationToken` property. The function could potentially be a network call to your token server.
 
 ```diff
   async function fetchAuthorizationToken() {
@@ -294,7 +294,7 @@ For simplicity, in our sample, we are using subscription key. If you need to use
     }),
     language: 'en-US',
     webSpeechPonyfillFactory: await createCognitiveServicesSpeechServicesPonyfillFactory({
-+     // Note we are passing the function, but not the result of the function call, there is no () appended to it.
++     // Note we are passing the function, not the result of the function call, as there is no () appended to it.
 +     // This function will be called every time the authorization token is being used.
 +     authorizationToken: fetchAuthorizationToken,
       region: 'YOUR_REGION',
@@ -303,7 +303,7 @@ For simplicity, in our sample, we are using subscription key. If you need to use
   }, document.getElementById('webchat'));
 ```
 
-The function `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not provided in this sample code. You should add caching based on the validity of the token.
+The function `fetchAuthorizationToken` will be called *every time* a token is needed. For simplicity, token caching is not provided in this sample code. You should add caching based on the validity of the token.
 
 ### Using two subscription keys for speech-to-text and text-to-speech
 
@@ -345,7 +345,7 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 
 > Note: it is correct that `speechSynthesis` is in camel-casing, while others are in Pascal-casing.
 
-Using this approach, you can also combine two polyfills of different types. For example, speech recognition powered by Cognitive Services with browser-supported speech synthesis. You can refer to [this sample for the hybrid speech approach][Sample: Using hybrid speech engine].
+Using this approach, you can also combine two polyfills of different types. For example, speech recognition powered by Cognitive Services with browser-supported speech synthesis. You can refer to our Web Chat sample [on hybrid speech][Sample: Using hybrid speech engine] to learn more.
 
 ## Related articles
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -15,9 +15,9 @@ In order to use speech functionality in Web Chat, browser would need to provide 
 Speech-to-text requires:
 
 - [WebRTC support](https://caniuse.com/#feat=rtcpeerconnection) in browser
-   - All modern browsers, excludes Internet Explorer 11
+   - All modern browsers, excluding Internet Explorer 11
 - Hosted over HTTPS
-- User permission given for microphone access
+- User permission explicitly given for microphone access
 
 On iOS, Safari is the only browser that support WebRTC. Both Chrome and Edge on iOS does not support WebRTC. Moreover, native apps built using `WKWebView` do not support WebRTC. This would include apps built using Cordova/PhoneGap and React Native.
 
@@ -26,13 +26,11 @@ On iOS, Safari is the only browser that support WebRTC. Both Chrome and Edge on 
 Text-to-speech requires:
 
 - [Web Audio API support](https://caniuse.com/#feat=audio-api) in browser
-   - All modern browsers, excludes Internet Explorer 11
+   - All modern browsers, excluding Internet Explorer 11
 
-#### Special considerations for Safari
+#### Special considerations for Safari on Mac OS and iOS
 
-> This includes both Safari on Mac OS and iOS.
-
-To play an audio clip, Safari requires additional permission granted implicitly by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played.
+To play an audio clip, Safari requires additional permission granted *implicitly* by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played.
 
 Web Chat will play a very short and silent audio clip when the user tap on the send button. This will enable Web Chat to play any audio clip during the browser session. If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari.
 
@@ -48,7 +46,7 @@ You will need to obtain a subscription key for your Azure Cognitive Services sub
 
 To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication).
 
-> To use the latest neural speech voice, you might need to have a subscription in "West US 2" region.
+> To use the [voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
 
 ### Integrating Web Chat into your page
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -33,7 +33,7 @@ Chrome, Edge and native apps built using `WKWebView` do not support WebRTC API. 
 
 #### Special considerations for Safari on Mac OS and iOS
 
-Safari requires additional permission granted *implicitly* by the user. The user would need to perform an interaction (click/tap/type) before any audio clips can be played during the browser session.
+Safari requires additional permission granted *implicitly* by the user. The user needs to perform an interaction (click/tap/type) before any audio clips can be played during the browser session.
 
 When the user taps on the microphone button for the first time, Web Chat will play a very short and silent audio clip. This will enable Web Chat to play any audio clip synthesized from bot messages.
 
@@ -98,7 +98,7 @@ These features are for improving the overall user experience while using speech 
 
 Instead of synthesizing text, Web Chat can also synthesize [Speech Synthesis Markup Language] (or SSML). [Cognitive Services supports SSML 1.0 with "mstts" extensions](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup).
 
-When the bot sends the activity, simply the SSML in the `speak` property.
+When the bot sends the activity, include the SSML in the `speak` property.
 
 ```xml
 <speak
@@ -110,8 +110,8 @@ When the bot sends the activity, simply the SSML in the `speak` property.
   <voice name="en-US-JessaNeural">
     <mstts:express-as type="cheerful">That'd be just amazing!</mstts:express-as>
   </voice>
-  <voice name="zh-HK-TracyRUS">
-    <prosody pitch="+150%">太神奇啦！</prosody>
+  <voice name="ja-JP-Ayumi-Apollo">
+    <prosody pitch="+150%">素晴らしい!</prosody>
   </voice>
 </speak>
 ```
@@ -190,7 +190,7 @@ Custom Voice is a trained synthesis model for providing your user with an unique
 
 First, you need to set up a Custom Voice project. Please follow the article on [creating a new Custom Voice project][Get started with Custom Voice].
 
-After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and your "Endpoint URL".
+After your Custom Voice project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Model / Voice name" and the value of "deploymentId" inside the "Endpoint URL" field.
 
 You will then need to modify your integration code as below. The `selectVoice` function will be used to choose which trained synthesis model to use.
 
@@ -329,17 +329,17 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 -     region: 'YOUR_REGION',
 -     subscriptionKey: 'YOUR_SUBSCRIPTION_KEY',
 -   })
-    webSpeechPonyfillFactory: options => {
-      const { SpeechGrammarList, SpeechRecognition } = speechToTextPonyfillFactory(options);
-      const { speechSynthesis, SpeechSynthesisUtterance } = textToSpeechPonyfillFactory(options);
-
-      return {
-        SpeechGrammarList,
-        SpeechRecognition,
-        speechSynthesis,
-        SpeechSynthesisUtterance
-      };
-    }
++   webSpeechPonyfillFactory: options => {
++     const { SpeechGrammarList, SpeechRecognition } = speechToTextPonyfillFactory(options);
++     const { speechSynthesis, SpeechSynthesisUtterance } = textToSpeechPonyfillFactory(options);
++
++     return {
++       SpeechGrammarList,
++       SpeechRecognition,
++       speechSynthesis,
++       SpeechSynthesisUtterance
++     };
++   }
   }, document.getElementById('webchat'));
 ```
 

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -39,7 +39,7 @@ When the user tap on the microphone button for the first time, Web Chat will pla
 
 If you customize Web Chat to perform any text-to-speech operations before any user gestures, Web Chat will be blocked by Safari for audio playback. Thus, bot messages will not be synthesized.
 
-You can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance and unblock Safari.
+You can present a splash screen with a tap-to-continue button, which would ready the engine by sending an empty utterance to unblock Safari.
 
 ## Setting up Web Chat
 
@@ -49,7 +49,7 @@ To use Cognitive Services in Web Chat, you will need to add minimal setup code t
 
 You will need to obtain a subscription key for your Azure Cognitive Services subscription. Please follow instructions on [this page][Try Cognitive Services] to obtain a subscription key.
 
-To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization token, and send only the authorization token to client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Cognitive Services resource in a production environment.*
+To prevent leaking your subscription key, you should build/host a server which use your subscription key to generate authorization tokens, and only send the authorization token to the client. You can find [more information about authorization token in this article][Authenticate requests to Azure Cognitive Services]. *Never use subscription keys to access your Azure resources in a production environment.*
 
 > To use [new voices powered by deep neural network](https://azure.microsoft.com/en-us/blog/microsoft-s-new-neural-text-to-speech-service-helps-machines-speak-like-people/), you might need to have a subscription in "West US 2" region.
 
@@ -57,7 +57,7 @@ To prevent leaking your subscription key, you should build/host a server which u
 
 This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Integrating with Cognitive Services Speech Services sample].
 
-> To bring more focus for the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production systems.
+> To bring more focus to the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production environment.
 
 ```js
 const {
@@ -97,7 +97,7 @@ These features are for improving the overall user experiences while using speech
 
 Different voice can be selected based on the synthesizing activity.
 
-In the following code, voice is selected based on the language of the synthesizing activity. If the activity is in Cantonese, we will select the voice with keyword "TracyRUS". Otherwise, we will select the voice with keyword "Jessa24kRUS".
+In the following code, voice is selected based on the language of the synthesizing activity. If the activity is in Cantonese (zh-HK), we will select the voice with keyword "TracyRUS". Otherwise, we will select the voice with keyword "Jessa24kRUS".
 
 ```diff
   const {
@@ -127,9 +127,9 @@ In the following code, voice is selected based on the language of the synthesizi
 
 ### Custom Speech
 
-Custom Speech is a trained model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or people names.
+Custom Speech is a trained model to improve recognition of words that are not in the default recognition model. For example, you can use it to improve accuracy when recognizing trademarks or name of person.
 
-First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech?].
+First, you will need to set up a Custom Speech project. Please follow [this article to create a new Custom Speech project][What is Custom Speech].
 
 After your Custom Speech project is set up and a model is published to a deployment endpoint, in the "Deployment" tab, save the "Endpoint ID".
 
@@ -314,7 +314,7 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 - [WebRTC API Support]
 - [Integrating with Cognitive Services Speech Services sample]
 - [Get started with Custom Voice]
-- [What is Custom Speech?]
+- [What is Custom Speech]
 
 [Authenticate requests to Azure Cognitive Services]: https://docs.microsoft.com/en-us/azure/cognitive-services/authentication
 [Get started with Custom Voice]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice
@@ -322,4 +322,4 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 [Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
 [Web Audio API support]: https://caniuse.com/#feat=audio-api
 [WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
-[What is Custom Speech?]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech)
+[What is Custom Speech]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech)

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -55,7 +55,7 @@ To prevent leaking your subscription key, you should build/host a server which u
 
 ### Integrating Web Chat into your page
 
-This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"][Integrating with Cognitive Services Speech Services sample].
+This integration code is excerpted from the [sample named "Integrating with Cognitive Services Speech Services"]Sample: [Integrating with Cognitive Services Speech Services].
 
 > To bring more focus to the integration part, we simplified the original sample code by using subscription key instead of authorization token. You should *always use authorization token* for production environment.
 
@@ -268,11 +268,11 @@ For simplicity, in our sample, we are using subscription key. If you need to use
   }, document.getElementById('webchat'));
 ```
 
-The function passed to `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not provided in this sample code. You should add caching based on the validity of the token.
+The function `fetchAuthorizationToken` will be called *every time* a token is needed. If simplicity, token caching is not provided in this sample code. You should add caching based on the validity of the token.
 
 ### Using two subscription keys for speech-to-text and text-to-speech
 
-In some cases, you may be using two different Cognitive Services subscriptions, one for speech-to-text and another one for text-to-speech. You could create two ponyfills and merge them together as another ponyfill.
+In some cases, you may be using two different Cognitive Services subscriptions, one for speech-to-text and another one for text-to-speech. You could create two ponyfills and combine together to form a hybrid ponyfill.
 
 ```diff
 + const speechToTextPonyfillFactory = await createCognitiveServicesSpeechServicesPonyfillFactory({
@@ -310,18 +310,23 @@ In some cases, you may be using two different Cognitive Services subscriptions, 
 
 > Note: it is correct that `speechSynthesis` is in camel-casing, while others are in Pascal-casing.
 
+Using this approach, you can also combine two polyfills of different types. For example, speech recognition powered by Cognitive Services with browser-supported speech synthesis. You can refer to [this sample for the hybrid speech approach][Sample: Using hybrid speech engine].
+
 ## Related articles
 
+- [Try Cognitive Services]
 - [Web Audio API support]
 - [WebRTC API Support]
-- [Integrating with Cognitive Services Speech Services sample]
 - [Get started with Custom Voice]
 - [What is Custom Speech]
+- [Sample: Integrating with Cognitive Services Speech Services]
+- [Sample: Using hybrid speech engine]
 
 [Authenticate requests to Azure Cognitive Services]: https://docs.microsoft.com/en-us/azure/cognitive-services/authentication
 [Get started with Custom Voice]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice
-[Integrating with Cognitive Services Speech Services sample]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js
+[Sample: Integrating with Cognitive Services Speech Services]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js
 [Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
+[Sample: Using hybrid speech engine]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.f.hybrid-speech
 [Web Audio API support]: https://caniuse.com/#feat=audio-api
 [WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
 [What is Custom Speech]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech)

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -2,7 +2,11 @@ import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   authorizationToken,
+  enableTelemetry,
   region,
+  speechRecognitionEndpointId,
+  speechSynthesisDeploymentId,
+  speechSynthesisOutputFormat,
   subscriptionKey,
   textNormalization
 }) {
@@ -13,8 +17,12 @@ export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   return ({ referenceGrammarID }) => {
     const ponyfill = createPonyfill({
       authorizationToken,
+      enableTelemetry,
       referenceGrammars: [`luis/${referenceGrammarID}-PRODUCTION`],
       region,
+      speechRecognitionEndpointId,
+      speechSynthesisDeploymentId,
+      speechSynthesisOutputFormat,
       subscriptionKey,
       textNormalization
     });


### PR DESCRIPTION
> ~Note to myself: make sure to test this one manually.~
> Note to myself: fix "diff" to add pluses for "hybrid subscription keys", we are missing those pluses.

## Description

We have many new and cool features for using speech in Web Chat. Let's add some documentations

## Specific Changes

- Add `SPEECH.md`

---

-  [x] ~Testing Added~
   -  No tests are required for documentation
