### PR TITLE
Add React Hooks for customization (part 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  PR [#2544](https://github.com/microsoft/BotFramework-WebChat/pull/2544): `useAvatarForBot`, `useAvatarForUser`
    -  PR [#2547](https://github.com/microsoft/BotFramework-WebChat/pull/2547): `useEmitTypingIndicator`, `usePeformCardAction`, `usePostActivity`, `useSendEvent`, `useSendFiles`, `useSendMessage`, `useSendMessageBack`, `useSendPostBack`
    -  PR [#2548](https://github.com/microsoft/BotFramework-WebChat/pull/2548): `useDisabled`
+   -  PR [#2551](https://github.com/microsoft/BotFramework-WebChat/pull/2551): `useLastTypingAt`, `useSendTypingIndicator`, `useTypingIndicator`
    -  PR [#2552](https://github.com/microsoft/BotFramework-WebChat/pull/2552): `useFocusSendBox`, `useScrollToEnd`, `useSendBoxValue`, `useSubmitSendBox`, `useTextBoxSubmit`, `useTextBoxValue`
 -  Fixes [#2597](https://github.com/microsoft/BotFramework-WebChat/issues/2597). Modify `watch` script to `start` and add `tableflip` script for throwing `node_modules`, by [@corinagum](https://github.com/corinagum) in PR [#2598](https://github.com/microsoft/BotFramework-WebChat/pull/2598)
 

--- a/__tests__/hooks/useLastTypingAt.js
+++ b/__tests__/hooks/useLastTypingAt.js
@@ -1,0 +1,30 @@
+import { timeouts } from '../constants.json';
+
+import minNumActivitiesShown from '../setup/conditions/minNumActivitiesShown';
+import uiConnected from '../setup/conditions/uiConnected';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+test('getter should get last typing at', async () => {
+  const { driver, pageObjects } = await setupWebDriver();
+
+  await driver.wait(uiConnected(), timeouts.directLine);
+  await pageObjects.sendMessageViaSendBox('typing 1', { waitForSend: true });
+
+  await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+  const now = Date.now();
+  const [lastTypingAt] = await pageObjects.runHook('useLastTypingAt');
+
+  expect(Math.abs(lastTypingAt.bot - now)).toBeLessThanOrEqual(timeouts.directLine);
+});
+
+test('setter should be falsy', async () => {
+  const { pageObjects } = await setupWebDriver();
+  const [_, setLastTypingAt] = await pageObjects.runHook('useLastTypingAt');
+
+  expect(setLastTypingAt).toBeFalsy();
+});

--- a/__tests__/hooks/useSendTypingIndicator.js
+++ b/__tests__/hooks/useSendTypingIndicator.js
@@ -1,0 +1,25 @@
+import { timeouts } from '../constants.json';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+test('getter should get sendTypingIndicator from props', async () => {
+  const { pageObjects } = await setupWebDriver({ props: { sendTypingIndicator: true } });
+
+  await expect(pageObjects.runHook('useSendTypingIndicator', [], result => result[0])).resolves.toBeTruthy();
+});
+
+test('getter should get default value if not set in props', async () => {
+  const { pageObjects } = await setupWebDriver();
+
+  await expect(pageObjects.runHook('useSendTypingIndicator', [], result => result[0])).resolves.toBeFalsy();
+});
+
+test('setter should be falsy', async () => {
+  const { pageObjects } = await setupWebDriver();
+  const [_, setSendTypingIndicator] = await pageObjects.runHook('useSendTypingIndicator');
+
+  expect(setSendTypingIndicator).toBeFalsy();
+});

--- a/__tests__/hooks/useTypingIndicatorVisible.js
+++ b/__tests__/hooks/useTypingIndicatorVisible.js
@@ -1,0 +1,37 @@
+import { timeouts } from '../constants.json';
+
+import minNumActivitiesShown from '../setup/conditions/minNumActivitiesShown';
+import uiConnected from '../setup/conditions/uiConnected';
+
+// selenium-webdriver API doc:
+// https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+
+jest.setTimeout(timeouts.test);
+
+test('getter should return true when typing indicator is shown', async () => {
+  const { driver, pageObjects } = await setupWebDriver();
+
+  await driver.wait(uiConnected(), timeouts.directLine);
+  await pageObjects.sendMessageViaSendBox('typing 1', { waitForSend: true });
+
+  await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
+
+  const [typingIndicatorVisible] = await pageObjects.runHook('useTypingIndicatorVisible');
+
+  expect(typingIndicatorVisible).toBeTruthy();
+});
+
+test('getter should return false when typing indicator is not shown', async () => {
+  const { pageObjects } = await setupWebDriver();
+
+  const [typingIndicatorVisible] = await pageObjects.runHook('useTypingIndicatorVisible');
+
+  expect(typingIndicatorVisible).toBeFalsy();
+});
+
+test('setter should be falsy', async () => {
+  const { pageObjects } = await setupWebDriver();
+  const [_, setTypingIndicatorVisible] = await pageObjects.runHook('useTypingIndicatorVisible');
+
+  expect(setTypingIndicatorVisible).toBeFalsy();
+});

--- a/packages/component/src/Dictation.js
+++ b/packages/component/src/Dictation.js
@@ -9,6 +9,7 @@ import useActivities from './hooks/useActivities';
 import useDisabled from './hooks/useDisabled';
 import useLanguage from './hooks/useLanguage';
 import useSendBoxValue from './hooks/useSendBoxValue';
+import useSendTypingIndicator from './hooks/useSendTypingIndicator';
 import useSubmitSendBox from './hooks/useSubmitSendBox';
 
 const {
@@ -19,7 +20,6 @@ const Dictation = ({
   dictateState,
   emitTypingIndicator,
   onError,
-  sendTypingIndicator,
   setDictateInterims,
   setDictateState,
   startSpeakingActivity,
@@ -30,6 +30,7 @@ const Dictation = ({
   const [activities] = useActivities();
   const [disabled] = useDisabled();
   const [language] = useLanguage();
+  const [sendTypingIndicator] = useSendTypingIndicator();
   const submitSendBox = useSubmitSendBox();
 
   const numSpeakingActivities = useMemo(() => activities.filter(({ channelData: { speak } = {} }) => speak).length, [
@@ -95,7 +96,6 @@ Dictation.propTypes = {
   dictateState: PropTypes.number.isRequired,
   emitTypingIndicator: PropTypes.func.isRequired,
   onError: PropTypes.func,
-  sendTypingIndicator: PropTypes.bool.isRequired,
   setDictateInterims: PropTypes.func.isRequired,
   setDictateState: PropTypes.func.isRequired,
   startSpeakingActivity: PropTypes.func.isRequired,
@@ -111,7 +111,6 @@ export default connectToWebChat(
     dictateState,
     emitTypingIndicator,
     postActivity,
-    sendTypingIndicator,
     setDictateInterims,
     setDictateState,
     startSpeakingActivity,
@@ -121,7 +120,6 @@ export default connectToWebChat(
     dictateState,
     emitTypingIndicator,
     postActivity,
-    sendTypingIndicator,
     setDictateInterims,
     setDictateState,
     startSpeakingActivity,

--- a/packages/component/src/SendBox/TypingIndicator.js
+++ b/packages/component/src/SendBox/TypingIndicator.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import TypingAnimation from './Assets/TypingAnimation';

--- a/packages/component/src/SendBox/TypingIndicator.js
+++ b/packages/component/src/SendBox/TypingIndicator.js
@@ -1,45 +1,53 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import connectToWebChat from '../connectToWebChat';
 import TypingAnimation from './Assets/TypingAnimation';
+import useLastTypingAt from '../hooks/useLastTypingAt';
 import useLocalize from '../hooks/useLocalize';
 import useStyleOptions from '../hooks/useStyleOptions';
 import useStyleSet from '../hooks/useStyleSet';
 
-const TypingIndicator = ({ lastTypingAt }) => {
-  const [{ typingAnimationDuration }] = useStyleOptions();
-  const [{ typingIndicator }] = useStyleSet();
-  const animationAriaLabel = useLocalize('TypingIndicator');
+function useTypingIndicatorVisible() {
+  const [lastTypingAt] = useLastTypingAt();
 
-  const [showTyping, setShowTyping] = useState(false);
+  const [{ typingAnimationDuration }] = useStyleOptions();
+
+  const last = Math.max(Object.values(lastTypingAt));
+  const typingAnimationTimeRemaining = last ? Math.max(0, typingAnimationDuration - Date.now() + last) : 0;
+
+  const [value, setValue] = useState(typingAnimationTimeRemaining > 0);
 
   useEffect(() => {
     let timeout;
-    const last = Math.max(Object.values(lastTypingAt));
-    const typingAnimationTimeRemaining = typingAnimationDuration - Date.now() + last;
 
-    if (last && typingAnimationTimeRemaining > 0) {
-      setShowTyping(true);
-      timeout = setTimeout(() => setShowTyping(false), typingAnimationTimeRemaining);
+    if (typingAnimationTimeRemaining > 0) {
+      setValue(true);
+      timeout = setTimeout(() => setValue(false), typingAnimationTimeRemaining);
     } else {
-      setShowTyping(false);
+      setValue(false);
     }
 
     return () => clearTimeout(timeout);
-  }, [lastTypingAt, typingAnimationDuration]);
+  }, [typingAnimationTimeRemaining]);
+
+  return [value];
+}
+
+const TypingIndicator = () => {
+  const [{ typingIndicator: typingIndicatorStyleSet }] = useStyleSet();
+  const [showTyping] = useTypingIndicatorVisible();
+
+  const animationAriaLabel = useLocalize('TypingIndicator');
 
   return (
     showTyping && (
-      <div className={typingIndicator}>
+      <div className={typingIndicatorStyleSet}>
         <TypingAnimation aria-label={animationAriaLabel} />
       </div>
     )
   );
 };
 
-TypingIndicator.propTypes = {
-  lastTypingAt: PropTypes.any.isRequired
-};
+export default TypingIndicator;
 
-export default connectToWebChat(({ lastTypingAt }) => ({ lastTypingAt }))(TypingIndicator);
+export { useTypingIndicatorVisible };

--- a/packages/component/src/hooks/index.js
+++ b/packages/component/src/hooks/index.js
@@ -5,6 +5,7 @@ import useDisabled from './useDisabled';
 import useEmitTypingIndicator from './useEmitTypingIndicator';
 import useFocusSendBox from './useFocusSendBox';
 import useLanguage from './useLanguage';
+import useLastTypingAt from './useLastTypingAt';
 import useLocalize from './useLocalize';
 import useLocalizeDate from './useLocalizeDate';
 import usePerformCardAction from './usePerformCardAction';
@@ -18,12 +19,14 @@ import useSendFiles from './useSendFiles';
 import useSendMessage from './useSendMessage';
 import useSendMessageBack from './useSendMessageBack';
 import useSendPostBack from './useSendPostBack';
+import useSendTypingIndicator from './useSendTypingIndicator';
 import useStyleOptions from './useStyleOptions';
 import useStyleSet from './useStyleSet';
 import useSubmitSendBox from './useSubmitSendBox';
 
 import { useSendBoxDictationStarted } from '../BasicSendBox';
 import { useTextBoxSubmit } from '../SendBox/TextBox';
+import { useTypingIndicatorVisible } from '../SendBox/TypingIndicator';
 
 export {
   useActivities,
@@ -33,6 +36,7 @@ export {
   useEmitTypingIndicator,
   useFocusSendBox,
   useLanguage,
+  useLastTypingAt,
   useLocalize,
   useLocalizeDate,
   usePerformCardAction,
@@ -47,8 +51,10 @@ export {
   useSendMessage,
   useSendMessageBack,
   useSendPostBack,
+  useSendTypingIndicator,
   useStyleOptions,
   useStyleSet,
   useSubmitSendBox,
-  useTextBoxSubmit
+  useTextBoxSubmit,
+  useTypingIndicatorVisible
 };

--- a/packages/component/src/hooks/useLastTypingAt.js
+++ b/packages/component/src/hooks/useLastTypingAt.js
@@ -1,0 +1,5 @@
+import { useSelector } from '../WebChatReduxContext';
+
+export default function useLastTypingAt() {
+  return [useSelector(({ lastTypingAt }) => lastTypingAt)];
+}

--- a/packages/component/src/hooks/useSendTypingIndicator.js
+++ b/packages/component/src/hooks/useSendTypingIndicator.js
@@ -1,0 +1,5 @@
+import { useSelector } from '../WebChatReduxContext';
+
+export default function useSendTypingIndicator() {
+  return [useSelector(({ sendTypingIndicator }) => sendTypingIndicator)];
+}


### PR DESCRIPTION
> Related to #2539.

Please merge #2540, #2541, #2542, #2543, #2544, #2547, #2548, #2549, #2550 before reviewing this one.

## Changelog Entry

-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim), in the following PRs:
   -  PR [#2540](https://github.com/microsoft/BotFramework-WebChat/pull/2540): `useActivities`, `useReferenceGrammarID`, `useSendBoxDictationStarted`
   -  PR [#2541](https://github.com/microsoft/BotFramework-WebChat/pull/2541): `useStyleOptions`, `useStyleSet`
   -  PR [#2542](https://github.com/microsoft/BotFramework-WebChat/pull/2542): `useLanguage`, `useLocalize`, `useLocalizeDate`
   -  PR [#2543](https://github.com/microsoft/BotFramework-WebChat/pull/2543): `useAdaptiveCardsHostConfig`, `useAdaptiveCardsPackage`, `useRenderMarkdownAsHTML`
   -  PR [#2544](https://github.com/microsoft/BotFramework-WebChat/pull/2544): `useAvatarForBot`, `useAvatarForUser`
   -  PR [#2547](https://github.com/microsoft/BotFramework-WebChat/pull/2547): `useEmitTypingIndicator`, `usePeformCardAction`, `usePostActivity`, `useSendEvent`, `useSendFiles`, `useSendMessage`, `useSendMessageBack`, `useSendPostBack`
   -  PR [#2548](https://github.com/microsoft/BotFramework-WebChat/pull/2548): `useDisabled`
   -  PR [#2549](https://github.com/microsoft/BotFramework-WebChat/pull/2549): `useSuggestedActions`
   -  PR [#2550](https://github.com/microsoft/BotFramework-WebChat/pull/2550): `useConnectivityStatus`, `useGroupTimestamp`, `useTimeoutForSend`, `useUserID`, `useUsername`
   -  PR [#2551](https://github.com/microsoft/BotFramework-WebChat/pull/2551): `useLastTypingAt`, `useSendTypingIndicator`, `useTypingIndicator`

## Description

Add several post message related hooks:

- `useLastTypingAt`
- `useSendTypingIndicator`
- `useTypingIndicator`

## Specific Changes

- Added the following hooks:
   - `useLastTypingAt`
   - `useSendTypingIndicator`
   - `useTypingIndicator`
- Updated components to use aforementioned hooks

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
