### PR TITLE
Fix waste render on connectivity status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2243](https://github.com/microsoft/BotFramework-WebChat/issues/2243). Fixed sagas to correctly mark activities with speaking attachments, by [@tdurnford](https://github.com/tdurnford) in PR [#2320](https://github.com/microsoft/BotFramework-WebChat/issues/2320)
 -  Fix [#2365](https://github.com/microsoft/BotFramework-WebChat/issues/2365). Fix Adaptive Card `pushButton` appearance on Chrome, by [@corinagum](https://github.com/corinagum) in PR [#2382](https://github.com/microsoft/BotFramework-WebChat/pull/2382)
 -  Fix [#2379](https://github.com/microsoft/BotFramework-WebChat/issues/2379). Speech synthesis can be configured off by passing `null`, by [@compulim](https://github.com/compulim) in PR [#2408](https://github.com/microsoft/BotFramework-WebChat/pull/2408)
+-  Fix [#2418](https://github.com/microsoft/BotFramework-WebChat/issues/2418). Connectivity status should not waste-render every 400 ms, by [@compulim](https://github.com/compulim) in PR [#2419](https://github.com/microsoft/BotFramework-WebChat/pull/2419)
 
 ### Added
 

--- a/packages/component/src/SendBox/ConnectivityStatus.js
+++ b/packages/component/src/SendBox/ConnectivityStatus.js
@@ -10,18 +10,30 @@ import WarningNotificationIcon from '../Attachment/Assets/WarningNotificationIco
 
 const CONNECTIVITY_STATUS_DEBOUNCE = 400;
 
+function setTimeoutSync(fn, interval) {
+  if (interval > 0) {
+    return setTimeout(fn, interval);
+  }
+
+  fn();
+}
+
 const DebouncedConnectivityStatus = ({ interval, children: propsChildren }) => {
-  const [children, setChildren] = useState(propsChildren);
+  const [children, setChildren] = useState(() => propsChildren);
   const [since, setSince] = useState(Date.now());
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setChildren(propsChildren);
-      setSince(Date.now());
-    }, Math.max(0, interval - Date.now() + since));
+  const intervalBeforeSwitch = Math.max(0, interval - Date.now() + since);
 
-    return () => clearTimeout(timeout);
-  }, [interval, propsChildren, setChildren, setSince, since]);
+  useEffect(() => {
+    if (children !== propsChildren) {
+      const timeout = setTimeout(() => {
+        setChildren(() => propsChildren);
+        setSince(Date.now());
+      }, intervalBeforeSwitch);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [children, intervalBeforeSwitch, propsChildren]);
 
   return typeof children === 'function' ? children() : false;
 };
@@ -116,17 +128,18 @@ const ConnectivityStatus = ({ connectivityStatus, language, styleSet }) => {
 
   const renderStatus = useCallback(() => {
     if (connectivityStatus === 'connectingslow') {
-      return renderConnectingSlow;
+      return renderConnectingSlow();
     } else if (connectivityStatus === 'error' || connectivityStatus === 'notconnected') {
-      return renderNotConnected;
+      return renderNotConnected();
     } else if (connectivityStatus === 'uninitialized') {
-      return renderUninitialized;
+      return renderUninitialized();
     } else if (connectivityStatus === 'reconnecting') {
-      return renderReconnecting;
+      return renderReconnecting();
     } else if (connectivityStatus === 'sagaerror') {
-      return renderSagaError;
+      return renderSagaError();
     }
-    return renderEmptyStatus;
+
+    return renderEmptyStatus();
   }, [
     connectivityStatus,
     renderConnectingSlow,
@@ -136,6 +149,8 @@ const ConnectivityStatus = ({ connectivityStatus, language, styleSet }) => {
     renderSagaError,
     renderUninitialized
   ]);
+
+  console.log('render');
 
   return (
     <div aria-atomic="false" aria-live="polite" role="status">

--- a/packages/component/src/SendBox/ConnectivityStatus.js
+++ b/packages/component/src/SendBox/ConnectivityStatus.js
@@ -26,7 +26,7 @@ const DebouncedConnectivityStatus = ({ interval, children: propsChildren }) => {
 
   useEffect(() => {
     if (children !== propsChildren) {
-      const timeout = setTimeout(() => {
+      const timeout = setTimeoutSync(() => {
         setChildren(() => propsChildren);
         setSince(Date.now());
       }, intervalBeforeSwitch);
@@ -149,8 +149,6 @@ const ConnectivityStatus = ({ connectivityStatus, language, styleSet }) => {
     renderSagaError,
     renderUninitialized
   ]);
-
-  console.log('render');
 
   return (
     <div aria-atomic="false" aria-live="polite" role="status">


### PR DESCRIPTION
Fixes #2418.

## Changelog Entry

### Fixed

-  Fix [#2418](https://github.com/microsoft/BotFramework-WebChat/issues/2418). Connectivity status should not waste-render every 400 ms, by [@compulim](https://github.com/compulim) in PR [#2419](https://github.com/microsoft/BotFramework-WebChat/pull/2419)

## Description

`DebouncedConnectivityStatus` is causing wasted render for every 400 ms.

## Specific Changes

This is due to misunderstanding of `useState` for assigning a function.

Instead of,

```js
const [predicate, setPredicate] = useState();

setValue(x => x === 'Hello, World!');
```

It should be,

```js
const [predicate, setPredicate] = useState();

setValue(() => x => x === 'Hello, World!');
```

This is because, if function is passed to `setXXX`, React will call the function with the existing value, and use the return value as the new state. If non-function is passed, React will directly set it as new state. This behavior is currently not documented.

---

-  [x] ~Testing Added~
   - We currently do not have a way to detect how many render done per seconds, etc. We should setup this tool.
