### PR TITLE
Fix version number to burn correctly under Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2518](https://github.com/microsoft/BotFramework-WebChat/issues/2518). Synthesis of bot activities with input hint expecting, should be interruptible, by [@compulim](https://github.com/compulim) in PR [#2520](https://github.com/microsoft/BotFramework-WebChat/pull/2520)
 -  Fixes [#2519](https://github.com/microsoft/BotFramework-WebChat/issues/2519). On Safari, microphone should turn on after synthesis of bot activities with input hint expecting, by [@compulim](https://github.com/compulim) in PR [#2520](https://github.com/microsoft/BotFramework-WebChat/pull/2520)
 -  Fixes [#2521](https://github.com/microsoft/BotFramework-WebChat/issues/2521). `webchat-es5.js` should not contains non-ES5 code and must be loadable by IE11, by [@compulim](https://github.com/compulim) in PR [#2522](https://github.com/microsoft/BotFramework-WebChat/pull/2522)
+-  Fixes [#2524](https://github.com/microsoft/BotFramework-WebChat/issues/2524). Version was not burnt into source code correctly, by [@compulim](https://github.com/compulim) in PR [#2525](https://github.com/microsoft/BotFramework-WebChat/pull/2525)
 
 ### Added
 

--- a/packages/bundle/.babelrc
+++ b/packages/bundle/.babelrc
@@ -13,7 +13,7 @@
     [
       "transform-inline-environment-variables", {
         "include": [
-          "NPM_PACKAGE_VERSION"
+          "npm_package_version"
         ]
       }
     ]

--- a/packages/bundle/src/addVersion.js
+++ b/packages/bundle/src/addVersion.js
@@ -21,7 +21,7 @@ function setMetaTag(name, content) {
 
 export default function addVersion(variant) {
   setMetaTag('botframework-webchat:bundle:variant', variant);
-  setMetaTag('botframework-webchat:bundle:version', process.env.NPM_PACKAGE_VERSION);
+  setMetaTag('botframework-webchat:bundle:version', process.env.npm_package_version);
   setMetaTag('botframework-webchat:core:version', coreVersion);
   setMetaTag('botframework-webchat:ui:version', componentVersion);
 }

--- a/packages/component/.babelrc
+++ b/packages/component/.babelrc
@@ -25,7 +25,7 @@
     [
       "transform-inline-environment-variables", {
         "include": [
-          "NPM_PACKAGE_VERSION"
+          "npm_package_version"
         ]
       }
     ]

--- a/packages/component/src/index.tsx
+++ b/packages/component/src/index.tsx
@@ -36,7 +36,7 @@ import createStyleSet from './Styles/createStyleSet';
 import defaultStyleOptions from './Styles/defaultStyleOptions';
 import getTabIndex from './Utils/TypeFocusSink/getTabIndex';
 
-const version = process.env.NPM_PACKAGE_VERSION;
+const version = process.env.npm_package_version;
 
 const Components = {
   Composer,

--- a/packages/core/.babelrc
+++ b/packages/core/.babelrc
@@ -12,7 +12,7 @@
     [
       "transform-inline-environment-variables", {
         "include": [
-          "NPM_PACKAGE_VERSION"
+          "npm_package_version"
         ]
       }
     ]

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -29,7 +29,7 @@ import * as ActivityClientState from './constants/ActivityClientState';
 import * as DictateState from './constants/DictateState';
 
 const Constants = { ActivityClientState, DictateState };
-const version = process.env.NPM_PACKAGE_VERSION;
+const version = process.env.npm_package_version;
 
 export {
   clearSuggestedActions,


### PR DESCRIPTION
Fixes #2524.

## Changelog Entry

-  Fixes [#2524](https://github.com/microsoft/BotFramework-WebChat/issues/2524). Version was not burnt into source code correctly, by [@compulim](https://github.com/compulim) in PR [#2525](https://github.com/microsoft/BotFramework-WebChat/pull/2525)

## Description

Version number burnt into the source code was `undefined` when building under Ubuntu, but works on Windows.

## Specific Changes

- Change all instances of `NPM_PACKAGE_VERSION` to `npm_package_version`

---

-  [x] ~Testing Added~
   - Manual tests are sufficient in release checklist
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
