### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `component`: Move `Composer` to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/microsoft/BotFramework-WebChat/pull/2308)
 -  `component`: Fix [#1818](https://github.com/microsoft/BotFramework-WebChat/issues/1818) Move to functional components by [@corinagum](https://github.com/corinagum), in PR [#2322](https://github.com/microsoft/BotFramework-WebChat/pull/2322)
 -  Fix [#2292](https://github.com/microsoft/BotFramework-WebChat/issues/2292). Added function to select voice to props, `selectVoice()`, by [@compulim](https://github.com/compulim), in PR [#2338](https://github.com/microsoft/BotFramework-WebChat/pull/2338)
--  Bumping dependencies, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Bumping dependencies, by [@compulim](https://github.com/compulim), in PR [#2500](https://github.com/microsoft/BotFramework-WebChat/pull/2500)
    -  `*`: [`web-speech-cognitive-services@5.0.1`](https://www.npmjs.com/package/web-speech-cognitive-services)
    -  `bundle`: [`botframework-directlinejs@0.11.6`](https://www.npmjs.com/package/botframework-directlinejs)
    -  `component`: [`react-film@1.3.0`](https://www.npmjs.com/package/react-film)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  `component`: Move `Composer` to React hooks and functional components, by [@compulim](https://github.com), in PR [#2308](https://github.com/microsoft/BotFramework-WebChat/pull/2308)
 -  `component`: Fix [#1818](https://github.com/microsoft/BotFramework-WebChat/issues/1818) Move to functional components by [@corinagum](https://github.com/corinagum), in PR [#2322](https://github.com/microsoft/BotFramework-WebChat/pull/2322)
 -  Fix [#2292](https://github.com/microsoft/BotFramework-WebChat/issues/2292). Added function to select voice to props, `selectVoice()`, by [@compulim](https://github.com/compulim), in PR [#2338](https://github.com/microsoft/BotFramework-WebChat/pull/2338)
+-  Bumping dependencies, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+   -  `*`: [`web-speech-cognitive-services@5.0.1`](https://www.npmjs.com/package/web-speech-cognitive-services)
+   -  `bundle`: [`botframework-directlinejs@0.11.6`](https://www.npmjs.com/package/botframework-directlinejs)
+   -  `component`: [`react-film@1.3.0`](https://www.npmjs.com/package/react-film)
 
 ### Fixed
 

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1606,9 +1606,9 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
-			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.6.tgz",
+			"integrity": "sha512-IpMTaaf1jGHVjstYX7IqRCr21adNvKAhAVVLFLmnlqF4WZVpzVy3X14ZgttBmCPJTNuu2MhugOTzh0YxpjtqVQ==",
 			"requires": {
 				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -2872,11 +2872,6 @@
 			"resolved": "https://registry.npmjs.org/event-as-promise/-/event-as-promise-1.0.5.tgz",
 			"integrity": "sha512-z/WIlyou7oTvXBjm5YYjfklr2d8gUWtx8b5GAcrIs1n1D35f7NIK0CrcYSXbY3VYikG9bUan+wScPyGXL/NH4A=="
 		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-		},
 		"events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -3949,14 +3944,6 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-parent": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
 		"global-modules": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -4121,9 +4108,9 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -4379,7 +4366,8 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -4390,6 +4378,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -7178,11 +7167,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
-		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7211,113 +7195,18 @@
 			}
 		},
 		"web-speech-cognitive-services": {
-			"version": "4.0.1-master.6b2b9e3",
-			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-4.0.1-master.6b2b9e3.tgz",
-			"integrity": "sha512-HfMH9ml62gWUAHDXWzlhvbZxUwbWF0+uG7h7VBbzU7WKLYUem7iTnvUJVrOrHY0xcw7fjt7Rqn/J1nA6OaRdSQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-5.0.1.tgz",
+			"integrity": "sha512-d+7DaeSr9JjOrJjWe7VY5IQ3KW12oisSt4Ou7kxn/xl9q1k2ogBF00kxhIMzMdUP4XMP2PsfpSb9VzFuL4mceQ==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"base64-arraybuffer": "^0.2.0",
-				"eslint": "^6.1.0",
 				"event-as-promise": "^1.0.5",
-				"event-target-shim": "^5.0.1",
 				"events": "^3.0.0",
 				"memoize-one": "^5.0.5",
 				"microsoft-cognitiveservices-speech-sdk": "1.6.0",
 				"on-error-resume-next": "^1.1.0",
 				"simple-update-in": "^2.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"eslint": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
-					"integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"ajv": "^6.10.0",
-						"chalk": "^2.1.0",
-						"cross-spawn": "^6.0.5",
-						"debug": "^4.0.1",
-						"doctrine": "^3.0.0",
-						"eslint-scope": "^5.0.0",
-						"eslint-utils": "^1.4.2",
-						"eslint-visitor-keys": "^1.1.0",
-						"espree": "^6.1.1",
-						"esquery": "^1.0.1",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^5.0.1",
-						"functional-red-black-tree": "^1.0.1",
-						"glob-parent": "^5.0.0",
-						"globals": "^11.7.0",
-						"ignore": "^4.0.6",
-						"import-fresh": "^3.0.0",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^6.4.1",
-						"is-glob": "^4.0.0",
-						"js-yaml": "^3.13.1",
-						"json-stable-stringify-without-jsonify": "^1.0.1",
-						"levn": "^0.3.0",
-						"lodash": "^4.17.14",
-						"minimatch": "^3.0.4",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"optionator": "^0.8.2",
-						"progress": "^2.0.0",
-						"regexpp": "^2.0.1",
-						"semver": "^6.1.2",
-						"strip-ansi": "^5.2.0",
-						"strip-json-comments": "^3.0.1",
-						"table": "^5.2.3",
-						"text-table": "^0.2.0",
-						"v8-compile-cache": "^2.0.3"
-					}
-				},
-				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"espree": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-					"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
-					"requires": {
-						"acorn": "^7.0.0",
-						"acorn-jsx": "^5.0.2",
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
-				}
 			}
 		},
 		"webpack": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -46,7 +46,7 @@
     "prop-types": "^15.7.2",
     "sanitize-html": "^1.19.0",
     "url-search-params-polyfill": "^5.0.0",
-    "web-speech-cognitive-services": "4.0.1-master.6b2b9e3",
+    "web-speech-cognitive-services": "^5.0.1",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "adaptivecards": "1.2.0",
-    "botframework-directlinejs": "^0.11.5",
+    "botframework-directlinejs": "^0.11.6",
     "botframework-webchat-component": "0.0.0-0",
     "botframework-webchat-core": "0.0.0-0",
     "core-js": "^3.1.4",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -4259,9 +4259,9 @@
 			}
 		},
 		"react-film": {
-			"version": "1.2.1-master.db29968",
-			"resolved": "https://registry.npmjs.org/react-film/-/react-film-1.2.1-master.db29968.tgz",
-			"integrity": "sha512-C0RN0tBbyrt8f16GZ8fTqvzCdOuR3cKFlHR5rvwvW1I5RiUmJW0waimgogVeuUsfZ9gsnupeIeR52gOnFer5JQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-film/-/react-film-1.3.0.tgz",
+			"integrity": "sha512-pNqOFzv+RZN0Laz3HFp30KRx1Jrw3TUyp6EuCa1quaUnCBE5RaIkkiBvjTu4RRdgFNe8B2fk5ZvsDzRwjA8qoQ==",
 			"requires": {
 				"classnames": "^2.2.6",
 				"glamor": "^2.20.40",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -53,7 +53,7 @@
     "memoize-one": "^5.0.2",
     "prop-types": "^15.7.2",
     "react-dictate-button": "^1.1.3",
-    "react-film": "1.2.1-master.db29968",
+    "react-film": "^1.3.0",
     "react-redux": "^7.1.0",
     "react-say": "^1.2.0",
     "react-scroll-to-bottom": "~1.3.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1089,9 +1089,9 @@
 			"optional": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
-			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.6.tgz",
+			"integrity": "sha512-IpMTaaf1jGHVjstYX7IqRCr21adNvKAhAVVLFLmnlqF4WZVpzVy3X14ZgttBmCPJTNuu2MhugOTzh0YxpjtqVQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^12.6.2",
     "babel-plugin-istanbul": "^5.1.4",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-    "botframework-directlinejs": "^0.11.5",
+    "botframework-directlinejs": "^0.11.6",
     "concurrently": "^4.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.18.2",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -2386,9 +2386,9 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
-			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.6.tgz",
+			"integrity": "sha512-IpMTaaf1jGHVjstYX7IqRCr21adNvKAhAVVLFLmnlqF4WZVpzVy3X14ZgttBmCPJTNuu2MhugOTzh0YxpjtqVQ==",
 			"requires": {
 				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "adaptivecards": "1.2.0",
-    "botframework-directlinejs": "^0.11.5",
+    "botframework-directlinejs": "^0.11.6",
     "botframework-webchat": "0.0.0-0",
     "classnames": "^2.2.6",
     "glamor": "^2.20.40",


### PR DESCRIPTION
Fixes #2499.

## Changelog Entry

-  Bumping dependencies, by [@compulim](https://github.com/compulim), in PR [#2500](https://github.com/microsoft/BotFramework-WebChat/pull/2500)
   -  `*`: [`web-speech-cognitive-services@5.0.1`](https://www.npmjs.com/package/web-speech-cognitive-services)
   -  `bundle`: [`botframework-directlinejs@0.11.6`](https://www.npmjs.com/package/botframework-directlinejs)
   -  `component`: [`react-film@1.3.0`](https://www.npmjs.com/package/react-film)

## Description

Bump dependencies for the following packages:

- `botframework-directlinejs@0.11.6`
   - https://github.com/microsoft/BotFramework-DirectLineJS/pull/240
- `react-film@1.3.0`
   - https://github.com/spyip/react-film/pull/27
   - https://github.com/spyip/react-film/pull/30
- `web-speech-cognitive-services@5.0.1`
   - https://github.com/compulim/web-speech-cognitive-services/pull/71
   - https://github.com/compulim/web-speech-cognitive-services/pull/72
   - https://github.com/compulim/web-speech-cognitive-services/pull/74
   - https://github.com/compulim/web-speech-cognitive-services/pull/75
   - https://github.com/compulim/web-speech-cognitive-services/pull/76

## Specific Changes

(As above)

---

-  [x] ~Testing Added~
   - Existing tests should be sufficient to cover all cases
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
