### PR TITLE
Replace webpack-visualizer-plugin with webpack-stats-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- `bundle`: Webpack will now use `webpack-stats-plugin` instead of `webpack-visualizer`
+- `bundle`: Webpack will now use `webpack-stats-plugin` instead of `webpack-visualizer-plugin`, by [@compulim](https://github.com/compulim) in PR [#2584](https://github.com/microsoft/BotFramework-WebChat/pull/2584)
    - This will fix [#2583](https://github.com/microsoft/BotFramework-WebChat/issues/2583) by not bringing in transient dependency of React
    - To view the bundle stats, browse to https://chrisbateman.github.io/webpack-visualizer/ and drop the file `/packages/bundle/dist/stats.json`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `bundle`: Webpack will now use `webpack-stats-plugin` instead of `webpack-visualizer`
+   - This will fix [#2583](https://github.com/microsoft/BotFramework-WebChat/issues/2583) by not bringing in transient dependency of React
+   - To view the bundle stats, browse to https://chrisbateman.github.io/webpack-visualizer/ and drop the file `/packages/bundle/dist/stats.json`
+
 ### Fixed
 
 -  Fixes [#2565](https://github.com/microsoft/BotFramework-WebChat/issues/2565). Fixed Adaptive Card host config should generate from style options with default options merged, by [@compulim](https://github.com/compulim) in PR [#2566](https://github.com/microsoft/BotFramework-WebChat/pull/2566

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1317,12 +1317,6 @@
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
-		},
 		"ansi-escapes": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
@@ -1420,12 +1414,6 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
-		},
 		"asn1.js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
@@ -1483,12 +1471,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
-		},
-		"ast-types": {
-			"version": "0.9.6",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-			"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
 			"dev": true
 		},
 		"astral-regex": {
@@ -1601,12 +1583,6 @@
 					}
 				}
 			}
-		},
-		"base62": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-			"integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
-			"dev": true
 		},
 		"base64-arraybuffer": {
 			"version": "0.2.0",
@@ -2036,38 +2012,6 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
-		"commoner": {
-			"version": "0.10.8",
-			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-			"dev": true,
-			"requires": {
-				"commander": "^2.5.0",
-				"detective": "^4.3.1",
-				"glob": "^5.0.15",
-				"graceful-fs": "^4.1.2",
-				"iconv-lite": "^0.4.5",
-				"mkdirp": "^0.5.0",
-				"private": "^0.1.6",
-				"q": "^1.1.2",
-				"recast": "^0.11.17"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
-			}
-		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2337,12 +2281,6 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
-		"d3": {
-			"version": "3.5.17",
-			"resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-			"integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
-			"dev": true
-		},
 		"date-fns": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.6.0.tgz",
@@ -2426,12 +2364,6 @@
 				}
 			}
 		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
-		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -2447,24 +2379,6 @@
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
-		},
-		"detective": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.2.1",
-				"defined": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				}
-			}
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -2673,16 +2587,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
 			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
-		},
-		"envify": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-			"dev": true,
-			"requires": {
-				"jstransform": "^11.0.3",
-				"through": "~2.3.4"
-			}
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -3182,33 +3086,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
-		},
-		"fbjs": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
-			"integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
-			"dev": true,
-			"requires": {
-				"core-js": "^1.0.0",
-				"loose-envify": "^1.0.0",
-				"promise": "^7.0.3",
-				"ua-parser-js": "^0.7.9",
-				"whatwg-fetch": "^0.9.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-					"dev": true
-				},
-				"whatwg-fetch": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
-					"integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=",
-					"dev": true
-				}
-			}
 		},
 		"figgy-pudding": {
 			"version": "3.5.1",
@@ -4790,42 +4667,6 @@
 				}
 			}
 		},
-		"jstransform": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-			"dev": true,
-			"requires": {
-				"base62": "^1.1.0",
-				"commoner": "^0.10.1",
-				"esprima-fb": "^15001.1.0-dev-harmony-fb",
-				"object-assign": "^2.0.0",
-				"source-map": "^0.4.2"
-			},
-			"dependencies": {
-				"esprima-fb": {
-					"version": "15001.1.0-dev-harmony-fb",
-					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
-					"dev": true
-				},
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
-		},
 		"jsx-ast-utils": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
@@ -6005,15 +5846,6 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
-		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -6089,12 +5921,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
-		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -6125,22 +5951,6 @@
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
 			}
-		},
-		"react": {
-			"version": "0.14.9",
-			"resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
-			"integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
-			"dev": true,
-			"requires": {
-				"envify": "^3.0.0",
-				"fbjs": "^0.6.1"
-			}
-		},
-		"react-dom": {
-			"version": "0.14.9",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
-			"integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=",
-			"dev": true
 		},
 		"react-is": {
 			"version": "16.11.0",
@@ -6218,32 +6028,6 @@
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
-				}
-			}
-		},
-		"recast": {
-			"version": "0.11.23",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-			"dev": true,
-			"requires": {
-				"ast-types": "0.9.6",
-				"esprima": "~3.1.0",
-				"private": "~0.1.5",
-				"source-map": "~0.5.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
 				}
 			}
 		},
@@ -7339,12 +7123,6 @@
 			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.20",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
-			"dev": true
-		},
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -7837,17 +7615,11 @@
 				"source-map": "~0.6.1"
 			}
 		},
-		"webpack-visualizer-plugin": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.11.tgz",
-			"integrity": "sha1-uHcK2GtPZSYSxosbeCJT+vn4o04=",
-			"dev": true,
-			"requires": {
-				"d3": "^3.5.6",
-				"mkdirp": "^0.5.1",
-				"react": "^0.14.0",
-				"react-dom": "^0.14.0"
-			}
+		"webpack-stats-plugin": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.3.0.tgz",
+			"integrity": "sha512-4a6mEl9HLtMukVjEPY8QPCSmtX2EDFJNhDTX5ZE2CLch2adKAZf53nUrpG6m7NattwigS0AodNcwNxlu9kMSDQ==",
+			"dev": true
 		},
 		"whatwg-fetch": {
 			"version": "3.0.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -76,7 +76,7 @@
     "typescript": "^3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
-    "webpack-visualizer-plugin": "^0.1.11"
+    "webpack-stats-plugin": "^0.3.0"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/bundle/webpack.config.js
+++ b/packages/bundle/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
+const { StatsWriterPlugin } = require('webpack-stats-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const Visualizer = require('webpack-visualizer-plugin');
 
 module.exports = {
   entry: {
@@ -29,7 +29,12 @@ module.exports = {
     libraryTarget: 'umd',
     path: resolve(__dirname, 'dist')
   },
-  plugins: [new Visualizer()],
+  plugins: [
+    new StatsWriterPlugin({
+      filename: 'stats.json',
+      transform: (_, opts) => JSON.stringify(opts.compiler.getStats().toJson({ chunkModules: true }), null, 2)
+    })
+  ],
   resolve: {
     alias: {
       react: resolve(__dirname, 'node_modules/isomorphic-react/dist/react.js'),


### PR DESCRIPTION
Fixes #2583.

## Changelog Entry

### Changed

- `bundle`: Webpack will now use `webpack-stats-plugin` instead of `webpack-visualizer-plugin`, by [@compulim](https://github.com/compulim) in PR [#2584](https://github.com/microsoft/BotFramework-WebChat/pull/2584)
   - This will fix [#2583](https://github.com/microsoft/BotFramework-WebChat/issues/2583) by not bringing in transient dependency of React
   - To view the bundle stats, browse to https://chrisbateman.github.io/webpack-visualizer/ and drop the file `/packages/bundle/dist/stats.json`

## Description

(Copied from #2583.)

> This bug only affect users who "npm install" Web Chat with `devDependencies`, e.g. playground or any packages that use `npm link` or `lerna` to include Web Chat in their build.
> 
> When `botframework-webchat` is installed with `devDependencies`, it installed React 0.14.9 due to transient dependencies from `webpack-visualizer-plugin`
> 
> `botframework-webchat` do not include `devDependencies` of React 16.8.6. This is because of the "Rules of Hooks" to maintain a single instance of React. We do include React 16.8.6 at the root package, so both `playground` and `botframework-webchat-*` will share the same instance of React.

## Specific Changes

- `bundle`: Replace `webpack-visualizer-plugin` plugin with `webpack-stats-plugin`

---

-  [x] ~Testing Added~
   - No tests are added for playground
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
