### PR TITLE
Add entrypoint and move breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ export default class extends React.Component {
 
 See a working sample of [Web Chat rendered via React](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/03.a.host-with-react/).
 
+## Integrate with Cognitive Services Speech Services
+
+You can use Cognitive Services Speech Services to add bi-directional speech functionality to Web Chat. Please refer to this article about [using Cognitive Services Speech Services](https://github.com/microsoft/BotFramework-WebChat/blob/master/SPEECH.md) for details.
+
 # Customize Web Chat UI
 
 Web Chat is designed to be customizable without forking the source code. The table below outlines what kind of customizations you can achieve when you are importing Web Chat in different ways. This list is not exhaustive.
@@ -155,13 +159,7 @@ Please refer to [`ACTIVITYTYPES.md`](https://github.com/microsoft/BotFramework-W
 
 ## Speech changes in Web Chat 4.5
 
-> This is a breaking change on behavior expectations regarding speech in Web Chat.
-
-In issue [#2022](https://github.com/microsoft/BotFramework-WebChat/issues/2022), it was brought to the Web Chat team's attention that the speech behavior of v3 and v4 of Web Chat do not match. In the 4.5 release, the expected behavior of a speech bot has been modified in order to bring parity to v3 behavior regarding [input hint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0). This means the following:
-- Expecting input will now be respected by Web Chat and open the microphone during a speech conversation. This is assuming that the user has given permission for the browser to use the mic.
-- Accepting input **will no longer** open the mic after the bot has responded to a speech activity from the user. Instead, the user will have to press the microphone button again in order to further interact with the bot.
-- Ignoring input will continue to **not** open the mic after a speech activity has been sent from the bot.
-
+This is a breaking change on behavior expectations regarding speech and input hint in Web Chat. Please refer to this section on [input hint behavior before 4.5.0](https://github.com/microsoft/BotFramework-WebChat/blob/master/SPEECH.md#input-hint-behavior-before-4-5-0).
 
 # Samples list
 
@@ -252,7 +250,7 @@ Please note, however:
 
 # How to connect client app to bot
 
-Web Chat provides UI on top of the Direct Line Channel. There are two ways to connect to your bot through HTTP calls from the client: by sending the Bot secret or generating a token via the secret. 
+Web Chat provides UI on top of the Direct Line Channel. There are two ways to connect to your bot through HTTP calls from the client: by sending the Bot secret or generating a token via the secret.
 
 <!-- TODO: https://github.com/microsoft/BotFramework-WebChat/issues/2151 -->
 <!-- Update the following paragraph and the API table (`directline`) with new documentation when updated docs are published  -->

--- a/SPEECH.md
+++ b/SPEECH.md
@@ -85,6 +85,7 @@ After adding the ponyfill factory, you should be able to see the microphone butt
 These features are for improving the overall user experience while using speech in Web Chat.
 
 - [Using Speech Synthesis Markup Language](#using-speech-synthesis-markup-language)
+- [Using input hint](#using-input-hint)
 - [Selecting voice](#selecting-voice)
 - [Custom Speech](#custom-speech)
 - [Custom Voice](#custom-voice)
@@ -119,6 +120,24 @@ When the bot sends the activity, include the SSML in the `speak` property.
 > The SSML code snippet above is using neural voice "JessaNeural" for expression, which is only supported in some regions.
 
 With "mstts" extension, you can also [add speaking style](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup#adjust-speaking-styles) (e.g. cheerful) and [background audio](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup#add-background-audio) to your synthesized speech.
+
+### Using input hint
+
+The bot can set input hint when sending activity to the user to indicate whether the bot is anticipating user input. This can be used re-open the microphone if the last message was sent through microphone. You can set it to either `expectingInput`, `acceptingInput`, and `ignoringInput`. If it is not defined, it will default to `acceptingInput`.
+
+-  `"expectingInput"`: Web Chat will open the microphone after the bot's message is spoken and the last message was sent through microphone
+-  `"acceptingInput"`: Web Chat will do nothing after the bot's message is spoken
+-  `"ignoringInput"`: Web Chat will explicitly close the microphone
+
+For more details, please follow this article on [adding input hints to messages][Add input hints to messages].
+
+#### Input hint behavior before 4.5.0
+
+In issue [#2022](https://github.com/microsoft/BotFramework-WebChat/issues/2022), it was brought to the Web Chat team's attention that the speech behavior of v3 and v4 of Web Chat do not match. In the 4.5.0 release, the expected behavior of a speech bot has been modified in order to bring parity to v3 behavior regarding [input hint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0). This means the following:
+
+-  Expecting input will now be respected by Web Chat and open the microphone during a speech conversation. This is assuming that the user has given permission for the browser to use the mic.
+-  Accepting input **will no longer** open the mic after the bot has responded to a speech activity from the user. Instead, the user will have to press the microphone button again in order to further interact with the bot.
+-  Ignoring input will continue to **not** open the mic after a speech activity has been sent from the bot.
 
 ### Selecting voice
 
@@ -353,6 +372,7 @@ Using this approach, you can also combine two polyfills of different types. For 
 - [List of browsers which support Web Audio API][Web Audio API support]
 - [List of browsers which support WebRTC API][WebRTC API Support]
 - [Speech Synthesis Markup Language (SSML)][Speech Synthesis Markup Language]
+- [Add input hints to messages]
 - [Get started with Custom Voice]
 - [What is Custom Speech]
 - [Sample: Integrating with Cognitive Services Speech Services]
@@ -362,8 +382,9 @@ Using this approach, you can also combine two polyfills of different types. For 
 [Get started with Custom Voice]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice
 [Sample: Integrating with Cognitive Services Speech Services]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js
 [Sample: Using hybrid speech engine]: https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/06.f.hybrid-speech
-[Speech Synthesis Markup Language]: (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup)
+[Speech Synthesis Markup Language]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup
 [Try Cognitive Services]: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/#speech
 [Web Audio API support]: https://caniuse.com/#feat=audio-api
 [WebRTC API Support]: https://caniuse.com/#feat=rtcpeerconnection
 [What is Custom Speech]: https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech
+[Add input hints to messages]: https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-add-input-hints?view=azure-bot-service-4.0


### PR DESCRIPTION
Fixes #2341.

## Changelog Entry

(Documentation update, no entry updated in `CHANGELOG.md`)

## Description

After the `SPEECH.md` was added, we need an entrypoint in `README.md` to help customers navigate to this new documentation.

## Specific Changes

- Added entrypoint of `SPEECH.md` to `README.md`
- Moved breaking changes about speech and input hint from `README.md` to `SPEECH.md`

---

-  [x] ~Testing Added~
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
