### PR TITLE
Added attachment style options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Added bubble nub and style options, by [@compulim](https://github.com/compulim), in PR [#2137](https://github.com/Microsoft/BotFramework-WebChat/pull/2137)
 -  Fix [#1808](https://github.com/microsoft/BotFramework-WebChat/issues/1808). Added documentation on activity types, by [@corinagum](https://github.com/corinagum) in PR [#2228](https://github.com/microsoft/BotFramework-WebChat/pull/2228)
+-  Fix [#2232](https://github.com/microsoft/BotFramework-WebChat/issues/2232). Added attachment style options, by [@stevkan](https://github.com/stevkan) in PR [#2410](https://github.com/microsoft/BotFramework-WebChat/pull/2410)
 
 ### Samples
 

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -66,7 +66,7 @@ If you need to do some simple styling, you can set them via `styleOptions`. Styl
       <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
       <script>
          const styleOptions = {
-            bubbleBackground: 'rgba(0, 0, 255, .1)',
+            bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
             bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
          };
 
@@ -105,7 +105,7 @@ For deeper styling, you can also modify the style set manually by setting the CS
       <script>
          // "styleSet" is a set of CSS rules which are generated from "styleOptions"
          const styleSet = window.WebChat.createStyleSet({
-            bubbleBackground: 'rgba(0, 0, 255, .1)',
+            bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
             bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
          });
 

--- a/__tests__/bubbleBorder.js
+++ b/__tests__/bubbleBorder.js
@@ -25,10 +25,10 @@ describe('bubble border', () => {
     const { driver, pageObjects } = await setupWebDriver({
       props: {
         styleOptions: {
-          bubbleBorderColor: 'Red',
-          bubbleBorderRadius: 10,
-          bubbleBorderStyle: 'dashed',
-          bubbleBorderWidth: 2,
+          bubbleFromBotBorderColor: 'Red',
+          bubbleFromBotBorderRadius: 10,
+          bubbleFromBotBorderStyle: 'dashed',
+          bubbleFromBotBorderWidth: 2,
 
           bubbleFromUserBorderColor: 'Green',
           bubbleFromUserBorderRadius: 20,
@@ -48,7 +48,7 @@ describe('bubble border', () => {
         props: {
           styleOptions: {
             bubbleBorder: 'dashed 2px Red',
-            bubbleBorderRadius: 10,
+            bubbleFromBotBorderRadius: 10,
 
             bubbleFromUserBorder: 'dotted 3px Green',
             bubbleFromUserBorderRadius: 20

--- a/__tests__/bubbleNub.js
+++ b/__tests__/bubbleNub.js
@@ -28,10 +28,12 @@ describe('bubble nub', () => {
     const { driver, pageObjects } = await setupWebDriver({
       props: {
         styleOptions: {
-          bubbleNubOffset: 0,
-          bubbleNubSize: 10,
+          bubbleFromBotNubOffset: 0,
+          bubbleFromBotNubSize: 10,
+          bubbleFromBotNubBorderColor: 'white',
           bubbleFromUserNubOffset: 0,
-          bubbleFromUserNubSize: 10
+          bubbleFromUserNubSize: 10,
+          bubbleFromUserNubBorderColor: 'white'
         }
       },
       zoom: 3
@@ -43,16 +45,18 @@ describe('bubble nub', () => {
   beforeEach(() => {
     props = {
       styleOptions: {
-        bubbleBorderColor: 'red',
-        bubbleBorderRadius: 10,
-        bubbleBorderWidth: 2,
+        bubbleFromBotBorderColor: 'red',
+        bubbleFromBotBorderRadius: 10,
+        bubbleFromBotBorderWidth: 2,
         bubbleFromUserBorderColor: 'green',
         bubbleFromUserBorderRadius: 10,
         bubbleFromUserNubOffset: 0,
         bubbleFromUserNubSize: 10,
+        bubbleFromUserNubBorderColor: 'white',
         bubbleFromUserBorderWidth: 2,
-        bubbleNubOffset: 0,
-        bubbleNubSize: 10
+        bubbleFromBotNubOffset: 0,
+        bubbleFromBotNubSize: 10,
+        bubbleFromBotNubBorderColor: 'white'
       }
     };
   });
@@ -140,7 +144,7 @@ describe('bubble nub', () => {
           styleOptions: {
             ...props.styleOptions,
             bubbleFromUserNubOffset: 5,
-            bubbleNubOffset: 5
+            bubbleFromBotNubOffset: 5
           }
         },
         zoom: 3
@@ -156,7 +160,7 @@ describe('bubble nub', () => {
           styleOptions: {
             ...props.styleOptions,
             bubbleFromUserNubOffset: 10,
-            bubbleNubOffset: 10
+            bubbleFromBotNubOffset: 10
           }
         },
         zoom: 3
@@ -172,7 +176,7 @@ describe('bubble nub', () => {
           styleOptions: {
             ...props.styleOptions,
             bubbleFromUserNubOffset: -5,
-            bubbleNubOffset: -5
+            bubbleFromBotNubOffset: -5
           }
         },
         zoom: 3
@@ -188,7 +192,7 @@ describe('bubble nub', () => {
           styleOptions: {
             ...props.styleOptions,
             bubbleFromUserNubOffset: -10,
-            bubbleNubOffset: -10
+            bubbleFromBotNubOffset: -10
           }
         },
         zoom: 3
@@ -204,7 +208,7 @@ describe('bubble nub', () => {
           styleOptions: {
             ...props.styleOptions,
             bubbleFromUserNubOffset: 'bottom',
-            bubbleNubOffset: 'bottom'
+            bubbleFromBotNubOffset: 'bottom'
           }
         },
         zoom: 3

--- a/packages/bundle/src/adaptiveCards/Styles/StyleSet/AdaptiveCardRenderer.js
+++ b/packages/bundle/src/adaptiveCards/Styles/StyleSet/AdaptiveCardRenderer.js
@@ -1,10 +1,32 @@
-export default function({ accent, paddingRegular, primaryFont }) {
+export default function({
+  accent,
+  bubbleAttachmentBackground,
+  bubbleAttachmentBorderColor,
+  bubbleAttachmentBorderRadius,
+  bubbleAttachmentBorderStyle,
+  bubbleAttachmentBorderWidth,
+  bubbleAttachmentTextColor,
+  paddingRegular,
+  primaryFont
+}) {
   return {
+    '& .ac-adaptiveCard': {
+      backgroundColor: bubbleAttachmentBackground,
+      borderColor: bubbleAttachmentBorderColor,
+      borderRadius: bubbleAttachmentBorderRadius,
+      borderStyle: bubbleAttachmentBorderStyle,
+      borderWidth: bubbleAttachmentBorderWidth
+    },
+
+    '& p': {
+      color: bubbleAttachmentTextColor
+    },
+
     '& .ac-pushButton': {
       backgroundColor: 'White',
       borderStyle: 'solid',
       borderWidth: 1,
-      color: accent,
+      color: 'accent',
       fontWeight: 600,
       padding: paddingRegular
     },

--- a/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.js
+++ b/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.js
@@ -22,6 +22,10 @@ export default ({ accent, primaryFont, subtle } = defaultStyleOptions) => ({
         default: {
           default: null,
           subtle: subtle
+        },
+        accent: {
+          default: null,
+          subtle: accent
         }
       }
     }

--- a/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.js
+++ b/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.js
@@ -1,31 +1,28 @@
 import { defaultStyleOptions } from 'botframework-webchat-component';
 // https://docs.microsoft.com/en-us/adaptive-cards/rendering-cards/host-config
 
-export default ({
-  accent,
-  bubbleTextColor,
-  cardEmphasisBackgroundColor,
-  primaryFont,
-  subtle
-} = defaultStyleOptions) => ({
+export default ({ accent, primaryFont, subtle } = defaultStyleOptions) => ({
   containerStyles: {
     default: {
+      backgroundColor: null,
       foregroundColors: {
         default: {
-          default: bubbleTextColor,
-          subtle
+          default: null,
+          subtle: subtle
         },
         accent: {
-          default: accent,
+          default: null,
           subtle: accent
         }
       }
     },
     emphasis: {
-      backgroundColor: cardEmphasisBackgroundColor,
-      default: {
-        default: bubbleTextColor,
-        subtle
+      backgroundColor: null,
+      foregroundColors: {
+        default: {
+          default: null,
+          subtle: subtle
+        }
       }
     }
   },

--- a/packages/component/src/Activity/Bubble.js
+++ b/packages/component/src/Activity/Bubble.js
@@ -29,7 +29,7 @@ const Bubble = ({ 'aria-hidden': ariaHidden, children, className, fromUser, nub,
     )}
   >
     <div className="webchat__bubble__content">{children}</div>
-    {nub && !!(fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleNubSize) && (
+    {nub && !!(fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleFromBotNubSize) && (
       <div className="webchat__bubble__nub" />
     )}
   </div>

--- a/packages/component/src/Activity/CarouselFilmStrip.js
+++ b/packages/component/src/Activity/CarouselFilmStrip.js
@@ -102,7 +102,7 @@ const WebChatCarouselFilmStrip = ({
 
   const fromUser = role === 'user';
   const activityDisplayText = messageBackDisplayText || text;
-  const indented = fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleNubSize;
+  const indented = fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleFromBotNubSize;
 
   return (
     <div

--- a/packages/component/src/Activity/StackedLayout.js
+++ b/packages/component/src/Activity/StackedLayout.js
@@ -103,22 +103,23 @@ const StackedLayout = ({ activity, avatarInitials, children, language, styleSet,
     avatarInitials,
     plainText
   );
-  const indented = fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleNubSize;
+  const indented = fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleFromBotNubSize;
 
   return (
     <div
       className={classNames(ROOT_CSS + '', styleSet.stackedLayout + '', {
         'from-user': fromUser,
         webchat__stacked_extra_left_indent:
-          fromUser && !styleSet.options.botAvatarInitials && styleSet.options.bubbleNubSize,
+          fromUser && !styleSet.options.botAvatarInitials && styleSet.options.bubbleFromBotNubSize,
         webchat__stacked_extra_right_indent:
           !fromUser && !styleSet.options.userAvatarInitials && styleSet.options.bubbleFromUserNubSize,
         webchat__stacked_indented_content: avatarInitials && !indented
       })}
     >
-      {!avatarInitials && !!(fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleNubSize) && (
-        <div className="avatar" />
-      )}
+      {!avatarInitials &&
+        !!(fromUser ? styleSet.options.bubbleFromUserNubSize : styleSet.options.bubbleFromBotNubSize) && (
+          <div className="avatar" />
+        )}
       <Avatar aria-hidden={true} className="avatar" fromUser={fromUser} />
       <div className="content">
         {type === 'typing' ? (

--- a/packages/component/src/Styles/StyleSet/Bubble.js
+++ b/packages/component/src/Styles/StyleSet/Bubble.js
@@ -31,23 +31,25 @@ function svgToDataURI(svg) {
 }
 
 export default function createBubbleStyle({
-  bubbleBackground,
-  bubbleBorderColor,
-  bubbleBorderRadius,
-  bubbleBorderStyle,
-  bubbleBorderWidth,
+  bubbleFromBotBackground,
+  bubbleFromBotTextColor,
+  bubbleFromBotBorderColor,
+  bubbleFromBotBorderRadius,
+  bubbleFromBotBorderStyle,
+  bubbleFromBotBorderWidth,
   bubbleFromUserBackground,
+  bubbleFromUserTextColor,
   bubbleFromUserBorderColor,
   bubbleFromUserBorderRadius,
   bubbleFromUserBorderStyle,
   bubbleFromUserBorderWidth,
+  bubbleFromBotNubOffset,
+  bubbleFromBotNubSize,
+  bubbleFromBotNubBorderColor,
   bubbleFromUserNubOffset,
   bubbleFromUserNubSize,
-  bubbleFromUserTextColor,
+  bubbleFromUserNubBorderColor,
   bubbleMinHeight,
-  bubbleNubOffset,
-  bubbleNubSize,
-  bubbleTextColor,
   messageActivityWordBreak,
   paddingRegular
 }) {
@@ -57,33 +59,33 @@ export default function createBubbleStyle({
     bubbleFromUserNubOffset = -0;
   }
 
-  if (bubbleNubOffset === 'top') {
-    bubbleNubOffset = 0;
-  } else if (typeof bubbleNubOffset !== 'number') {
-    bubbleNubOffset = -0;
+  if (bubbleFromBotNubOffset === 'top') {
+    bubbleFromBotNubOffset = 0;
+  } else if (typeof bubbleFromBotNubOffset !== 'number') {
+    bubbleFromBotNubOffset = -0;
   }
 
-  const botNubUpSideDown = !isPositive(bubbleNubOffset);
+  const botNubUpSideDown = !isPositive(bubbleFromBotNubOffset);
   const userNubUpSideDown = !isPositive(bubbleFromUserNubOffset);
 
   const botNubSVG = acuteNubSVG(
-    bubbleNubSize,
-    bubbleBackground,
-    bubbleBorderColor,
-    bubbleBorderWidth,
+    bubbleFromBotNubSize,
+    bubbleFromBotBackground,
+    bubbleFromBotTextColor,
+    bubbleFromBotBorderWidth,
     'bot',
     botNubUpSideDown
   );
   const userNubSVG = acuteNubSVG(
     bubbleFromUserNubSize,
     bubbleFromUserBackground,
-    bubbleFromUserBorderColor,
+    bubbleFromUserTextColor,
     bubbleFromUserBorderWidth,
     'user',
     userNubUpSideDown
   );
 
-  const botNubCornerRadius = Math.min(bubbleBorderRadius, Math.abs(bubbleNubOffset));
+  const botNubCornerRadius = Math.min(bubbleFromBotBorderRadius, Math.abs(bubbleFromBotNubOffset));
   const userNubCornerRadius = Math.min(bubbleFromUserBorderRadius, Math.abs(bubbleFromUserNubOffset));
 
   return {
@@ -93,38 +95,39 @@ export default function createBubbleStyle({
 
     '&:not(.from-user)': {
       '&.webchat__bubble_has_nub': {
-        '& > .webchat__bubble__content': bubbleNubSize ? { marginLeft: paddingRegular } : {}
+        '& > .webchat__bubble__content': bubbleFromBotNubSize ? { marginLeft: paddingRegular } : {}
       },
 
       '& > .webchat__bubble__content': {
-        background: bubbleBackground,
-        borderColor: bubbleBorderColor,
-        borderRadius: bubbleBorderRadius,
-        borderStyle: bubbleBorderStyle,
-        borderWidth: bubbleBorderWidth,
-        color: bubbleTextColor,
-        minHeight: bubbleMinHeight - bubbleBorderWidth * 2
+        background: bubbleFromBotBackground,
+        borderColor: bubbleFromBotBorderColor,
+        borderRadius: bubbleFromBotBorderRadius,
+        borderStyle: bubbleFromBotBorderStyle,
+        borderWidth: bubbleFromBotBorderWidth,
+        color: bubbleFromBotTextColor,
+        minHeight: bubbleMinHeight - bubbleFromBotBorderWidth * 2
       },
 
       '&.webchat__bubble_has_nub > .webchat__bubble__content': {
         // Hide border radius if there is a nub on the top/bottom left corner
-        ...(bubbleNubSize && botNubUpSideDown ? { borderBottomLeftRadius: botNubCornerRadius } : {}),
-        ...(bubbleNubSize && !botNubUpSideDown ? { borderTopLeftRadius: botNubCornerRadius } : {})
+        ...(bubbleFromBotNubSize && botNubUpSideDown ? { borderBottomLeftRadius: botNubCornerRadius } : {}),
+        ...(bubbleFromBotNubSize && !botNubUpSideDown ? { borderTopLeftRadius: botNubCornerRadius } : {})
       },
 
       '& > .webchat__bubble__nub': {
         backgroundImage: `url("${svgToDataURI(botNubSVG).replace(/"/gu, "'")}")`,
-        bottom: isPositive(bubbleNubOffset) ? undefined : -bubbleNubOffset,
-        height: bubbleNubSize,
-        left: bubbleBorderWidth - bubbleNubSize + paddingRegular,
-        top: isPositive(bubbleNubOffset) ? bubbleNubOffset : undefined,
-        width: bubbleNubSize
+        bottom: isPositive(bubbleFromBotNubOffset) ? undefined : -bubbleFromBotNubOffset,
+        height: bubbleFromBotNubSize,
+        left: bubbleFromBotBorderWidth - bubbleFromBotNubSize + paddingRegular,
+        top: isPositive(bubbleFromBotNubOffset) ? bubbleFromBotNubOffset : undefined,
+        width: bubbleFromBotNubSize,
+        borderColor: bubbleFromBotNubBorderColor
       }
     },
 
     '&.from-user': {
       '&.webchat__bubble_has_nub': {
-        '& > .webchat__bubble__content': bubbleNubSize ? { marginRight: paddingRegular } : {}
+        '& > .webchat__bubble__content': bubbleFromBotNubSize ? { marginRight: paddingRegular } : {}
       },
 
       '& > .webchat__bubble__content': {
@@ -149,7 +152,8 @@ export default function createBubbleStyle({
         right: bubbleFromUserBorderWidth - bubbleFromUserNubSize + paddingRegular,
         bottom: isPositive(bubbleFromUserNubOffset) ? undefined : -bubbleFromUserNubOffset,
         top: isPositive(bubbleFromUserNubOffset) ? bubbleFromUserNubOffset : undefined,
-        width: bubbleFromUserNubSize
+        width: bubbleFromUserNubSize,
+        borderColor: bubbleFromUserNubBorderColor
       }
     }
   };

--- a/packages/component/src/Styles/createStyleSet.js
+++ b/packages/component/src/Styles/createStyleSet.js
@@ -70,21 +70,21 @@ export default function createStyleSet(options) {
 
   if (bubbleBorder) {
     console.warn(
-      'Web Chat: styleSet.bubbleBorder is being deprecated. Please use bubbleBorderColor, bubbleBorderStyle, and, bubbleBorderWidth.'
+      'Web Chat: styleSet.bubbleBorder is being deprecated. Please use bubbleFromBotBorderColor, bubbleFromBotBorderStyle, and, bubbleFromBotBorderWidth.'
     );
 
     const { color, style, width } = parseBorder(bubbleBorder);
 
     if (color && color !== 'initial') {
-      options.bubbleBorderColor = color;
+      options.bubbleFromBotBorderColor = color;
     }
 
     if (style && style !== 'initial') {
-      options.bubbleBorderStyle = style;
+      options.bubbleFromBotBorderStyle = style;
     }
 
     if (PIXEL_UNIT_PATTERN.test(width)) {
-      options.bubbleBorderWidth = parseInt(width, 10);
+      options.bubbleFromBotBorderWidth = parseInt(width, 10);
     }
   }
 

--- a/packages/component/src/Styles/defaultStyleOptions.js
+++ b/packages/component/src/Styles/defaultStyleOptions.js
@@ -5,15 +5,12 @@ function fontFamily(fonts) {
 }
 
 const DEFAULT_ACCENT = '#0063B1';
-const DEFAULT_BACKGROUND = '#FFFFFF';
-const DEFAULT_COLOR = '#000000';
 const PADDING_REGULAR = 10;
 const DEFAULT_SUBTLE = '#767676'; // With contrast 4.5:1 to white
 
 const DEFAULT_OPTIONS = {
   // Color and paddings
   accent: DEFAULT_ACCENT,
-  backgroundColor: DEFAULT_BACKGROUND,
   paddingRegular: PADDING_REGULAR,
   paddingWide: PADDING_REGULAR * 2,
   subtle: DEFAULT_SUBTLE,
@@ -34,30 +31,30 @@ const DEFAULT_OPTIONS = {
   userAvatarInitials: '',
 
   // Bubble
-  bubbleFromBotBackground: `${DEFAULT_BACKGROUND}`,
-  bubbleFromBotBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromBotBackground: 'White',
+  bubbleFromBotBorderColor: '#E6E6E6',
   bubbleFromBotBorderRadius: 2,
   bubbleFromBotBorderStyle: 'solid',
   bubbleFromBotBorderWidth: 1,
-  bubbleFromBotTextColor: `${DEFAULT_COLOR}`,
-  bubbleFromUserBackground: `${DEFAULT_BACKGROUND}`,
-  bubbleFromUserBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromBotTextColor: 'Black',
+  bubbleFromUserBackground: 'White',
+  bubbleFromUserBorderColor: '#E6E6E6',
   bubbleFromUserBorderRadius: 2,
   bubbleFromUserBorderStyle: 'solid',
   bubbleFromUserBorderWidth: 1,
-  bubbleFromUserTextColor: `${DEFAULT_COLOR}`,
-  bubbleAttachmentBackground: `${DEFAULT_BACKGROUND}`,
-  bubbleAttachmentTextColor: `${DEFAULT_COLOR}`,
-  bubbleAttachmentBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromUserTextColor: 'Black',
+  bubbleAttachmentBackground: 'White',
+  bubbleAttachmentTextColor: 'Black',
+  bubbleAttachmentBorderColor: '#E6E6E6',
   bubbleAttachmentBorderRadius: 2,
   bubbleAttachmentBorderStyle: 'solid',
   bubbleAttachmentBorderWidth: 1,
   bubbleFromBotNubOffset: 'bottom',
   bubbleFromBotNubSize: 0,
-  bubbleFromBotNubBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromBotNubBorderColor: '#E6E6E6',
   bubbleFromUserNubOffset: 'bottom',
   bubbleFromUserNubSize: 0,
-  bubbleFromUserNubBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromUserNubBorderColor: '#E6E6E6',
   bubbleImageHeight: 240,
   bubbleMaxWidth: 480, // screen width = 600px
   bubbleMinHeight: 40,
@@ -77,14 +74,14 @@ const DEFAULT_OPTIONS = {
   hideSendBox: false,
   hideUploadButton: false,
   microphoneButtonColorOnDictate: '#F33',
-  sendBoxBackground: `${DEFAULT_BACKGROUND}`,
+  sendBoxBackground: 'White',
   sendBoxButtonColor: '#767676',
   sendBoxButtonColorOnDisabled: '#CCC',
   sendBoxButtonColorOnFocus: '#333',
   sendBoxButtonColorOnHover: '#333',
   sendBoxHeight: 40,
   sendBoxMaxHeight: 200,
-  sendBoxTextColor: `${DEFAULT_COLOR}`,
+  sendBoxTextColor: 'Black',
   sendBoxBorderBottom: '',
   sendBoxBorderLeft: '',
   sendBoxBorderRight: '',
@@ -96,12 +93,12 @@ const DEFAULT_OPTIONS = {
   showSpokenText: false,
 
   // Suggested actions
-  suggestedActionBackground: `${DEFAULT_BACKGROUND}`,
+  suggestedActionBackground: 'White',
   suggestedActionBorder: `solid 2px ${DEFAULT_ACCENT}`,
   suggestedActionBorderRadius: 0,
   suggestedActionImageHeight: 20,
   suggestedActionTextColor: DEFAULT_ACCENT,
-  suggestedActionDisabledBackground: `${DEFAULT_BACKGROUND}`,
+  suggestedActionDisabledBackground: 'White',
   suggestedActionDisabledBorder: `solid 2px #E6E6E6`,
   suggestedActionDisabledTextColor: DEFAULT_SUBTLE,
   suggestedActionHeight: 40,
@@ -113,9 +110,9 @@ const DEFAULT_OPTIONS = {
   transcriptOverlayButtonBackground: 'rgba(0, 0, 0, .6)',
   transcriptOverlayButtonBackgroundOnFocus: 'rgba(0, 0, 0, .8)',
   transcriptOverlayButtonBackgroundOnHover: 'rgba(0, 0, 0, .8)',
-  transcriptOverlayButtonColor: `${DEFAULT_BACKGROUND}`,
-  transcriptOverlayButtonColorOnFocus: `${DEFAULT_BACKGROUND}`,
-  transcriptOverlayButtonColorOnHover: `${DEFAULT_BACKGROUND}`,
+  transcriptOverlayButtonColor: 'White',
+  transcriptOverlayButtonColorOnFocus: 'White',
+  transcriptOverlayButtonColorOnHover: 'White',
 
   // Video
   videoHeight: 270, // based on bubbleMaxWidth, 480 / 16 * 9 = 270

--- a/packages/component/src/Styles/defaultStyleOptions.js
+++ b/packages/component/src/Styles/defaultStyleOptions.js
@@ -11,6 +11,7 @@ const DEFAULT_SUBTLE = '#767676'; // With contrast 4.5:1 to white
 const DEFAULT_OPTIONS = {
   // Color and paddings
   accent: DEFAULT_ACCENT,
+  backgroundColor: 'White',
   paddingRegular: PADDING_REGULAR,
   paddingWide: PADDING_REGULAR * 2,
   subtle: DEFAULT_SUBTLE,

--- a/packages/component/src/Styles/defaultStyleOptions.js
+++ b/packages/component/src/Styles/defaultStyleOptions.js
@@ -5,14 +5,15 @@ function fontFamily(fonts) {
 }
 
 const DEFAULT_ACCENT = '#0063B1';
-const DEFAULT_SUBTLE = '#767676'; // With contrast 4.5:1 to white
+const DEFAULT_BACKGROUND = '#FFFFFF';
+const DEFAULT_COLOR = '#000000';
 const PADDING_REGULAR = 10;
+const DEFAULT_SUBTLE = '#767676'; // With contrast 4.5:1 to white
 
 const DEFAULT_OPTIONS = {
   // Color and paddings
   accent: DEFAULT_ACCENT,
-  backgroundColor: 'White',
-  cardEmphasisBackgroundColor: '#F0F0F0',
+  backgroundColor: DEFAULT_BACKGROUND,
   paddingRegular: PADDING_REGULAR,
   paddingWide: PADDING_REGULAR * 2,
   subtle: DEFAULT_SUBTLE,
@@ -33,26 +34,34 @@ const DEFAULT_OPTIONS = {
   userAvatarInitials: '',
 
   // Bubble
-  bubbleBackground: 'White',
-  bubbleBorderColor: '#E6E6E6',
-  bubbleBorderRadius: 2,
-  bubbleBorderStyle: 'solid',
-  bubbleBorderWidth: 1,
-  bubbleFromUserBackground: 'White',
-  bubbleFromUserBorderColor: '#E6E6E6',
+  bubbleFromBotBackground: `${DEFAULT_BACKGROUND}`,
+  bubbleFromBotBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleFromBotBorderRadius: 2,
+  bubbleFromBotBorderStyle: 'solid',
+  bubbleFromBotBorderWidth: 1,
+  bubbleFromBotTextColor: `${DEFAULT_COLOR}`,
+  bubbleFromUserBackground: `${DEFAULT_BACKGROUND}`,
+  bubbleFromUserBorderColor: `${DEFAULT_ACCENT}`,
   bubbleFromUserBorderRadius: 2,
   bubbleFromUserBorderStyle: 'solid',
   bubbleFromUserBorderWidth: 1,
+  bubbleFromUserTextColor: `${DEFAULT_COLOR}`,
+  bubbleAttachmentBackground: `${DEFAULT_BACKGROUND}`,
+  bubbleAttachmentTextColor: `${DEFAULT_COLOR}`,
+  bubbleAttachmentBorderColor: `${DEFAULT_ACCENT}`,
+  bubbleAttachmentBorderRadius: 2,
+  bubbleAttachmentBorderStyle: 'solid',
+  bubbleAttachmentBorderWidth: 1,
+  bubbleFromBotNubOffset: 'bottom',
+  bubbleFromBotNubSize: 0,
+  bubbleFromBotNubBorderColor: `${DEFAULT_ACCENT}`,
   bubbleFromUserNubOffset: 'bottom',
   bubbleFromUserNubSize: 0,
-  bubbleFromUserTextColor: 'Black',
+  bubbleFromUserNubBorderColor: `${DEFAULT_ACCENT}`,
   bubbleImageHeight: 240,
   bubbleMaxWidth: 480, // screen width = 600px
   bubbleMinHeight: 40,
   bubbleMinWidth: 250, // min screen width = 300px, Edge requires 372px (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13621468/)
-  bubbleNubOffset: 'bottom',
-  bubbleNubSize: 0,
-  bubbleTextColor: 'Black',
 
   // Markdown
   markdownRespectCRLF: true,
@@ -68,14 +77,14 @@ const DEFAULT_OPTIONS = {
   hideSendBox: false,
   hideUploadButton: false,
   microphoneButtonColorOnDictate: '#F33',
-  sendBoxBackground: 'White',
+  sendBoxBackground: `${DEFAULT_BACKGROUND}`,
   sendBoxButtonColor: '#767676',
   sendBoxButtonColorOnDisabled: '#CCC',
   sendBoxButtonColorOnFocus: '#333',
   sendBoxButtonColorOnHover: '#333',
   sendBoxHeight: 40,
   sendBoxMaxHeight: 200,
-  sendBoxTextColor: 'Black',
+  sendBoxTextColor: `${DEFAULT_COLOR}`,
   sendBoxBorderBottom: '',
   sendBoxBorderLeft: '',
   sendBoxBorderRight: '',
@@ -87,12 +96,12 @@ const DEFAULT_OPTIONS = {
   showSpokenText: false,
 
   // Suggested actions
-  suggestedActionBackground: 'White',
+  suggestedActionBackground: `${DEFAULT_BACKGROUND}`,
   suggestedActionBorder: `solid 2px ${DEFAULT_ACCENT}`,
   suggestedActionBorderRadius: 0,
   suggestedActionImageHeight: 20,
   suggestedActionTextColor: DEFAULT_ACCENT,
-  suggestedActionDisabledBackground: 'White',
+  suggestedActionDisabledBackground: `${DEFAULT_BACKGROUND}`,
   suggestedActionDisabledBorder: `solid 2px #E6E6E6`,
   suggestedActionDisabledTextColor: DEFAULT_SUBTLE,
   suggestedActionHeight: 40,
@@ -104,9 +113,9 @@ const DEFAULT_OPTIONS = {
   transcriptOverlayButtonBackground: 'rgba(0, 0, 0, .6)',
   transcriptOverlayButtonBackgroundOnFocus: 'rgba(0, 0, 0, .8)',
   transcriptOverlayButtonBackgroundOnHover: 'rgba(0, 0, 0, .8)',
-  transcriptOverlayButtonColor: 'White',
-  transcriptOverlayButtonColorOnFocus: 'White',
-  transcriptOverlayButtonColorOnHover: 'White',
+  transcriptOverlayButtonColor: `${DEFAULT_BACKGROUND}`,
+  transcriptOverlayButtonColorOnFocus: `${DEFAULT_BACKGROUND}`,
+  transcriptOverlayButtonColorOnHover: `${DEFAULT_BACKGROUND}`,
 
   // Video
   videoHeight: 270, // based on bubbleMaxWidth, 480 / 16 * 9 = 270

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -89,16 +89,16 @@ export default class extends React.Component {
         ...(styleBubbleBorder === 'deprecated'
           ? {
               bubbleBorder: 'dotted 2px Red',
-              bubbleBorderRadius: 10,
+              bubbleFromBotBorderRadius: 10,
               bubbleFromUserBorder: 'dashed 2px Green',
               bubbleFromUserBorderRadius: 10
             }
           : styleBubbleBorder
           ? {
-              bubbleBorderColor: 'Red',
-              bubbleBorderRadius: 10,
-              bubbleBorderStyle: 'dotted',
-              bubbleBorderWidth: 2,
+              bubbleFromBotBorderColor: 'Red',
+              bubbleFromBotBorderRadius: 10,
+              bubbleFromBotBorderStyle: 'dotted',
+              bubbleFromBotBorderWidth: 2,
               bubbleFromUserBorderColor: 'Green',
               bubbleFromUserBorderRadius: 10,
               bubbleFromUserBorderStyle: 'dashed',
@@ -110,8 +110,8 @@ export default class extends React.Component {
           ? {
               bubbleFromUserNubSize: 10,
               bubbleFromUserNubOffset: -5,
-              bubbleNubOffset: 5,
-              bubbleNubSize: 10
+              bubbleFromBotNubOffset: 5,
+              bubbleFromBotNubSize: 10
             }
           : {}),
 

--- a/samples/05.a.branding-webchat-styling/index.html
+++ b/samples/05.a.branding-webchat-styling/index.html
@@ -4,9 +4,9 @@
     <title>Web Chat: Custom style options</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!--
-      This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
-      https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
-    -->
+        This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
+        https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
+      -->
     <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <style>
       html, body { height: 100% }
@@ -32,7 +32,7 @@
 
         // You can modify the style set by providing a limited set of style options
         const styleOptions = {
-          bubbleBackground: 'rgba(0, 0, 255, .1)',
+          bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
           bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
         };
 

--- a/samples/05.b.idiosyncratic-manual-styling/README.md
+++ b/samples/05.b.idiosyncratic-manual-styling/README.md
@@ -43,7 +43,7 @@ First, we want to overwrite the current `styleSet` by using the `createStyleSet`
 …
   const { token } = await res.json();
 + const styleSet = window.WebChat.createStyleSet({
-+ bubbleBackground: 'rgba(0, 0, 255, .1)',
++ bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
 +  bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
 + });
 
@@ -100,7 +100,7 @@ Here is the finished `index.html`:
         const { token } = await res.json();
 
 +       const styleSet = window.WebChat.createStyleSet({
-+         bubbleBackground: 'rgba(0, 0, 255, .1)',
++         bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
 +         bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
 +       });
 

--- a/samples/05.b.idiosyncratic-manual-styling/index.html
+++ b/samples/05.b.idiosyncratic-manual-styling/index.html
@@ -4,9 +4,9 @@
     <title>Web Chat: Custom style set</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!--
-      This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
-      https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
-    -->
+        This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
+        https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
+      -->
     <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <style>
       html, body { height: 100% }
@@ -32,18 +32,18 @@
 
         // You can modify the style set by providing a limited set of style options
         const styleSet = window.WebChat.createStyleSet({
-          bubbleBackground: 'rgba(0, 0, 255, .1)',
+          bubbleFromBotBackground: 'rgba(0, 0, 255, .1)',
           bubbleFromUserBackground: 'rgba(0, 255, 0, .1)'
         });
 
         // You can also modify the style set by the actual CSS
         styleSet.textContent = Object.assign(
           {},
-          styleSet.textContent,
-          {
-            fontFamily: '\'Comic Sans MS\', \'Arial\', sans-serif',
-            fontWeight: 'bold'
-          }
+          styleSet.textContent,
+          {
+            fontFamily: '\'Comic Sans MS\', \'Arial\', sans-serif',
+            fontWeight: 'bold'
+          }
         );
 
         window.WebChat.renderWebChat({


### PR DESCRIPTION
Fixes #2232 

## Changelog Entry

Fix [#2232](https://github.com/microsoft/BotFramework-WebChat/issues/2232). Added attachment style options, by [@stevkan](https://github.com/stevkan) in PR [#2410](https://github.com/microsoft/BotFramework-WebChat/pull/2410)

## Description

Provides the ability to apply separate styling options for attachments (cards) and activities sent from the bot. Addresses attachment background and text color, attachment border styling, and nub border styling.

## Specific Changes

Updated defaultStyleOptions.js:
- Included style options for attachments.
- Altered 'bot' property names to include "FromBot". For example, changed `bubbleBackground` to `bubbleFromBotBackground`.

Updated adaptiveCardHostConfig.js:
- Included `backgroundColor` in `containerStyles` styles.
- Set some `containerStyles` values to `null`. Otherwise, values compile as inline CSS requiring `!important` to be appended to style options in order to override.
  - As default values are providedd via the defaultStyleOptions.js, including `null` values should not have an effect.

Propagated property name changes across project files.

---

-  [ ] Testing Added
Unable to test due to PowerShell/Docker issues. Will require another to perform testing.
