### PR TITLE
Configuring off speech synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors to be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)
 -  Fix [#2243](https://github.com/microsoft/BotFramework-WebChat/issues/2243). Fixed sagas to correctly mark activities with speaking attachments, by [@tdurnford](https://github.com/tdurnford) in PR [#2320](https://github.com/microsoft/BotFramework-WebChat/issues/2320)
 -  Fix [#2365](https://github.com/microsoft/BotFramework-WebChat/issues/2365). Fix Adaptive Card `pushButton` appearance on Chrome, by [@corinagum](https://github.com/corinagum) in PR [#2382](https://github.com/microsoft/BotFramework-WebChat/pull/2382)
--  Fix [#2379](https://github.com/microsoft/BotFramework-WebChat/issues/2379). Speech synthesis can be configured off by passing `null`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2379](https://github.com/microsoft/BotFramework-WebChat/issues/2379). Speech synthesis can be configured off by passing `null`, by [@compulim](https://github.com/compulim) in PR [#2408](https://github.com/microsoft/BotFramework-WebChat/pull/2408)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2298](https://github.com/microsoft/BotFramework-WebChat/issues/2298). Speech synthesize errors to be ignored, by [@compulim](https://github.com/compulim) in PR [#2300](https://github.com/microsoft/BotFramework-WebChat/issues/2300)
 -  Fix [#2243](https://github.com/microsoft/BotFramework-WebChat/issues/2243). Fixed sagas to correctly mark activities with speaking attachments, by [@tdurnford](https://github.com/tdurnford) in PR [#2320](https://github.com/microsoft/BotFramework-WebChat/issues/2320)
 -  Fix [#2365](https://github.com/microsoft/BotFramework-WebChat/issues/2365). Fix Adaptive Card `pushButton` appearance on Chrome, by [@corinagum](https://github.com/corinagum) in PR [#2382](https://github.com/microsoft/BotFramework-WebChat/pull/2382)
+-  Fix [#2379](https://github.com/microsoft/BotFramework-WebChat/issues/2379). Speech synthesis can be configured off by passing `null`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Added
 

--- a/__tests__/setup/pageObjects/getConsoleLogs.js
+++ b/__tests__/setup/pageObjects/getConsoleLogs.js
@@ -1,0 +1,3 @@
+export default async function getConsoleLogs(driver) {
+  return await driver.executeScript(() => window.__console__);
+}

--- a/__tests__/setup/pageObjects/index.js
+++ b/__tests__/setup/pageObjects/index.js
@@ -5,6 +5,7 @@ import dispatchAction from './dispatchAction';
 import endSpeechSynthesize from './endSpeechSynthesize';
 import errorSpeechSynthesize from './errorSpeechSynthesize';
 import executePromiseScript from './executePromiseScript';
+import getConsoleLogs from './getConsoleLogs';
 import getNotificationText from './getNotificationText';
 import getNumActivitiesShown from './getNumActivitiesShown';
 import getSendBoxText from './getSendBoxText';
@@ -37,6 +38,7 @@ export default function pageObjects(driver) {
       endSpeechSynthesize,
       errorSpeechSynthesize,
       executePromiseScript,
+      getConsoleLogs,
       getNotificationText,
       getNumActivitiesShown,
       getSendBoxText,

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -110,7 +110,9 @@ const BasicTranscript = ({
               >
                 {element}
                 {// TODO: [P2] We should use core/definitions/speakingActivity for this predicate instead
-                activity.channelData && activity.channelData.speak && <SpeakActivity activity={activity} />}
+                speechSynthesis && activity.channelData && activity.channelData.speak && (
+                  <SpeakActivity activity={activity} />
+                )}
               </li>
             ))}
           </ul>
@@ -141,8 +143,8 @@ BasicTranscript.propTypes = {
     }).isRequired
   }).isRequired,
   webSpeechPonyfill: PropTypes.shape({
-    speechSynthesis: PropTypes.any.isRequired,
-    SpeechSynthesisUtterance: PropTypes.any.isRequired
+    speechSynthesis: PropTypes.any,
+    SpeechSynthesisUtterance: PropTypes.any
   })
 };
 


### PR DESCRIPTION
Fixes #2379.

## Changelog Entry

### Fixed

-  Fix [#2379](https://github.com/microsoft/BotFramework-WebChat/issues/2379). Speech synthesis can be configured off by passing `null`, by [@compulim](https://github.com/compulim) in PR [#2408](https://github.com/microsoft/BotFramework-WebChat/pull/2408)

## Description

To configure off speech synthesis but leaving speech recognition, we pass a Web Speech ponyfill:

```js
{
  SpeechGrammarList: ...,
  SpeechRecognition: ...,
  speechSynthesis: null,
  SpeechSynthesisUtterance: null
}
```

We explicitly set `speechSynthesis` to `null` rather than leaving it as `undefined`, because `undefined` usually means, "implicitly leave as blank" and "leave it as default". I.e. Web Chat will use speech synthesis engine from browser if it is `undefined`.

But when we setting it to `null`, we are seeing exception because we are trying to synthesis using a `null` engine.

## Specific Changes

In `BasicTranscript.js`, if `speechSynthesis` is falsy, do not render `<SpeakActivity>`, which will stop from synthesizing the text.

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
