### PR TITLE
Use `thumbnailUrl` for thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2415](https://github.com/microsoft/BotFramework-WebChat/issues/2415) and [#2416](https://github.com/microsoft/BotFramework-WebChat/issues/2416). Fix Adaptive Cards cannot be disabled on-the-fly, by [@compulim](https://github.com/compulim) in PR [#2417](https://github.com/microsoft/BotFramework-WebChat/issues/2417)
 -  Fix [#2360](https://github.com/microsoft/BotFramework-WebChat/issues/2360). Timestamp should update on language change, by [@compulim](https://github.com/compulim) in PR [#2414](https://github.com/microsoft/BotFramework-WebChat/pull/2414)
 -  Fix [#2428](https://github.com/microsoft/BotFramework-WebChat/issues/2428). Should interrupt speech synthesis after microphone button is clicked, by [@compulim](https://github.com/compulim) in PR [#2429](https://github.com/microsoft/BotFramework-WebChat/pull/2429)
--  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Storing thumbnail URL using `attachment.thumbnailUrl` field in the activity, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
+-  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Store thumbnail URL using the activity's `attachment.thumbnailUrl` field, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `component`: Move `Composer` to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
 -  `component`: Fix [#1818](https://github.com/microsoft/BotFramework-WebChat/issues/1818) Move to functional components by [@corinagum](https://github.com/corinagum), in PR [#2322](https://github.com/microsoft/BotFramework-WebChat/pull/2322)
 -  Fix [#2292](https://github.com/microsoft/BotFramework-WebChat/issues/2292). Added function to select voice to props, `selectVoice()`, by [@compulim](https://github.com/compulim), in PR [#2338](https://github.com/microsoft/BotFramework-WebChat/pull/2338)
--  `bundle`: Bumped DirectLineJS to support metadata when uploading attachments, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  `bundle`: Bumped DirectLineJS to support metadata when uploading attachments, in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
    - [`botframework-directlinejs@0.11.5`](https://www.npmjs.com/package/botframework-directlinejs)
    - Removed DirectLineJS as a dev dependency for `component` because it was not referenced
 
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2415](https://github.com/microsoft/BotFramework-WebChat/issues/2415) and [#2416](https://github.com/microsoft/BotFramework-WebChat/issues/2416). Fix Adaptive Cards cannot be disabled on-the-fly, by [@compulim](https://github.com/compulim) in PR [#2417](https://github.com/microsoft/BotFramework-WebChat/issues/2417)
 -  Fix [#2360](https://github.com/microsoft/BotFramework-WebChat/issues/2360). Timestamp should update on language change, by [@compulim](https://github.com/compulim) in PR [#2414](https://github.com/microsoft/BotFramework-WebChat/pull/2414)
 -  Fix [#2428](https://github.com/microsoft/BotFramework-WebChat/issues/2428). Should interrupt speech synthesis after microphone button is clicked, by [@compulim](https://github.com/compulim) in PR [#2429](https://github.com/microsoft/BotFramework-WebChat/pull/2429)
--  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Storing thumbnail URL using `attachment.thumbnailUrl` field in the activity, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Storing thumbnail URL using `attachment.thumbnailUrl` field in the activity, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
 
 ### Added
 
@@ -113,6 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `embed`: Added ES5 polyfills and dev server, by [@compulim](https://github.com/compulim), in PR [#2315](https://github.com/microsoft/BotFramework-WebChat/pull/2315)
 -  Fix [#2380](https://github.com/microsoft/BotFramework-WebChat/issues/2380). Added `botAvatarBackgroundColor` and `userAvatarBackgroundColor` to the default style options, by [@tdurnford](https://github.com/tdurnford) in PR [#2384](https://github.com/microsoft/BotFramework-WebChat/pull/2384)
 -  Added full screen capability to `IFRAME` in the `YouTubeContent` and `VimeoContent` components by [@tdurnford](https://github.com/tdurnford) in PR [#2399](https://github.com/microsoft/BotFramework-WebChat/pull/2399)
+-  Render thumbnail for image attachments using `activity.attachments[].thumbnailUrl`, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
 
 ### Samples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `component`: Move `Composer` to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/compulim/BotFramework-WebChat/pull/2308)
 -  `component`: Fix [#1818](https://github.com/microsoft/BotFramework-WebChat/issues/1818) Move to functional components by [@corinagum](https://github.com/corinagum), in PR [#2322](https://github.com/microsoft/BotFramework-WebChat/pull/2322)
 -  Fix [#2292](https://github.com/microsoft/BotFramework-WebChat/issues/2292). Added function to select voice to props, `selectVoice()`, by [@compulim](https://github.com/compulim), in PR [#2338](https://github.com/microsoft/BotFramework-WebChat/pull/2338)
+-  `bundle`: Bumped DirectLineJS to support metadata when uploading attachments, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+   - [`botframework-directlinejs@0.11.5`](https://www.npmjs.com/package/botframework-directlinejs)
+   - Removed DirectLineJS as a dev dependency for `component` because it was not referenced
 
 ### Fixed
 
@@ -92,6 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2415](https://github.com/microsoft/BotFramework-WebChat/issues/2415) and [#2416](https://github.com/microsoft/BotFramework-WebChat/issues/2416). Fix Adaptive Cards cannot be disabled on-the-fly, by [@compulim](https://github.com/compulim) in PR [#2417](https://github.com/microsoft/BotFramework-WebChat/issues/2417)
 -  Fix [#2360](https://github.com/microsoft/BotFramework-WebChat/issues/2360). Timestamp should update on language change, by [@compulim](https://github.com/compulim) in PR [#2414](https://github.com/microsoft/BotFramework-WebChat/pull/2414)
 -  Fix [#2428](https://github.com/microsoft/BotFramework-WebChat/issues/2428). Should interrupt speech synthesis after microphone button is clicked, by [@compulim](https://github.com/compulim) in PR [#2429](https://github.com/microsoft/BotFramework-WebChat/pull/2429)
+-  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Storing thumbnail URL using `attachment.thumbnailUrl` field in the activity, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Added
 

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1652,20 +1652,20 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
-			"integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
+			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-					"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+					"integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
 					"requires": {
-						"regenerator-runtime": "^0.12.0"
+						"regenerator-runtime": "^0.13.2"
 					}
 				}
 			}
@@ -5895,9 +5895,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "adaptivecards": "~1.2.0",
-    "botframework-directlinejs": "^0.11.4",
+    "botframework-directlinejs": "^0.11.5",
     "botframework-webchat-component": "0.0.0-0",
     "botframework-webchat-core": "0.0.0-0",
     "core-js": "^3.1.4",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -1114,9 +1114,9 @@
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
@@ -1333,16 +1333,6 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true,
       "optional": true
-    },
-    "botframework-directlinejs": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
-      "integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "rxjs": "^5.0.3"
-      }
     },
     "bowser": {
       "version": "1.9.3",
@@ -1567,23 +1557,6 @@
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0",
         "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "code-point-at": {
@@ -1689,15 +1662,6 @@
             "normalize-package-data": "^2.3.2",
             "parse-json": "^4.0.0",
             "pify": "^3.0.0"
-          }
-        },
-        "rxjs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-          "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
           }
         },
         "supports-color": {
@@ -1942,9 +1906,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -4771,20 +4735,12 @@
       }
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-          "dev": true
-        }
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -5191,12 +5147,12 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -5671,6 +5627,12 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5689,6 +5651,15 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         }
       }

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -36,7 +36,6 @@
     "@types/react": "^16.8.23",
     "babel-plugin-istanbul": "^5.1.4",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-    "botframework-directlinejs": "^0.11.4",
     "concurrently": "^4.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react-hooks": "^1.7.0",
@@ -66,7 +65,6 @@
     "strip-markdown": "^3.0.4"
   },
   "peerDependencies": {
-    "botframework-directlinejs": "^0.11.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/component/src/Attachment/ImageAttachment.js
+++ b/packages/component/src/Attachment/ImageAttachment.js
@@ -3,9 +3,9 @@ import React from 'react';
 
 import ImageContent from './ImageContent';
 
-const ImageAttachment = ({ attachment }) => {
-  return <ImageContent alt={attachment.name} src={attachment.thumbnailUrl || attachment.contentUrl} />;
-};
+const ImageAttachment = ({ attachment }) => (
+  <ImageContent alt={attachment.name} src={attachment.thumbnailUrl || attachment.contentUrl} />
+);
 
 ImageAttachment.propTypes = {
   activity: PropTypes.shape({
@@ -13,7 +13,8 @@ ImageAttachment.propTypes = {
   }).isRequired,
   attachment: PropTypes.shape({
     contentUrl: PropTypes.string.isRequired,
-    name: PropTypes.string
+    name: PropTypes.string,
+    thumbnailUrl: PropTypes.string
   }).isRequired
 };
 

--- a/packages/component/src/Attachment/ImageAttachment.js
+++ b/packages/component/src/Attachment/ImageAttachment.js
@@ -3,18 +3,8 @@ import React from 'react';
 
 import ImageContent from './ImageContent';
 
-const ImageAttachment = ({ activity, attachment }) => {
-  const { attachmentThumbnails } = activity.channelData || {};
-
-  if (attachmentThumbnails) {
-    const attachmentThumbnail = attachmentThumbnails[activity.attachments.indexOf(attachment)];
-
-    if (attachmentThumbnail) {
-      return <ImageContent alt={attachment.name} src={attachmentThumbnail} />;
-    }
-  }
-
-  return <ImageContent alt={attachment.name} src={attachment.contentUrl} />;
+const ImageAttachment = ({ attachment }) => {
+  return <ImageContent alt={attachment.name} src={attachment.thumbnailUrl || attachment.contentUrl} />;
 };
 
 ImageAttachment.propTypes = {

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -88,7 +88,6 @@ Dictation.propTypes = {
   language: PropTypes.string.isRequired,
   numSpeakingActivities: PropTypes.number.isRequired,
   onError: PropTypes.func,
-  postActivity: PropTypes.func.isRequired,
   sendTypingIndicator: PropTypes.bool.isRequired,
   setDictateInterims: PropTypes.func.isRequired,
   setDictateState: PropTypes.func.isRequired,

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -16,7 +16,6 @@ const Dictation = ({
   language,
   numSpeakingActivities,
   onError,
-  postActivity,
   sendTypingIndicator,
   setDictateInterims,
   setDictateState,

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -53,7 +53,7 @@ const Dictation = ({
         sendTypingIndicator && emitTypingIndicator();
       }
     },
-    [dictateState, postActivity, sendTypingIndicator, setDictateInterims, setDictateState]
+    [dictateState, emitTypingIndicator, sendTypingIndicator, setDictateInterims, setDictateState]
   );
 
   const handleError = useCallback(() => {
@@ -85,6 +85,7 @@ Dictation.defaultProps = {
 Dictation.propTypes = {
   dictateState: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
+  emitTypingIndicator: PropTypes.func.isRequired,
   language: PropTypes.string.isRequired,
   numSpeakingActivities: PropTypes.number.isRequired,
   onError: PropTypes.func,

--- a/packages/component/src/Middleware/Attachment/createCoreMiddleware.js
+++ b/packages/component/src/Middleware/Attachment/createCoreMiddleware.js
@@ -8,12 +8,6 @@ import UploadAttachment from '../../Attachment/UploadAttachment';
 import TextAttachment from '../../Attachment/TextAttachment';
 import VideoAttachment from '../../Attachment/VideoAttachment';
 
-function hasThumbnail({ attachments = [], channelData: { attachmentThumbnails = [] } = {} }, attachment) {
-  const attachmentIndex = attachments.indexOf(attachment);
-
-  return !!attachmentThumbnails[attachmentIndex];
-}
-
 // TODO: [P4] Rename this file or the whole middleware, it looks either too simple or too comprehensive now
 export default function createCoreMiddleware() {
   return () => next => {
@@ -21,9 +15,9 @@ export default function createCoreMiddleware() {
       activity = {},
       activity: { from: { role } } = {},
       attachment,
-      attachment: { contentType, contentUrl } = {}
+      attachment: { contentType, contentUrl, thumbnailUrl } = {}
     }) =>
-      role === 'user' && !/^text\//u.test(contentType) && !hasThumbnail(activity, attachment) ? (
+      role === 'user' && !/^text\//u.test(contentType) && !thumbnailUrl ? (
         <UploadAttachment activity={activity} attachment={attachment} />
       ) : /^audio\//u.test(contentType) ? (
         <AudioAttachment activity={activity} attachment={attachment} />

--- a/packages/component/src/Utils/RelativeTime.js
+++ b/packages/component/src/Utils/RelativeTime.js
@@ -28,7 +28,7 @@ const RelativeTime = ({ language, value }) => {
   const [timer, setTimer] = useState(nextTimer(value));
   const handleInterval = useCallback(() => {
     setTimer(nextTimer(value));
-  }, [language, value]);
+  }, [value]);
 
   const localizedAbsoluteTime = localize('SentAt', language) + getLocaleString(value, language);
   const text = getText(language, value);

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1112,13 +1112,22 @@
 			"optional": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
-			"integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
-			"dev": true,
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
+			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+					"integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"brace-expansion": {
@@ -3988,7 +3997,6 @@
 			"version": "5.5.12",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
 			"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
 			},
@@ -3996,8 +4004,7 @@
 				"symbol-observable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-					"dev": true
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 				}
 			}
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^12.6.2",
     "babel-plugin-istanbul": "^5.1.4",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-    "botframework-directlinejs": "^0.11.4",
+    "botframework-directlinejs": "^0.11.5",
     "concurrently": "^4.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.18.2",

--- a/packages/core/src/sagas/postActivitySaga.js
+++ b/packages/core/src/sagas/postActivitySaga.js
@@ -35,10 +35,11 @@ function* postActivity(directLine, userID, username, numActivitiesPosted, { meta
     ...deleteKey(activity, 'id'),
     attachments:
       attachments &&
-      attachments.map(({ contentType, contentUrl, name }) => ({
+      attachments.map(({ contentType, contentUrl, name, thumbnailUrl }) => ({
         contentType,
         contentUrl,
-        name
+        name,
+        thumbnailUrl
       })),
     channelData: {
       clientActivityID,

--- a/packages/core/src/sagas/sendFilesToPostActivitySaga.js
+++ b/packages/core/src/sagas/sendFilesToPostActivitySaga.js
@@ -10,14 +10,14 @@ const getType = mime.getType.bind(mime);
 function* postActivityWithFiles({ payload: { files } }) {
   yield put(
     postActivity({
-      attachments: [].map.call(files, ({ name, url }) => ({
+      attachments: [].map.call(files, ({ name, thumbnail, url }) => ({
         contentType: getType(name) || 'application/octet-stream',
         contentUrl: url,
-        name
+        name,
+        thumbnailUrl: thumbnail
       })),
       channelData: {
-        attachmentSizes: [].map.call(files, ({ size }) => size),
-        attachmentThumbnails: [].map.call(files, ({ thumbnail }) => thumbnail)
+        attachmentSizes: [].map.call(files, ({ size }) => size)
       },
       type: 'message'
     })

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -2426,26 +2426,26 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.4.tgz",
-			"integrity": "sha512-dp1kqXcnU41NqpFaKgHMTaA+3BBUF91XeUIUGzzMGE6TZNVyKWk1U1UWPWwL5dppiGDyZh1yMHOK+HgqPEG8jQ==",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
+			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-					"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+					"integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
 					"requires": {
-						"regenerator-runtime": "^0.12.0"
+						"regenerator-runtime": "^0.13.2"
 					}
 				},
 				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 				}
 			}
 		},

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "adaptivecards": "~1.2.0",
-    "botframework-directlinejs": "^0.11.4",
+    "botframework-directlinejs": "^0.11.5",
     "botframework-webchat": "0.0.0-0",
     "classnames": "^2.2.6",
     "glamor": "^2.20.40",


### PR DESCRIPTION
Fixes #2422.

## Changelog Entry

### Changed

-  `bundle`: Bumped DirectLineJS to support metadata when uploading attachments, in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)
   - [`botframework-directlinejs@0.11.5`](https://www.npmjs.com/package/botframework-directlinejs)
   - Removed DirectLineJS as a dev dependency for `component` because it was not referenced

### Fixed

-  Fix [#2422](https://github.com/microsoft/BotFramework-WebChat/issues/2422). Storing thumbnail URL using `attachment.thumbnailUrl` field in the activity, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)

### Added

-  Render thumbnail for image attachments using `activity.attachments[].thumbnailUrl`, by [@compulim](https://github.com/compulim) in PR [#2433](https://github.com/microsoft/BotFramework-WebChat/pull/2433)

## Description

Today, Web Chat locally build thumbnails and we save the thumbnail using `thumbnailUrl`.

In Direct Line API, there is a field dedicated for thumbnail, namely, `activity.attachments[].thumbnailUrl`.

Tomorrow, we will use the `thumbnailUrl` to upload and render.

## Specific Changes

- Bump to `botframework-directlinejs@0.11.5`, which support metadata while uploading attachments
- Move from `channelData.thumbnails` to the new `thumbnailUrl` field
- Render image attachments using `thumbnailUrl` if available, fallback to `contentUrl`

---

-  [x] ~Testing Added~
   - No new tests are added
