### PR TITLE
#2512 De-bump remark and strip-markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -  Fixes [#2565](https://github.com/microsoft/BotFramework-WebChat/issues/2565). Fixed Adaptive Card host config should generate from style options with default options merged, by [@compulim](https://github.com/compulim) in PR [#2566](https://github.com/microsoft/BotFramework-WebChat/pull/2566)
+-  Fixes [#2512](https://github.com/microsoft/BotFramework-WebChat/issues/2512). De-bump remark and strip-markdown, by [@corinagum](https://github.com/corinagum) in PR [#2576](https://github.com/microsoft/BotFramework-WebChat/pull/2576)
 
 ### Added
 
@@ -36,78 +37,78 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped all dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2533](https://github.com/microsoft/BotFramework-WebChat/pull/2533)
-   - Development dependencies
-      - Root package
-         - `@azure/storage-blob@12.0.0`
-         - `@babel/plugin-proposal-class-properties@7.5.5`
-         - `@babel/plugin-proposal-object-rest-spread@7.6.2`
-         - `@babel/plugin-transform-runtime@7.6.2`
-         - `@babel/preset-env@7.6.3`
-         - `@babel/preset-react@7.6.3`
-         - `@babel/preset-typescript@7.6.0`
-         - `@babel/runtime@7.6.3`
-         - `babel-jest@24.9.0`
-         - `core-js@3.3.6`
-         - `coveralls@3.0.7`
-         - `husky@3.0.9`
-         - `jest-image-snapshot@2.11.0`
-         - `jest@24.9.0`
-         - `lerna@3.18.3`
-         - `lint-staged@9.4.2`
-         - `selenium-webdriver@4.0.0-alpha.5`
-         - `serve-handler@6.1.2`
-      - Other packages
-         - `@babel/cli@7.6.4`
-         - `@babel/core@7.6.4`
-         - `@babel/plugin-proposal-class-properties@7.5.5`
-         - `@babel/plugin-proposal-object-rest-spread@7.6.2`
-         - `@babel/plugin-transform-runtime@7.6.2`
-         - `@babel/preset-env@7.6.3`
-         - `@babel/preset-react@7.6.3`
-         - `@babel/preset-typescript@7.6.0`
-         - `@types/node@12.12.3`
-         - `@types/react@16.9.11`
-         - `@typescript-eslint/eslint-plugin@2.6.0`
-         - `@typescript-eslint/parser@2.6.0`
-         - `babel-plugin-istanbul@5.2.0`
-         - `concurrently@5.0.0`
-         - `copy-webpack-plugin@5.0.4`
-         - `eslint-plugin-prettier@3.1.1`
-         - `eslint-plugin-react-hooks@2.2.0`
-         - `eslint-plugin-react@7.16.0`
-         - `eslint@6.6.0`
-         - `http-proxy-middleware@0.20.0`
-         - `jest@24.9.0`
-         - `terser-webpack-plugin@2.2.1`
-         - `typescript@3.6.4`
-         - `webpack-cli@3.3.10`
-         - `webpack@4.41.2`
-   - Production dependencies
-      - `core`
-         - `@babel/runtime@7.6.3`
-         - `jsonwebtoken@8.5.1`
-         - `math-random`
-         - `redux-saga@1.1.1`
-         - `simple-update-in@2.1.1`
-      - `bundle`
-         - `@babel/runtime@7.6.3`
-         - `core-js@3.3.6`
-         - `markdown-it@10.0.0`
-         - `memoize-one@5.1.1`
-         - `sanitize-html@1.19.0`
-         - `url-search-params-polyfill@7.0.0`
-      - `component`
-         - `bytes@3.1.0`
-         - `memoize-one@5.1.1`
-         - `react-redux@7.1.1`
-         - `remark@11.0.1`
-         - `sanitize-html@1.20.1`
-         - `simple-update-in@2.1.1`
-         - `strip-markdown@3.1.1`
-      - `embed`
-         - `@babel/runtime@7.6.3`
-         - `core-js@3.3.6`
+-  Bumped all dependencies to latest version, by [@compulim](https://github.com/compulim), in PR [#2533](https://github.com/microsoft/BotFramework-WebChat/pull/2533)
+   -  Development dependencies
+      -  Root package
+         -  `@azure/storage-blob@12.0.0`
+         -  `@babel/plugin-proposal-class-properties@7.5.5`
+         -  `@babel/plugin-proposal-object-rest-spread@7.6.2`
+         -  `@babel/plugin-transform-runtime@7.6.2`
+         -  `@babel/preset-env@7.6.3`
+         -  `@babel/preset-react@7.6.3`
+         -  `@babel/preset-typescript@7.6.0`
+         -  `@babel/runtime@7.6.3`
+         -  `babel-jest@24.9.0`
+         -  `core-js@3.3.6`
+         -  `coveralls@3.0.7`
+         -  `husky@3.0.9`
+         -  `jest-image-snapshot@2.11.0`
+         -  `jest@24.9.0`
+         -  `lerna@3.18.3`
+         -  `lint-staged@9.4.2`
+         -  `selenium-webdriver@4.0.0-alpha.5`
+         -  `serve-handler@6.1.2`
+      -  Other packages
+         -  `@babel/cli@7.6.4`
+         -  `@babel/core@7.6.4`
+         -  `@babel/plugin-proposal-class-properties@7.5.5`
+         -  `@babel/plugin-proposal-object-rest-spread@7.6.2`
+         -  `@babel/plugin-transform-runtime@7.6.2`
+         -  `@babel/preset-env@7.6.3`
+         -  `@babel/preset-react@7.6.3`
+         -  `@babel/preset-typescript@7.6.0`
+         -  `@types/node@12.12.3`
+         -  `@types/react@16.9.11`
+         -  `@typescript-eslint/eslint-plugin@2.6.0`
+         -  `@typescript-eslint/parser@2.6.0`
+         -  `babel-plugin-istanbul@5.2.0`
+         -  `concurrently@5.0.0`
+         -  `copy-webpack-plugin@5.0.4`
+         -  `eslint-plugin-prettier@3.1.1`
+         -  `eslint-plugin-react-hooks@2.2.0`
+         -  `eslint-plugin-react@7.16.0`
+         -  `eslint@6.6.0`
+         -  `http-proxy-middleware@0.20.0`
+         -  `jest@24.9.0`
+         -  `terser-webpack-plugin@2.2.1`
+         -  `typescript@3.6.4`
+         -  `webpack-cli@3.3.10`
+         -  `webpack@4.41.2`
+   -  Production dependencies
+      -  `core`
+         -  `@babel/runtime@7.6.3`
+         -  `jsonwebtoken@8.5.1`
+         -  `math-random`
+         -  `redux-saga@1.1.1`
+         -  `simple-update-in@2.1.1`
+      -  `bundle`
+         -  `@babel/runtime@7.6.3`
+         -  `core-js@3.3.6`
+         -  `markdown-it@10.0.0`
+         -  `memoize-one@5.1.1`
+         -  `sanitize-html@1.19.0`
+         -  `url-search-params-polyfill@7.0.0`
+      -  `component`
+         -  `bytes@3.1.0`
+         -  `memoize-one@5.1.1`
+         -  `react-redux@7.1.1`
+         -  `remark@11.0.1`
+         -  `sanitize-html@1.20.1`
+         -  `simple-update-in@2.1.1`
+         -  `strip-markdown@3.1.1`
+      -  `embed`
+         -  `@babel/runtime@7.6.3`
+         -  `core-js@3.3.6`
 -  `component`: Bumps [`adaptivecards@1.2.3`](https://npmjs.com/package/adaptivecards), by [@corinagum](https://github.com/corinagum) in PR [#2523](https://github.com/microsoft/BotFramework-WebChat/pull/2532)
 -  Bumps Chrome in Docker to 78.0.3904.70, by [@spyip](https://github.com/spyip) in PR [#2545](https://github.com/microsoft/BotFramework-WebChat/pull/2545)
 

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -948,8 +948,7 @@
 		"@types/node": {
 			"version": "12.12.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
-			"integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
-			"dev": true
+			"integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
@@ -971,6 +970,24 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
+			"integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
+			"requires": {
+				"vfile-message": "*"
+			}
 		},
 		"acorn": {
 			"version": "7.1.0",
@@ -3430,8 +3447,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -4627,19 +4643,19 @@
 			}
 		},
 		"remark": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-11.0.1.tgz",
-			"integrity": "sha512-Fl2AvN+yU6sOBAjUz3xNC5iEvLkXV8PZicLOOLifjU8uKGusNvhHfGRCfETsqyvRHZ24JXqEyDY4hRLhoUd30A==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+			"integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
 			"requires": {
-				"remark-parse": "^7.0.0",
-				"remark-stringify": "^7.0.0",
-				"unified": "^8.2.0"
+				"remark-parse": "^6.0.0",
+				"remark-stringify": "^6.0.0",
+				"unified": "^7.0.0"
 			}
 		},
 		"remark-parse": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
-			"integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
 			"requires": {
 				"collapse-white-space": "^1.0.2",
 				"is-alphabetical": "^1.0.0",
@@ -4659,9 +4675,9 @@
 			}
 		},
 		"remark-stringify": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-7.0.3.tgz",
-			"integrity": "sha512-+jgmjNjm2kR7y2Ns1BATXRlFr+iQ7sDcpSgytfU77nkw7UCd5yJNArSxB3MU3Uul7HuyYNTCjetoGfy8xLia1A==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+			"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
 			"requires": {
 				"ccount": "^1.0.0",
 				"is-alphanumeric": "^1.0.0",
@@ -4674,7 +4690,7 @@
 				"parse-entities": "^1.0.2",
 				"repeat-string": "^1.5.4",
 				"state-toggle": "^1.0.0",
-				"stringify-entities": "^2.0.0",
+				"stringify-entities": "^1.0.1",
 				"unherit": "^1.0.4",
 				"xtend": "^4.0.1"
 			}
@@ -5207,14 +5223,13 @@
 			}
 		},
 		"stringify-entities": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
-			"integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
 			"requires": {
 				"character-entities-html4": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
 				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.2",
 				"is-hexadecimal": "^1.0.0"
 			}
 		},
@@ -5246,9 +5261,9 @@
 			"dev": true
 		},
 		"strip-markdown": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-3.1.1.tgz",
-			"integrity": "sha512-Q83C2WWWxASuJm7XuSqS9PGYQb8yTSxPtxE6bjCj/8kwuk4IY5qi9aEQkfyeqky0E5uCQpl1pDgOvQRh90FyMg=="
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-3.0.4.tgz",
+			"integrity": "sha512-O+0DAu96wofH82JPZN4RkGdi3Lruo0yveDCeXUg0uRNWztPcn/s1AD85584OYUsAcjW0qR4pBlh8OBl/hH4Erw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -5491,22 +5506,18 @@
 			"dev": true
 		},
 		"unified": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
-			"integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
 			"requires": {
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
-				"is-plain-obj": "^2.0.0",
+				"is-plain-obj": "^1.1.0",
 				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"dependencies": {
-				"is-plain-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-					"integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
-				}
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
 			}
 		},
 		"union-value": {
@@ -5655,15 +5666,29 @@
 			}
 		},
 		"vfile": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
-			"integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
 			"requires": {
-				"@types/unist": "^2.0.0",
 				"is-buffer": "^2.0.0",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			},
+			"dependencies": {
+				"unist-util-stringify-position": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+					"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+				},
+				"vfile-message": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+					"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+					"requires": {
+						"unist-util-stringify-position": "^1.1.1"
+					}
+				}
 			}
 		},
 		"vfile-location": {
@@ -5767,6 +5792,11 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -58,10 +58,10 @@
     "react-say": "^1.2.0",
     "react-scroll-to-bottom": "~1.3.2",
     "redux": "^4.0.4",
-    "remark": "^11.0.1",
+    "remark": "10.0.1",
     "sanitize-html": "^1.20.1",
     "simple-update-in": "^2.1.1",
-    "strip-markdown": "^3.1.1"
+    "strip-markdown": "3.0.4"
   },
   "peerDependencies": {
     "react": "^16.8.6",


### PR DESCRIPTION
Fixes #2512
## Changelog Entry
-  Fixes [#2512](https://github.com/microsoft/BotFramework-WebChat/issues/2512). De-bump remark and strip-markdown, by [@corinagum](https://github.com/corinagum) in PR [#2576](https://github.com/microsoft/BotFramework-WebChat/pull/2576)

## Description

A previous bump of `remark` caused Internet Explorer to report render errors due to non-transpiled es6 code in a subdependency, `'is-plain-obj'`
## Specific Changes
Simple de-bump of dependencies
---

-  [ ] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
