### PR TITLE
Stop dictate if microphone is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2473](https://github.com/microsoft/BotFramework-WebChat/issues/2473). Fix samples 13 using wrong region for Speech Services credentials, by [@compulim](https://github.com/compulim) in PR [#2482](https://github.com/microsoft/BotFramework-WebChat/pull/2482)
 -  Fixes [#2420](https://github.com/microsoft/BotFramework-WebChat/issues/2420). Fix saga error should not result in an unhandled exception, by [@compulim](https://github.com/compulim) in PR [#2421](https://github.com/microsoft/BotFramework-WebChat/pull/2421)
 -  Fixes [#2513](https://github.com/microsoft/BotFramework-WebChat/issues/2513). Fix `core-js` not loading properly, by [@compulim](https://github.com/compulim) in PR [#2514](https://github.com/microsoft/BotFramework-WebChat/pull/2514)
+-  Fixes [#2516](https://github.com/microsoft/BotFramework-WebChat/issues/2516). Disable microphone input for `expecting` input hint on Safari, by [@compulim](https://github.com/compulim) in PR [#2517](https://github.com/microsoft/BotFramework-WebChat/pull/2517)
 
 ### Added
 


### PR DESCRIPTION
Fixes #2516.

## Changelog Entry

-  Fixes [#2516](https://github.com/microsoft/BotFramework-WebChat/issues/2516). Disable microphone input for `expecting` input hint on Safari, by [@compulim](https://github.com/compulim) in PR [#2517](https://github.com/microsoft/BotFramework-WebChat/pull/2517)

## Description

Safari block microphone access if the code was not executed based on an user interaction.

We can check if we have access to microphone (see #2516). But the microphone check will result in an non-user interaction code, thus, code executed after the check will be blocked for microphone access.

In this PR, we are turning on microphone and checking access at the same time. If access is not granted, we will turn off microphone.

## Specific Changes

- Modify `Dictation.js`
   - When microphone access is required, it will do both simultaneously
      - Continue to open microphone
      - Check if microphone access is allowed
   - If microphone access is not allowed, we will close microphone

---

-  [x] ~Testing Added~
   - No tests are added because the specific route only repro on Safari
