### PR TITLE
Fix saga error should not result in unhandled exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2435](https://github.com/microsoft/BotFramework-WebChat/issues/2435). Fix microphone button getting stuck on voice-triggered expecting input hint without a speech synthesis engine, by [@compulim](https://github.com/compulim) in PR [#2445](https://github.com/microsoft/BotFramework-WebChat/pull/2445)
 -  Fixes [#2472](https://github.com/microsoft/BotFramework-WebChat/issues/2472). Update samples to use repo's version of React, by [@corinagum](https://github.com/corinagum) in PR [#2478](https://github.com/microsoft/BotFramework-WebChat/pull/2478)
 -  Fixes [#2473](https://github.com/microsoft/BotFramework-WebChat/issues/2473). Fix samples 13 using wrong region for Speech Services credentials, by [@compulim](https://github.com/compulim) in PR [#2482](https://github.com/microsoft/BotFramework-WebChat/pull/2482)
+-  Fixes [#2420](https://github.com/microsoft/BotFramework-WebChat/issues/2420). Fix saga error should not result in an unhandled exception, by [@compulim](https://github.com/compulim) in PR [#2421](https://github.com/microsoft/BotFramework-WebChat/pull/2421)
 
 ### Added
 

--- a/packages/core/src/reducers/connectivityStatus.js
+++ b/packages/core/src/reducers/connectivityStatus.js
@@ -8,41 +8,43 @@ import { SAGA_ERROR } from '../actions/sagaError';
 const DEFAULT_STATE = 'uninitialized';
 
 export default function connectivityStatus(state = DEFAULT_STATE, { type, meta }) {
-  switch (type) {
-    case CONNECT_PENDING:
-    case RECONNECT_PENDING:
-      if (state !== 'uninitialized') {
-        state = 'reconnecting';
-      }
+  if (state !== 'sagaerror') {
+    switch (type) {
+      case CONNECT_PENDING:
+      case RECONNECT_PENDING:
+        if (state !== 'uninitialized') {
+          state = 'reconnecting';
+        }
 
-      break;
+        break;
 
-    case CONNECT_FULFILLED:
-      state = 'connected';
-      break;
+      case CONNECT_FULFILLED:
+        state = 'connected';
+        break;
 
-    case RECONNECT_FULFILLED:
-      state = 'reconnected';
-      break;
+      case RECONNECT_FULFILLED:
+        state = 'reconnected';
+        break;
 
-    case CONNECT_REJECTED:
-      state = 'error';
-      break;
+      case CONNECT_REJECTED:
+        state = 'error';
+        break;
 
-    case CONNECT_STILL_PENDING:
-      state = 'connectingslow';
-      break;
+      case CONNECT_STILL_PENDING:
+        state = 'connectingslow';
+        break;
 
-    case DISCONNECT_FULFILLED:
-      state = meta.error ? 'error' : 'notconnected';
-      break;
+      case DISCONNECT_FULFILLED:
+        state = meta && meta.error ? 'error' : 'notconnected';
+        break;
 
-    case SAGA_ERROR:
-      state = 'sagaerror';
-      break;
+      case SAGA_ERROR:
+        state = 'sagaerror';
+        break;
 
-    default:
-      break;
+      default:
+        break;
+    }
   }
 
   return state;


### PR DESCRIPTION
> Fixes #2420

## Changelog Entry

### Fixed

-  Fix [#2420](https://github.com/microsoft/BotFramework-WebChat/issues/2420). Fix saga error should not result in an unhandled exception, by [@compulim](https://github.com/compulim) in PR [#2421](https://github.com/microsoft/BotFramework-WebChat/pull/2421)

## Description

Saga error is currently resulted in unhandled exception. Once that is fixed, it become disconnected, instead of keeping at saga error.

## Specific Changes

- Modified `connectivityStatus.js`
   - Fixed null reference exception
   - Should not change connectivity status once it become `sagaerror`

---

-  [x] ~Testing Added~
   - We currently do not have tests to check how many console errors
