### PR TITLE
Add React hooks for customization (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customziation, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in the following PRs:
+-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in the following PRs:
    -  PR [#2540](https://github.com/microsoft/BotFramework-WebChat/pull/2540): `useActivities`, `useReferenceGrammarID`, `useSendBoxDictationStarted`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in the following PRs:
+-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim), in the following PRs:
    -  PR [#2540](https://github.com/microsoft/BotFramework-WebChat/pull/2540): `useActivities`, `useReferenceGrammarID`, `useSendBoxDictationStarted`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Fixes [#2565](https://github.com/microsoft/BotFramework-WebChat/issues/2565). Fixed Adaptive Card host config should generate from style options with default options merged, by [@compulim](https://github.com/compulim) in PR [#2566](https://github.com/microsoft/BotFramework-WebChat/pull/2566)
 
+### Added
+
+-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customziation, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in the following PRs:
+   -  PR [#2540](https://github.com/microsoft/BotFramework-WebChat/pull/2540): `useActivities`, `useReferenceGrammarID`, `useSendBoxDictationStarted`
+
+### Fixed
+
 ### Changed
 
 - Bumped all dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2533](https://github.com/microsoft/BotFramework-WebChat/pull/2533)

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,642 @@
+# Web Chat API as React hooks
+
+Web Chat is designed to be highly customizable. In order to build your own UI, you can use React Hooks to hook your UI component into Web Chat API.
+
+To enable Web Chat API, all UI components must be located under the [`<Composer>`](https://github.com/microsoft/BotFramework-WebChat/blob/master/packages/component/src/Composer.js) component. You can refer to our [plain UI customization](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/21.customization-plain-ui) sample for details.
+
+## Why React Hooks
+
+React Hooks will make your code cleaner and shorter, and also greatly improve readability.
+
+Web Chat expose our APIs through React Hooks. This API surface enables us to freely move stuff behind the scene, introduce new APIs, and a safe way to deprecate APIs. It will also make us easier to shuffle work between our internal Redux store and React Context.
+
+## Two types of hooks
+
+We design our hooks largely with two basic shapes:
+
+- Actions, these are functions that you can call at any time to perform a side-effect
+- Properties, these are getter function with an optional setter
+   - This is same as [React State Hook pattern](https://reactjs.org/docs/hooks-state.html), but setter could be optional
+   - If the value changed, React will call your render function again
+
+### Actions
+
+All actions will return a function that you can call later. For example, if you want to focus to the send box, you will use the following code:
+
+```js
+const focusSendBox = useFocusSendBox();
+
+focusSendBox();
+```
+
+### Properties
+
+All properties follow [React State Hook pattern](https://reactjs.org/docs/hooks-state.html). For example, if you want to get and set the value of send box, you will use the following code:
+
+```js
+const [sendBoxValue, setSendBoxValue] = useSendBoxValue();
+
+console.log(`The send box value is "${ sendBoxValue }".`);
+
+setSendBoxValue('Hello, World!');
+```
+
+> Note: some properties may not be settable.
+
+# List of hooks
+
+Following is the list of hooks supported by Web Chat API.
+
+- [`useActivities`](#useactivities)
+- [`useAdaptiveCardsHostConfig`](#useadaptivecardshostconfig)
+- [`useAdaptiveCardsPackage`](#useadaptivecardspackage)
+- [`useAvatarForBot`](#useavatarforbot)
+- [`useAvatarForUser`](#useavatarforuser)
+- [`useConnectivityStatus`](#useconnectivitystatus)
+- [`useDictateInterims`](#usedictateinterims)
+- [`useDictateState`](#usedictatestate)
+- [`useDisabled`](#usedisabled)
+- [`useEmitTypingIndicator`](#useemittypingindicator)
+- [`useFocusSendBox`](#usefocussendbox)
+- [`useGrammars`](#usegrammars)
+- [`useGroupTimestamp`](#usegrouptimestamp)
+- [`useLanguage`](#uselanguage)
+- [`useLastTypingAt`](#uselasttypingat)
+- [`useLocalize`](#uselocalize)
+- [`useMarkActivityAsSpoken`](#usemarkactivityasspoken)
+- [`usePerformCardAction`](#useperformcardaction)
+- [`usePostActivity`](#usepostactivity)
+- [`useReferenceGrammarID`](#usereferencegrammarid)
+- [`useRenderActivity`](#useRenderActivity)
+- [`useRenderAttachment`](#useRenderAttachment)
+- [`useRenderMarkdownAsHTML`](#useRenderMarkdownAsHTML)
+- [`useScrollToEnd`](#usescrolltoend)
+- [`useSendBoxValue`](#usesendboxvalue)
+- [`useSendEvent`](#usesendevent)
+- [`useSendFiles`](#usesendfiles)
+- [`useSendMessage`](#usesendmessage)
+- [`useSendMessageBack`](#usesendmessageback)
+- [`useSendPostBack`](#usesendpostback)
+- [`useSendTypingIndicator`](#usesendtypingindicator)
+- [`useShouldSpeakIncomingActivity`](#useshouldspeakincomingactivity)
+- [`useStartDictate`](#usestartdictate)
+- [`useStopDictate`](#usestopdictate)
+- [`useStyleOptions`](#usestyleoptions)
+- [`useStyleSet`](#usestyleset)
+- [`useSubmitSendBox`](#usesubmitsendbox)
+- [`useSuggestedActions`](#usesuggestedactions)
+- [`useTimeoutForSend`](#usetimeoutforsend)
+- [`useUserID`](#useuserid)
+- [`useUsername`](#useusername)
+- [`useVoiceSelector`](#usevoiceselector)
+- [`useWebSpeechPonyfill`](#usewebspeechponyfill)
+
+## `useActivities`
+
+```js
+useActivities(): [Activity[]]
+```
+
+This function will return a list of activities.
+
+## `useAdaptiveCardsHostConfig`
+
+```js
+useAdaptiveCardsHostConfig(): [AdaptiveCards.HostConfig]
+```
+
+This function is only available in full bundle. The function will return the Adaptive Cards Host Config used for styling Adaptive Cards.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useAdaptiveCardsPackage`
+
+```js
+useAdaptiveCardsPackage(): [AdaptiveCards]
+```
+
+This function is only available in full bundle. The function will return the Adaptive Cards package used for building and rendering Adaptive Cards.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useAvatarForBot`
+
+```js
+useAvatarForBot(): [{
+  image: string,
+  initials: string
+}]
+```
+
+This function will return the image and initials of the bot. Both image and initials are optional and can be falsy.
+
+To set the avatar for bot, use style options.
+
+## `useAvatarForUser`
+
+```js
+useAvatarForUser(): [{
+  image: string,
+  initials: string
+}]
+```
+
+This function will return the image and initials of the user. Both image and initials are optional and can be falsy.
+
+To set the avatar for user, use style options.
+
+## `useConnectivityStatus`
+
+```js
+useConnectivityStatus(): [string]
+```
+
+This function will return the connectivity status of:
+
+- `connected`: Connected
+- `connectingslow`: Still connecting, not connected
+- `error`: Connection error
+- `notconnected`: Not connected
+- `reconnected`: Reconnected after interruption
+- `reconnecting`: Reconnecting after interruption
+- `sagaerror`: Errors on JavaScript side
+- `uninitialized`: Never connect and not connecting
+
+## `useDictateInterims`
+
+```js
+useDictateInterims(): [string[][]]
+```
+
+This function will return interims for dictation.
+
+The first array represents separate sentences. And the second array represents various ambiguities/alternatives for the same sentence.
+
+## `useDictateState`
+
+```js
+useDictateState(): [string]
+```
+
+This function will return the dictate state of:
+
+- `0`: Idle
+- `1`: Starting
+- `2`: Dictating
+- `3`: Stopping
+
+To control dictate state, use [`useStartDictate`](#usestartdictate) and [`useStopDictate`](#usestopdictate) hooks.
+
+## `useDisabled`
+
+```js
+useDisabled(): [boolean]
+```
+
+This function will return whether the UI should be disabled or not. All interactable UI components should honor this value.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useEmitTypingIndicator`
+
+```js
+useEmitTypingIndicator(): () => void
+```
+
+When called, this function will send a typing activity to the bot.
+
+## `useFocusSendBox`
+
+```js
+useFocusSendBox(): () => void
+```
+
+When called, this function will send focus to the send box.
+
+## `useGrammars`
+
+```js
+useGrammars(): [string[]]
+```
+
+This function will return the grammars for speech-to-text.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useGroupTimestamp`
+
+```js
+useGroupTimestamp(): [number]
+```
+
+This function will return the interval for grouping similar activities with a single timestamp. The interval is represented in milliseconds.
+
+For example, if this value is `5000`, activities with successive within 5 seconds will not have timestamp shown.
+
+To control the `groupTimestamp` state, use style options.
+
+## `useLanguage`
+
+```js
+useLanguage(): [string]
+```
+
+This function will return the language of the UI. All UI components should honor this value.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useLastTypingAt`
+
+```js
+useLastTypingAt(): [{
+  [id: string]: number
+}]
+```
+
+This function will return a map of last typing time of all participants. The time is based on client clock.
+
+This property is computed on every incoming activity.
+
+## `useLocalize`
+
+```js
+useLocalize(identifier: string) => string
+```
+
+This function will return a localized string represented by the identifier. It honor the language settings from `useLanguage` hook.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useMarkActivityAsSpoken`
+
+```js
+useMarkActivityAsSpoken(): (activity: Activity) => void
+```
+
+When called, this function will mark the activity as spoken and remove it from the text-to-speech queue.
+
+## `usePerformCardAction`
+
+```js
+usePerformCardAction(): ({
+  displayText: string,
+  text: string,
+  type: string,
+  value: string
+}) => void
+```
+
+When called, this function will perform the card action based on its `type`. The card action will be performed by `cardActionMiddleware`.
+
+## `usePostActivity`
+
+```js
+usePostActivity(): (activity: Activity) => void
+```
+
+When called, this function will post the activity on behalf of the user, to the bot.
+
+You can use this function to send any type of activities to the bot. We highly recommend you send the following type of activities only:
+
+- `event`
+- `message`
+- `typing`
+
+## `useReferenceGrammarID`
+
+```js
+useReferenceGrammarId(): [string]
+```
+
+When called, this function will return the reference grammar ID used to improve speech-to-text performance when used with Cognitive Services.
+
+This value is not controllable and is passed from Direct Line channel.
+
+## `useRenderActivity`
+
+```js
+useRenderActivity(): ({
+  activity: Activity,
+  renderAttachment: ({
+    activity: Activity,
+    attachment: Attachment
+  }) => React.Element,
+  timestampClassName: string
+}) => React.Element
+```
+
+This function is for rendering activity into React element. The caller will need to pass `activity`, `timestampClassName`, and a render function for attachment. This function is a composition of `activityRendererMiddleware`, which is passed as a prop.
+
+## `useRenderAttachment`
+
+```js
+useRenderAttachment(): ({
+  activity: Activity,
+  attachment: Attachment
+}) => React.Element
+```
+
+This function is for rendering attachment into React element. The caller will need to pass `activity` and `attachment`. This function is a composition of `attachmentRendererMiddleware`, which is passed as a prop.
+
+```js
+() => next => { activity, attachment } => next({ activity, attachment })
+```
+
+## `useRenderMarkdownAsHTML`
+
+```js
+useRenderMarkdownAsHTML(): (markdown: string): string
+```
+
+This function will return a function that render Markdown into HTML string. For example,
+
+```js
+const renderMarkdown = useRenderMarkdown();
+
+renderMarkdown('Hello, World!') === '<p>Hello, World!</p>\n';
+```
+
+To modify this value, change the props passed to Web Chat.
+
+## `useScrollToEnd`
+
+```js
+useScrollToEnd(): () => void
+```
+
+This function will return a function that when called, it will scroll the transcript view to the end.
+
+## `useSendBoxValue`
+
+```js
+useSendBoxValue(): [string, (value: string) => void]
+```
+
+This function will return the value of the send box, and the setter function to change the value.
+
+## `useSendEvent`
+
+```js
+useSendEvent(): (name: string, value: string) => void
+```
+
+When called, this function will send an event activity to the bot.
+
+## `useSendFiles`
+
+```js
+useSendFiles(): (files: (Blob | File)[]) => void
+```
+
+When called, this function will send a message activity with one or more [File](https://developer.mozilla.org/en-US/docs/Web/API/File) attachments to the bot, including these operations:
+
+- Convert [File](https://developer.mozilla.org/en-US/docs/Web/API/File) into object URL
+- Generate thumbnail and will use Web Worker and offscreen canvas if supported
+
+If you are using `ArrayBuffer`, you can use `FileReader` to convert it into a blob before calling [`URL.createObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).
+
+## `useSendMessage`
+
+```js
+useSendMessage(): (text: string, method: string) => void
+```
+
+When called, this function will send a text message activity to the bot.
+
+You can optionally include the input method the text message is collected. Currently, if specified, only `speech` is supported.
+
+## `useSendMessageBack`
+
+```js
+useSendMessageBack(): (value: any, text: string, displayText: string) => void
+```
+
+When called, this function will send a `messageBack` activity to the bot.
+
+## `useSendPostBack`
+
+```js
+useSendPostBack(): (value: any) => void
+```
+
+When called, this function will send a `postBack` activity to the bot.
+
+## `useSendTypingIndicator`
+
+```js
+useSendTypingIndicator(): [boolean]
+```
+
+This function will return whether typing indicator will be send to the bot when the send box value is changed.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useShouldSpeakIncomingActivity`
+
+```js
+useShouldSpeakIncomingActivity(): [boolean, (value: boolean) => void]
+```
+
+This function will return whether the next incoming activity will be queued for text-to-speech or not, and a setter function to control the behavior.
+
+If the last outgoing message is sent by speech, Web Chat will set this state to `true`, so the response from bot will be synthesized as speech.
+
+## `useStartDictate`
+
+```js
+useStartDictate(): () => void
+```
+
+This function will open the microphone for dictation. You should only call this function by user-initiated gesture. Otherwise, the browser may block access to the microphone.
+
+## `useStopDictate`
+
+```js
+useStopDictate(): () => void
+```
+
+This function will close the microphone. It will not send the interims to the bot, but leave the interims in the send box.
+
+## `useStyleOptions`
+
+```js
+useStyleOptions(): [StyleOptions]
+```
+
+This function will return the style options. UI components should honor the styling preferences.
+
+The value is not the same as the props. Web Chat will merge the style options passed in props with default values specified in [`defaultStyleOptions.js`](https://github.com/microsoft/BotFramework-WebChat/blob/master/packages/component/src/Styles/defaultStyleOptions.js).
+
+To modify the value of `styleOptions` state, change the props you pass to Web Chat.
+
+## `useStyleSet`
+
+```js
+useStyleSet(): [StyleSet]
+```
+
+This function will return the style set.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useSubmitSendBox`
+
+```js
+useSubmitSendBox(): () => void
+```
+
+This function will send the text in the send box to the bot, and clear the send box.
+
+## `useSuggestedActions`
+
+```js
+useSuggestedActions(): [CardAction[], (CardAction[]) => void]
+```
+
+This function will return a list of suggested actions that should show to the user, and a setter function to clear suggested actions. The setter function can only be used to clear suggested actions, and it will accept empty array or falsy value only.
+
+The suggested actions is computed from the last message activity sent from the bot. If the user posted an activity, the suggested actions will be cleared.
+
+## `useTimeoutForSend`
+
+```js
+useTimeoutForSend(): [number]
+```
+
+This function will return the interval before a sending activity is considered fail. The interval is represented in milliseconds. Due to network partitioning problem, activity that failed to send could eventually successfully deliver to the bot.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useUserID`
+
+```js
+useUserID(): [string]
+```
+
+This function will return the user ID.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useUsername`
+
+```js
+useUsername(): [string]
+```
+
+This function will return the username.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useVoiceSelector`
+
+```js
+useVoiceSelector(activity: Activity): (voices: SpeechSynthesisVoice[]) => SpeechSynthesisVoice
+```
+
+This function will return a function that can be called to select the voice for a specific activity.
+
+To modify this value, change the props passed to Web Chat.
+
+## `useWebSpeechPonyfill`
+
+```js
+useWebSpeechPonyfill(): [{
+  SpeechGrammarList: SpeechGrammarList,
+  SpeechRecognition: SpeechRecognition,
+  speechSynthesis: SpeechSynthesis,
+  SpeechSynthesisUtterance: SpeechSynthesisUtterance
+}]
+```
+
+This function will return the ponyfill for Web Speech API.
+
+To modify this value, change the props passed to Web Chat.
+
+# Component-specific hooks
+
+These are hooks specific provide specific user experience.
+
+## `MicrophoneButton`
+
+These are hooks that are specific for the microphone button.
+
+- [`useMicrophoneButtonClick`](#usemicrophonebuttonclick)
+- [`useMicrophoneButtonDisabled`](#usemicrophonebuttondisabled)
+
+### `useMicrophoneButtonClick`
+
+```js
+useMicrophoneButtonClick(): () => void
+```
+
+When called, this function will toggle microphone open or close.
+
+### `useMicrophoneButtonDisabled`
+
+```js
+useMicrophoneButtonDisabled(): () => void
+```
+
+This function will return whether the microphone button is disabled. This is more than `useDisabled()`. The microphone button could be disabled because it is currently starting or stopping.
+
+This value can be partly controllable through Web Chat props.
+
+## `SendBox`
+
+These are hooks that are specific for the send box.
+
+- [`useSendBoxDictationStarted`](#usesendboxdictationstarted)
+
+### `useSendBoxDictationStarted`
+
+```js
+useSendBoxDictationStarted(): [boolean]
+```
+
+This function will return whether the speech-to-text has been started or not.
+
+## `TextBox`
+
+These are hooks that are specific to the text box in the send box.
+
+- [`useTextBoxSubmit`](#usetextboxsubmit)
+- [`useTextBoxValue`](#usetextboxvalue)
+
+### `useTextBoxSubmit`
+
+```js
+useTextBoxSubmit(): (setFocus: boolean) => void
+```
+
+This function will send the text box value as a message to the bot. In addition to the original `useSubmitSendBox` hook, this function will also scroll to bottom and optionally, set focus to the send box.
+
+The focus is useful for phone scenario, where virtual keyboard will only be shown when a text box is focused.
+
+### `useTextBoxValue`
+
+```js
+useTextBoxValue(): [string, (value: string) => void]
+```
+
+This function will return the text box value, and a setter function to set the value.
+
+The setter function will call the setter of [`useSendBoxValue`](#usesendboxvalue) and also stop dictation if started.
+
+## `TypingIndicator`
+
+These are hooks that are specific to the typing indicator.
+
+- [`useTypingIndicatorVisible`](#usetypingindicatorvisible)
+
+### `useTypingIndicatorVisible`
+
+```js
+useTypingIndicatorVisible(): [boolean]
+```
+
+This function will return whether the typing indicator should be visible or not. This function is time-sensitive, means, the value could varies based on the clock.
+
+This function derive the visibility of the typing indicator by:
+
+- `typingAnimationDuration` value specified in style options, in milliseconds
+- Values from the `useLastTypingAt` hook

--- a/__tests__/hooks/useActivity.js
+++ b/__tests__/hooks/useActivity.js
@@ -1,0 +1,54 @@
+import { timeouts } from '../constants.json';
+
+import minNumActivitiesShown from '../setup/conditions/minNumActivitiesShown';
+import uiConnected from '../setup/conditions/uiConnected';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+test('should return list of activities', async () => {
+  const { driver, pageObjects } = await setupWebDriver();
+
+  await driver.wait(uiConnected(), timeouts.directLine);
+  await pageObjects.sendMessageViaSendBox('Hello, World!', { waitForSend: true });
+
+  await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+  const [activities] = await pageObjects.runHook('useActivities');
+  const cleanedActivities = activities
+    .filter(({ type }) => type === 'message')
+    .map(({ from: { role }, speak, text, textFormat, type }) => ({ from: { role }, speak, text, textFormat, type }));
+
+  expect(cleanedActivities).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "from": Object {
+          "role": "user",
+        },
+        "speak": undefined,
+        "text": "Hello, World!",
+        "textFormat": "plain",
+        "type": "message",
+      },
+      Object {
+        "from": Object {
+          "role": "bot",
+        },
+        "speak": "Unknown command: I don't know Hello, World!. You can say \\"help\\" to learn more.",
+        "text": "Unknown command: \`Hello, World!\`.
+
+    Type \`help\` to learn more.",
+        "textFormat": undefined,
+        "type": "message",
+      },
+    ]
+  `);
+});
+
+test('setter should throw exception', async () => {
+  const { pageObjects } = await setupWebDriver();
+
+  await expect(pageObjects.runHook('useActivities', [], result => result[1]())).rejects.toThrow();
+});

--- a/__tests__/hooks/useReferenceGrammarId.js
+++ b/__tests__/hooks/useReferenceGrammarId.js
@@ -1,0 +1,32 @@
+import { timeouts } from '../constants.json';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+test('getter should return reference grammar ID', async () => {
+  const { pageObjects } = await setupWebDriver({
+    createDirectLine: options => {
+      const workingDirectLine = window.WebChat.createDirectLine(options);
+
+      return {
+        activity$: workingDirectLine.activity$,
+        connectionStatus$: workingDirectLine.connectionStatus$,
+        getSessionId: workingDirectLine.getSessionId.bind(workingDirectLine),
+        postActivity: workingDirectLine.postActivity.bind(workingDirectLine),
+        referenceGrammarId: '12345678-1234-5678-abcd-12345678abcd'
+      };
+    }
+  });
+
+  const [referenceGrammarID] = await pageObjects.runHook('useReferenceGrammarID');
+
+  expect(referenceGrammarID).toBe('12345678-1234-5678-abcd-12345678abcd');
+});
+
+test('setter should throw exception', async () => {
+  const { pageObjects } = await setupWebDriver();
+
+  await expect(pageObjects.runHook('useReferenceGrammarID', [], result => result[1]())).rejects.toThrow();
+});

--- a/__tests__/setup/pageObjects/index.js
+++ b/__tests__/setup/pageObjects/index.js
@@ -15,6 +15,7 @@ import isDictating from './isDictating';
 import pingBot from './pingBot';
 import playMediaToCompletion from './playMediaToCompletion';
 import putSpeechRecognitionResult from './putSpeechRecognitionResult';
+import runHook from './runHook';
 import scrollToTop from './scrollToTop';
 import sendFile from './sendFile';
 import sendMessageViaMicrophone from './sendMessageViaMicrophone';
@@ -53,6 +54,7 @@ export default function pageObjects(driver) {
       pingBot,
       playMediaToCompletion,
       putSpeechRecognitionResult,
+      runHook,
       scrollToTop,
       sendFile,
       sendMessageViaMicrophone,

--- a/__tests__/setup/pageObjects/runHook.js
+++ b/__tests__/setup/pageObjects/runHook.js
@@ -1,0 +1,19 @@
+import executePromiseScript from './executePromiseScript';
+
+const NULL_FN = arg => arg;
+
+export default async function runHook(driver, name, args = [], selector = NULL_FN) {
+  return await executePromiseScript(
+    driver,
+    (name, args, selectorString) => {
+      const selector = eval(`(${selectorString})`);
+
+      args.unshift(name);
+
+      return window.WebChatTest.runHook.apply(null, args).then(selector);
+    },
+    name,
+    args,
+    selector.toString()
+  );
+}

--- a/__tests__/setup/web/index.html
+++ b/__tests__/setup/web/index.html
@@ -50,6 +50,8 @@
     <script src="https://tdurnford.github.io/BotFramework-Offline-MockBot/index.js"></script>
     <script src="https://unpkg.com/event-target-shim@5.0.1/dist/event-target-shim.umd.js"></script>
     <script src="https://unpkg.com/simple-update-in"></script>
+    <script src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js"></script>
     <script src="/createProduceConsumeBroker.js"></script>
     <script src="/mockWebSpeech.js"></script>
   </head>
@@ -62,6 +64,23 @@
         });
 
         return obj;
+      }
+
+      async function runHook(name, args) {
+        return new Promise((resolve, reject) => {
+          window.WebChatTest.store.dispatch({
+            type: 'DIRECT_LINE/INCOMING_ACTIVITY',
+            payload: {
+              activity: {
+                from: { id: 'bot' },
+                id: Math.random().toString(36).substr(2, 10),
+                name: 'hook',
+                type: 'event',
+                value: { args, name, reject, resolve }
+              }
+            }
+          });
+        });
       }
 
       function loadScript(src) {
@@ -138,7 +157,24 @@
           };
         });
 
+        const activityMiddleware = () => next => card => {
+          const { activity } = card;
+          if (activity.type === 'event' && activity.name === 'hook') {
+            return children => React.createElement(() => {
+              const { args, name, reject, resolve } = activity.value;
+              try {
+                resolve(window.WebChat.hooks[name](args));
+              } catch (err) {
+                reject(err);
+              }
+              return false;
+            });
+          }
+          return next(card);
+        };
+
         props = {
+          activityMiddleware,
           directLine,
           store,
           styleSet: createStyleSet && createStyleSet(props.styleOptions),
@@ -160,7 +196,8 @@
 
       window.WebChatTest = {
         actions: [],
-        loadScript
+        loadScript,
+        runHook
       };
     </script>
   </body>

--- a/packages/bundle/src/index-minimal.ts
+++ b/packages/bundle/src/index-minimal.ts
@@ -7,7 +7,8 @@ import ReactWebChat, {
   Components,
   concatMiddleware,
   connectToWebChat,
-  createStyleSet
+  createStyleSet,
+  hooks
 } from 'botframework-webchat-component';
 
 import addVersion from './addVersion';
@@ -35,6 +36,7 @@ export {
   createBrowserWebSpeechPonyfillFactory,
   createStore,
   createStyleSet,
+  hooks,
   renderWebChat,
   version
 };
@@ -48,6 +50,7 @@ window['WebChat'] = {
   createDirectLine,
   createStore,
   createStyleSet,
+  hooks,
   ReactWebChat,
   renderWebChat
 };

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -3,7 +3,7 @@
 
 export * from './index-minimal';
 
-import { version } from './index-minimal';
+import { hooks, version } from './index-minimal';
 import addVersion from './addVersion';
 import coreRenderWebChat from './renderWebChat';
 import createCognitiveServicesBingSpeechPonyfillFactory from './createCognitiveServicesBingSpeechPonyfillFactory';
@@ -29,6 +29,7 @@ export {
   createCognitiveServicesBingSpeechPonyfillFactory,
   createCognitiveServicesSpeechServicesPonyfillFactory,
   createStyleSet,
+  hooks,
   renderMarkdown,
   renderWebChat
 };
@@ -39,6 +40,7 @@ window['WebChat'] = {
   createCognitiveServicesSpeechServicesPonyfillFactory,
   createDirectLine,
   createStyleSet,
+  hooks,
   ReactWebChat,
   renderMarkdown,
   renderWebChat

--- a/packages/component/src/BasicSendBox.js
+++ b/packages/component/src/BasicSendBox.js
@@ -29,6 +29,11 @@ const DICTATION_INTERIMS_CSS = css({ flex: 10000 });
 const MICROPHONE_BUTTON_CSS = css({ flex: 1 });
 const TEXT_BOX_CSS = css({ flex: 10000 });
 
+// TODO: [P3] We should consider exposing core/src/definitions and use it instead
+function activityIsSpeakingOrQueuedToSpeak({ channelData: { speak } = {} }) {
+  return !!speak;
+}
+
 function useSendBoxDictationStarted(dictateState) {
   const [activities] = useActivities();
 
@@ -83,11 +88,6 @@ BasicSendBox.propTypes = {
     SpeechRecognition: PropTypes.any
   })
 };
-
-// TODO: [P3] We should consider exposing core/src/definitions and use it instead
-function activityIsSpeakingOrQueuedToSpeak({ channelData: { speak } = {} }) {
-  return !!speak;
-}
 
 export default connectToWebChat(({ dictateState, styleSet, webSpeechPonyfill }) => ({
   dictateState,

--- a/packages/component/src/BasicSendBox.js
+++ b/packages/component/src/BasicSendBox.js
@@ -72,7 +72,7 @@ BasicSendBox.defaultProps = {
 
 BasicSendBox.propTypes = {
   className: PropTypes.string,
-  dictationStarted: PropTypes.bool.isRequired,
+  dictateState: PropTypes.bool.isRequired,
   styleSet: PropTypes.shape({
     options: PropTypes.shape({
       hideUploadButton: PropTypes.bool.isRequired
@@ -89,7 +89,7 @@ function activityIsSpeakingOrQueuedToSpeak({ channelData: { speak } = {} }) {
   return !!speak;
 }
 
-export default connectToWebChat(({ activities, dictateState, styleSet, webSpeechPonyfill }) => ({
+export default connectToWebChat(({ dictateState, styleSet, webSpeechPonyfill }) => ({
   dictateState,
   styleSet,
   webSpeechPonyfill

--- a/packages/component/src/BasicSendBox.js
+++ b/packages/component/src/BasicSendBox.js
@@ -13,6 +13,7 @@ import SuggestedActions from './SendBox/SuggestedActions';
 import TextBox from './SendBox/TextBox';
 import TypingIndicator from './SendBox/TypingIndicator';
 import UploadButton from './SendBox/UploadButton';
+import useActivities from './hooks/useActivities';
 
 const {
   DictateState: { DICTATING, STARTING }
@@ -28,28 +29,41 @@ const DICTATION_INTERIMS_CSS = css({ flex: 10000 });
 const MICROPHONE_BUTTON_CSS = css({ flex: 1 });
 const TEXT_BOX_CSS = css({ flex: 10000 });
 
-const BasicSendBox = ({ className, dictationStarted, styleSet, webSpeechPonyfill }) => (
-  <div className={classNames(styleSet.sendBox + '', ROOT_CSS + '', className + '')} role="form">
-    <TypingIndicator />
-    <ConnectivityStatus />
-    <SuggestedActions />
-    <div className="main">
-      {!styleSet.options.hideUploadButton && <UploadButton />}
-      {dictationStarted ? (
-        <DictationInterims className={DICTATION_INTERIMS_CSS + ''} />
-      ) : (
-        <TextBox className={TEXT_BOX_CSS + ''} />
-      )}
-      <div>
-        {(webSpeechPonyfill || {}).SpeechRecognition ? (
-          <MicrophoneButton className={MICROPHONE_BUTTON_CSS + ''} />
+function useSendBoxDictationStarted(dictateState) {
+  const [activities] = useActivities();
+
+  return [
+    (dictateState === STARTING || dictateState === DICTATING) &&
+      !activities.filter(activityIsSpeakingOrQueuedToSpeak).length
+  ];
+}
+
+const BasicSendBox = ({ className, dictateState, styleSet, webSpeechPonyfill }) => {
+  const [dictationStarted] = useSendBoxDictationStarted(dictateState);
+
+  return (
+    <div className={classNames(styleSet.sendBox + '', ROOT_CSS + '', className + '')} role="form">
+      <TypingIndicator />
+      <ConnectivityStatus />
+      <SuggestedActions />
+      <div className="main">
+        {!styleSet.options.hideUploadButton && <UploadButton />}
+        {dictationStarted ? (
+          <DictationInterims className={DICTATION_INTERIMS_CSS + ''} />
         ) : (
-          <SendButton />
+          <TextBox className={TEXT_BOX_CSS + ''} />
         )}
+        <div>
+          {(webSpeechPonyfill || {}).SpeechRecognition ? (
+            <MicrophoneButton className={MICROPHONE_BUTTON_CSS + ''} />
+          ) : (
+            <SendButton />
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 BasicSendBox.defaultProps = {
   className: '',
@@ -76,9 +90,9 @@ function activityIsSpeakingOrQueuedToSpeak({ channelData: { speak } = {} }) {
 }
 
 export default connectToWebChat(({ activities, dictateState, styleSet, webSpeechPonyfill }) => ({
-  dictationStarted:
-    (dictateState === STARTING || dictateState === DICTATING) &&
-    !activities.filter(activityIsSpeakingOrQueuedToSpeak).length,
+  dictateState,
   styleSet,
   webSpeechPonyfill
 }))(BasicSendBox);
+
+export { useSendBoxDictationStarted };

--- a/packages/component/src/BasicSendBox.js
+++ b/packages/component/src/BasicSendBox.js
@@ -72,7 +72,7 @@ BasicSendBox.defaultProps = {
 
 BasicSendBox.propTypes = {
   className: PropTypes.string,
-  dictateState: PropTypes.bool.isRequired,
+  dictateState: PropTypes.number.isRequired,
   styleSet: PropTypes.shape({
     options: PropTypes.shape({
       hideUploadButton: PropTypes.bool.isRequired

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -138,7 +138,6 @@ BasicTranscript.defaultProps = {
 };
 
 BasicTranscript.propTypes = {
-  activities: PropTypes.array.isRequired,
   activityRenderer: PropTypes.func.isRequired,
   attachmentRenderer: PropTypes.func.isRequired,
   className: PropTypes.string,
@@ -157,8 +156,7 @@ BasicTranscript.propTypes = {
 };
 
 export default connectToWebChat(
-  ({ activities, activityRenderer, attachmentRenderer, groupTimestamp, styleSet, webSpeechPonyfill }) => ({
-    activities,
+  ({ activityRenderer, attachmentRenderer, groupTimestamp, styleSet, webSpeechPonyfill }) => ({
     activityRenderer,
     attachmentRenderer,
     groupTimestamp,

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -8,6 +8,7 @@ import React from 'react';
 import connectToWebChat from './connectToWebChat';
 import ScrollToEndButton from './Activity/ScrollToEndButton';
 import SpeakActivity from './Activity/Speak';
+import useActivities from './hooks/useActivities';
 
 import {
   speechSynthesis as bypassSpeechSynthesis,
@@ -58,13 +59,13 @@ function sameTimestampGroup(activityX, activityY, groupTimestamp) {
 
 const BasicTranscript = ({
   activityRenderer,
-  activities,
   attachmentRenderer,
   className,
   groupTimestamp,
   styleSet,
   webSpeechPonyfill
 }) => {
+  const [activities] = useActivities();
   const { speechSynthesis, SpeechSynthesisUtterance } = webSpeechPonyfill || {};
 
   // We use 2-pass approach for rendering activities, for show/hide timestamp grouping.

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -3,10 +3,11 @@ import {
   FunctionContext as ScrollToBottomFunctionContext
 } from 'react-scroll-to-bottom';
 
-import { connect, Provider } from 'react-redux';
+import { Provider } from 'react-redux';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo } from 'react';
+import useReferenceGrammarID from './hooks/useReferenceGrammarID';
 
 import {
   clearSuggestedActions,
@@ -35,14 +36,14 @@ import {
 } from 'botframework-webchat-core';
 
 import concatMiddleware from './Middleware/concatMiddleware';
-import Context from './Context';
 import createCoreCardActionMiddleware from './Middleware/CardAction/createCoreMiddleware';
 import createStyleSet from './Styles/createStyleSet';
 import defaultSelectVoice from './defaultSelectVoice';
 import Dictation from './Dictation';
 import mapMap from './Utils/mapMap';
 import observableToPromise from './Utils/observableToPromise';
-import WebChatReduxContext from './WebChatReduxContext';
+import WebChatReduxContext, { useDispatch } from './WebChatReduxContext';
+import WebChatUIContext from './WebChatUIContext';
 
 // List of Redux actions factory we are hoisting as Web Chat functions
 const DISPATCHERS = {
@@ -147,11 +148,9 @@ const Composer = ({
   children,
   directLine,
   disabled,
-  dispatch,
   grammars,
   groupTimestamp,
   locale,
-  referenceGrammarID,
   renderMarkdown,
   scrollToEnd,
   selectVoice,
@@ -166,6 +165,9 @@ const Composer = ({
   username,
   webSpeechPonyfillFactory
 }) => {
+  const dispatch = useDispatch();
+  const [referenceGrammarID] = useReferenceGrammarID();
+
   const patchedGrammars = useMemo(() => grammars || [], [grammars]);
   const patchedSendTypingIndicator = useMemo(() => {
     if (typeof sendTyping === 'undefined') {
@@ -248,6 +250,8 @@ const Composer = ({
   // 2. Filter out profanity
 
   // TODO: [P4] Revisit all members of context
+  //       This context should have all stuff that is not in the Redux store
+  //       That means, stuff that are not interested in other type of UIs
   const context = useMemo(
     () => ({
       ...cardActionContext,
@@ -296,47 +300,37 @@ const Composer = ({
   );
 
   return (
-    <Context.Provider value={context}>
+    <WebChatUIContext.Provider value={context}>
       {typeof children === 'function' ? children(context) : children}
       <Dictation />
-    </Context.Provider>
+    </WebChatUIContext.Provider>
   );
 };
 
-// TODO: [P1] When react-redux support useSelector with custom context, we should move to that architecture to simplify our code.
-const ConnectedComposer = connect(
-  ({ referenceGrammarID }) => ({ referenceGrammarID }),
-  null,
-  null,
-  { context: WebChatReduxContext }
-)(props => (
-  <ScrollToBottomComposer>
-    <ScrollToBottomFunctionContext.Consumer>
-      {({ scrollToEnd }) => <Composer scrollToEnd={scrollToEnd} {...props} />}
-    </ScrollToBottomFunctionContext.Consumer>
-  </ScrollToBottomComposer>
-));
-
 // We will create a Redux store if it was not passed in
-const ConnectedComposerWithStore = ({ store, ...props }) => {
+const ComposeWithStore = ({ store, ...props }) => {
   const memoizedStore = useMemo(() => store || createStore(), [store]);
 
   return (
     <Provider context={WebChatReduxContext} store={memoizedStore}>
-      <ConnectedComposer {...props} />
+      <ScrollToBottomComposer>
+        <ScrollToBottomFunctionContext.Consumer>
+          {({ scrollToEnd }) => <Composer scrollToEnd={scrollToEnd} {...props} />}
+        </ScrollToBottomFunctionContext.Consumer>
+      </ScrollToBottomComposer>
     </Provider>
   );
 };
 
-ConnectedComposerWithStore.defaultProps = {
+ComposeWithStore.defaultProps = {
   store: undefined
 };
 
-ConnectedComposerWithStore.propTypes = {
+ComposeWithStore.propTypes = {
   store: PropTypes.any
 };
 
-export default ConnectedComposerWithStore;
+export default ComposeWithStore;
 
 // TODO: [P3] We should consider moving some data from Redux store to props
 //       Although we use `connectToWebChat` to hide the details of accessor of Redux store,
@@ -353,7 +347,6 @@ Composer.defaultProps = {
   grammars: [],
   groupTimestamp: true,
   locale: window.navigator.language || 'en-US',
-  referenceGrammarID: '',
   renderMarkdown: text => text,
   selectVoice: undefined,
   sendBoxRef: undefined,
@@ -388,11 +381,9 @@ Composer.propTypes = {
     token: PropTypes.string
   }).isRequired,
   disabled: PropTypes.bool,
-  dispatch: PropTypes.func.isRequired,
   grammars: PropTypes.arrayOf(PropTypes.string),
   groupTimestamp: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   locale: PropTypes.string,
-  referenceGrammarID: PropTypes.string,
   renderMarkdown: PropTypes.func,
   scrollToEnd: PropTypes.func.isRequired,
   selectVoice: PropTypes.func,

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -1,9 +1,11 @@
 import { Composer as DictateComposer } from 'react-dictate-button';
 import { Constants } from 'botframework-webchat-core';
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import connectToWebChat from './connectToWebChat';
+
+import useActivities from './hooks/useActivities';
 
 const {
   DictateState: { DICTATING, IDLE, STARTING }
@@ -14,7 +16,6 @@ const Dictation = ({
   disabled,
   emitTypingIndicator,
   language,
-  numSpeakingActivities,
   onError,
   sendTypingIndicator,
   setDictateInterims,
@@ -25,6 +26,12 @@ const Dictation = ({
   submitSendBox,
   webSpeechPonyfill: { SpeechGrammarList, SpeechRecognition } = {}
 }) => {
+  const [activities] = useActivities();
+
+  const numSpeakingActivities = useMemo(() => activities.filter(({ channelData: { speak } = {} }) => speak).length, [
+    activities
+  ]);
+
   const handleDictate = useCallback(
     ({ result: { transcript } = {} }) => {
       if (dictateState === DICTATING || dictateState === STARTING) {
@@ -86,7 +93,6 @@ Dictation.propTypes = {
   disabled: PropTypes.bool,
   emitTypingIndicator: PropTypes.func.isRequired,
   language: PropTypes.string.isRequired,
-  numSpeakingActivities: PropTypes.number.isRequired,
   onError: PropTypes.func,
   sendTypingIndicator: PropTypes.bool.isRequired,
   setDictateInterims: PropTypes.func.isRequired,
@@ -103,7 +109,6 @@ Dictation.propTypes = {
 
 export default connectToWebChat(
   ({
-    activities,
     dictateState,
     disabled,
     emitTypingIndicator,
@@ -122,7 +127,6 @@ export default connectToWebChat(
     disabled,
     emitTypingIndicator,
     language,
-    numSpeakingActivities: activities.filter(({ channelData: { speak } = {} }) => speak).length,
     postActivity,
     sendTypingIndicator,
     setDictateInterims,

--- a/packages/component/src/ScreenReaderText.js
+++ b/packages/component/src/ScreenReaderText.js
@@ -3,8 +3,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import connectToWebChat from './connectToWebChat';
-
 const ROOT_CSS = css({
   // .sr-only - This component is intended to be invisible to the visual Web Chat user, but read by the AT when using a screen reader
   color: 'transparent',
@@ -18,7 +16,7 @@ const ROOT_CSS = css({
 });
 
 const ScreenReaderText = ({ text }) => (
-  /* Because of differences in browser implementations, <span aria-label> is used to make the screen reader perform the same on different browsers. This workaround was made to accommodate Edge v44 */
+  // Because of differences in browser implementations, <span aria-label> is used to make the screen reader perform the same on different browsers. This workaround was made to accommodate Edge v44
   <span aria-label={text} className={classNames(ROOT_CSS + '')}>
     {text}
   </span>
@@ -28,4 +26,4 @@ ScreenReaderText.propTypes = {
   text: PropTypes.string.isRequired
 };
 
-export default connectToWebChat()(ScreenReaderText);
+export default ScreenReaderText;

--- a/packages/component/src/WebChatReduxContext.js
+++ b/packages/component/src/WebChatReduxContext.js
@@ -1,3 +1,13 @@
 import { createContext } from 'react';
+import { createDispatchHook, createSelectorHook } from 'react-redux';
 
-export default createContext();
+const context = createContext();
+
+const useDispatch = createDispatchHook(context);
+const useSelector = createSelectorHook(context);
+
+context.displayName = 'WebChatReduxContext';
+
+export default context;
+
+export { useDispatch, useSelector };

--- a/packages/component/src/WebChatUIContext.js
+++ b/packages/component/src/WebChatUIContext.js
@@ -4,6 +4,6 @@ const context = React.createContext({
   sendFocusRef: null
 });
 
-context.displayName = 'TypeFocusSinkContext';
+context.displayName = 'WebChatUIContext';
 
 export default context;

--- a/packages/component/src/connectToWebChat.js
+++ b/packages/component/src/connectToWebChat.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 import React from 'react';
 
-import Context from './Context';
 import WebChatReduxContext from './WebChatReduxContext';
+import WebChatUIContext from './WebChatUIContext';
 
 function removeUndefinedValues(map) {
   return Object.keys(map).reduce((result, key) => {
@@ -43,7 +43,9 @@ export default function connectToWebChat(...selectors) {
     )(Component);
 
     const WebChatConnectedComponent = props => (
-      <Context.Consumer>{context => <ConnectedComponent {...props} context={context} />}</Context.Consumer>
+      <WebChatUIContext.Consumer>
+        {context => <ConnectedComponent {...props} context={context} />}
+      </WebChatUIContext.Consumer>
     );
 
     return WebChatConnectedComponent;

--- a/packages/component/src/hooks/index.js
+++ b/packages/component/src/hooks/index.js
@@ -1,0 +1,6 @@
+import useActivities from './useActivities';
+import useReferenceGrammarID from './useReferenceGrammarID';
+
+import { useSendBoxDictationStarted } from '../BasicSendBox';
+
+export { useActivities, useReferenceGrammarID, useSendBoxDictationStarted };

--- a/packages/component/src/hooks/useActivities.js
+++ b/packages/component/src/hooks/useActivities.js
@@ -1,0 +1,5 @@
+import { useSelector } from '../WebChatReduxContext';
+
+export default function useActivities() {
+  return [useSelector(({ activities }) => activities)];
+}

--- a/packages/component/src/hooks/useReferenceGrammarID.js
+++ b/packages/component/src/hooks/useReferenceGrammarID.js
@@ -1,0 +1,5 @@
+import { useSelector } from '../WebChatReduxContext';
+
+export default function useReferenceGrammarID() {
+  return [useSelector(({ referenceGrammarID }) => referenceGrammarID)];
+}

--- a/packages/component/src/index.tsx
+++ b/packages/component/src/index.tsx
@@ -29,12 +29,14 @@ import UploadButton, { connectUploadButton } from './SendBox/UploadButton';
 
 import concatMiddleware from './Middleware/concatMiddleware';
 import connectToWebChat from './connectToWebChat';
-import Context from './Context';
+import Context from './WebChatUIContext';
 import createCoreActivityMiddleware from './Middleware/Activity/createCoreMiddleware';
 import createCoreAttachmentMiddleware from './Middleware/Attachment/createCoreMiddleware';
 import createStyleSet from './Styles/createStyleSet';
 import defaultStyleOptions from './Styles/defaultStyleOptions';
 import getTabIndex from './Utils/TypeFocusSink/getTabIndex';
+
+import * as hooks from './hooks/index';
 
 const version = process.env.npm_package_version;
 
@@ -93,6 +95,7 @@ export {
   createStyleSet,
   defaultStyleOptions,
   getTabIndex,
+  hooks,
   localize,
   version
 };

--- a/samples/21.customization-plain-ui/src/PlainWebChat.js
+++ b/samples/21.customization-plain-ui/src/PlainWebChat.js
@@ -1,13 +1,28 @@
-import { connectToWebChat } from 'botframework-webchat-component';
-import React, { useState } from 'react';
+import { connectToWebChat, hooks } from 'botframework-webchat-component';
+import React, { useCallback, useState } from 'react';
 
 import Attachment from './Attachment';
 import SuggestedActions from './SuggestedActions';
 
 import getValueOrUndefined from './util/getValueOrUndefined';
 
-const PlainWebChat = ({ activities, sendMessage }) => {
+const { useActivities } = hooks;
+
+const PlainWebChat = ({ sendMessage }) => {
+  const [activities] = useActivities();
   const [sendBoxValue, setSendBoxValue] = useState('');
+
+  const handleChange = useCallback(({ target: { value } }) => setSendBoxValue(value), [setSendBoxValue]);
+
+  const handleSubmit = useCallback(
+    event => {
+      event.preventDefault();
+
+      sendMessage(sendBoxValue);
+      setSendBoxValue('');
+    },
+    [sendMessage, setSendBoxValue]
+  );
 
   return (
     <div>
@@ -56,20 +71,8 @@ const PlainWebChat = ({ activities, sendMessage }) => {
       <div>
         {/* This is the send box, and suggested actions change based on the send box, not activity */}
         <SuggestedActions />
-        <form
-          onSubmit={event => {
-            event.preventDefault();
-
-            sendMessage(sendBoxValue);
-            setSendBoxValue('');
-          }}
-        >
-          <input
-            autoFocus={true}
-            onChange={({ target: { value } }) => setSendBoxValue(value)}
-            type="textbox"
-            value={sendBoxValue}
-          />
+        <form onSubmit={handleSubmit}>
+          <input autoFocus={true} onChange={handleChange} type="textbox" value={sendBoxValue} />
         </form>
       </div>
     </div>


### PR DESCRIPTION
> Related to #2539.

## Changelog Entry

-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim) and [@corinagum](https://github.com/corinagum), in the following PRs:
   -  PR [#2540](https://github.com/microsoft/BotFramework-WebChat/pull/2540): `useActivities`, `useReferenceGrammarID`, `useSendBoxDictationStarted`

## Description

Add `useActivities`, `useReferenceGrammarID` and `useSendBoxDictationStarted`.

## Specific Changes

- Test harness
   - Added `runHook` function
- Exporting `hooks`
- Added the following hooks:
   - `useActivities`
   - `useReferenceGrammarID`
   - `useSendBoxDictationStarted`
- Updated components to use forementioned hooks
- Renamed `Context` to `WebChatUIContext`
- Removed unnecessary HOC for `<ScreenReaderText>`
- Updated `WebChatReduxContext` to export custom Redux hooks (this is not publicly exporting)
- Updated sample 21 to use aforementioned hooks
---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
