### PR TITLE
add audioConfig prop to Speech SDK Ponyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fix [#2461](https://github.com/Microsoft/BotFramework-WebChat/issues/2461), added `isomorphic-react` and `isomorphic-react-dom` packages, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in PR [#2478](https://github.com/microsoft/BotFramework-WebChat/pull/2478)
 -  Added missing Norwegian (nb-NO) translations, by [@taarskog](https://github.com/taarskog)
 -  Added missing Italian (it-IT) translations, by [@AntoT84](https://github.com/AntoT84)
+-  Resolve [#2481](https://github.com/microsoft/BotFramework-WebChat/issues/2481). Support alternative audio input source by adding `audioConfig` prop to `createCognitiveServicesSpeechServicesPonyfillFactory`, by [@corinagum](https://github.com/corinagum), in PR [#xxx](https://github.com/microsoft/BotFramework-WebChat/pull/xxx)
 
 ### Samples
 

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -1,6 +1,7 @@
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 export default function createCognitiveServicesSpeechServicesPonyfillFactory({
+  audioConfig,
   authorizationToken,
   enableTelemetry,
   region,
@@ -16,6 +17,7 @@ export default function createCognitiveServicesSpeechServicesPonyfillFactory({
 
   return ({ referenceGrammarID }) => {
     const ponyfill = createPonyfill({
+      audioConfig,
       authorizationToken,
       enableTelemetry,
       referenceGrammars: [`luis/${referenceGrammarID}-PRODUCTION`],


### PR DESCRIPTION
#2481 (ignore branch name -- I have dyslexia?)

## Changelog Entry

-  Resolve [#2481](https://github.com/microsoft/BotFramework-WebChat/issues/2481). Support alternative audio input source by adding `audioConfig` prop to `createCognitiveServicesSpeechServicesPonyfillFactory`, by [@corinagum](https://github.com/corinagum), in PR [#xxx](https://github.com/microsoft/BotFramework-WebChat/pull/xxx)

## Description

This will allow customers (once bug by Speech SDK team is resolved) to manually indicate the microphone to register speech from.

## Specific Changes
- Added `audioConfig` prop to `createCognitiveServicesSpeechServicesPonyfillFactory.