### PR TITLE
Limiting scope of imports for microsoft-cognitiveservices-speech-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2516](https://github.com/microsoft/BotFramework-WebChat/issues/2516). Disable microphone input for `expecting` input hint on Safari, by [@compulim](https://github.com/compulim) in PR [#2517](https://github.com/microsoft/BotFramework-WebChat/pull/2517) and PR [#2520](https://github.com/microsoft/BotFramework-WebChat/pull/2520)
 -  Fixes [#2518](https://github.com/microsoft/BotFramework-WebChat/issues/2518). Synthesis of bot activities with input hint expecting, should be interruptible, by [@compulim](https://github.com/compulim) in PR [#2520](https://github.com/microsoft/BotFramework-WebChat/pull/2520)
 -  Fixes [#2519](https://github.com/microsoft/BotFramework-WebChat/issues/2519). On Safari, microphone should turn on after synthesis of bot activities with input hint expecting, by [@compulim](https://github.com/compulim) in PR [#2520](https://github.com/microsoft/BotFramework-WebChat/pull/2520)
+-  Fixes [#2521](https://github.com/microsoft/BotFramework-WebChat/issues/2521). `webchat-es5.js` should not contains non-ES5 code and must be loadable by IE11, by [@compulim](https://github.com/compulim) in PR [#2522](https://github.com/microsoft/BotFramework-WebChat/pull/2522)
 
 ### Added
 

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -21,7 +21,6 @@ export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   //       And on next recognition, they will re-use the AudioContext object.
   if (!audioConfig) {
     audioConfig = AudioConfig.fromDefaultMicrophoneInput();
-    // audioConfig.privSource.privContext = new (window.AudioContext || window.webkitAudioContext)();
 
     const source = audioConfig.privSource;
 

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -1,4 +1,4 @@
-import { AudioConfig } from 'microsoft-cognitiveservices-speech-sdk/distrib/es2015/src/sdk/Audio/AudioConfig';
+import { AudioConfig } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/sdk/Audio/AudioConfig';
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 export default function createCognitiveServicesSpeechServicesPonyfillFactory({
@@ -21,6 +21,7 @@ export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   //       And on next recognition, they will re-use the AudioContext object.
   if (!audioConfig) {
     audioConfig = AudioConfig.fromDefaultMicrophoneInput();
+    // audioConfig.privSource.privContext = new (window.AudioContext || window.webkitAudioContext)();
 
     const source = audioConfig.privSource;
 

--- a/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
+++ b/packages/bundle/src/createCognitiveServicesSpeechServicesPonyfillFactory.js
@@ -1,4 +1,4 @@
-import { AudioConfig } from 'microsoft-cognitiveservices-speech-sdk';
+import { AudioConfig } from 'microsoft-cognitiveservices-speech-sdk/distrib/es2015/src/sdk/Audio/AudioConfig';
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 export default function createCognitiveServicesSpeechServicesPonyfillFactory({
@@ -21,7 +21,6 @@ export default function createCognitiveServicesSpeechServicesPonyfillFactory({
   //       And on next recognition, they will re-use the AudioContext object.
   if (!audioConfig) {
     audioConfig = AudioConfig.fromDefaultMicrophoneInput();
-    // audioConfig.privSource.privContext = new (window.AudioContext || window.webkitAudioContext)();
 
     const source = audioConfig.privSource;
 


### PR DESCRIPTION
Fixes #2521.

## Changelog Entry

-  Fixes [#2521](https://github.com/microsoft/BotFramework-WebChat/issues/2521). `webchat-es5.js` should not contains non-ES5 code and must be loadable by IE11, by [@compulim](https://github.com/compulim) in PR [#2522](https://github.com/microsoft/BotFramework-WebChat/pull/2522)

## Description

When we import `AudioConfig`, Webpack is loading a non-ES5 build from `/node_modules/microsoft-cognitiveservices-speech-sdk/distrib/es2015/src/sdk/Audio/AudioConfig`. In fact, it should import from `/distrib/lib/src/` instead.

## Specific Changes

- Limiting the scope of import to `/distrib/lib/src/` for `microsoft-cognitiveservices-speech-sdk`

---

-  [x] ~Testing Added~
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
