### PR TITLE
Debump embed to 4.3

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -7,8 +7,8 @@
     },
     "4": {
       "redirects": [
-        ["feature:nextminor", "4.5"],
-        ["*", "4.5"]
+        ["feature:nextminor", "4.3"],
+        ["*", "4.3"]
       ]
     },
     "4.1": {


### PR DESCRIPTION
## Description

We have a fix for IE11 related to #2582. But we don't want to roll out an updated version of Web Chat via embed over the holiday season. So we are debumping it back to 4.3.

We will still keep other 4.4 and 4.5 entries.

## Specific Changes

- `embed`: Modify `servicingPlan.json` and default everyone to `4.3`

---

-  [x] Testing Added
   - Will test manually
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
