### PR TITLE
Added check to ensure Adaptive Card's content is an Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2565](https://github.com/microsoft/BotFramework-WebChat/issues/2565). Fixed Adaptive Card host config should generate from style options with default options merged, by [@compulim](https://github.com/compulim) in PR [#2566](https://github.com/microsoft/BotFramework-WebChat/pull/2566
 -  Resolves [#2337](https://github.com/microsoft/BotFramework-WebChat/issues/2337). Remove Cognitive Services Preview warning, by [@corinagum](https://github.com/corinagum) in PR [#2578](https://github.com/microsoft/BotFramework-WebChat/pull/2578)
 -  Fixes [#2512](https://github.com/microsoft/BotFramework-WebChat/issues/2512). De-bump remark and strip-markdown, by [@corinagum](https://github.com/corinagum) in PR [#2576](https://github.com/microsoft/BotFramework-WebChat/pull/2576)
+-  Fixes [#2512](https://github.com/microsoft/BotFramework-WebChat/issues/2512). Adds check to ensure Adaptive Card's content is an Object, by [@tdurnford](https://github.com/tdurnford) in PR [#2590](https://github.com/microsoft/BotFramework-WebChat/pull/2590)
 
 ### Added
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardAttachment.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardAttachment.js
@@ -25,6 +25,10 @@ const AdaptiveCardAttachment = ({ adaptiveCardHostConfig, adaptiveCards, attachm
       // TODO: [P3] Move from "onParseError" to "card.parse(json, errors)"
       adaptiveCards.AdaptiveCard.onParseError = error => errors.push(error);
 
+      if (typeof content !== 'object') {
+        content = {};
+      }
+
       card.parse(
         stripSubmitAction({
           version: '1.0',


### PR DESCRIPTION
Fixes #2512 

## Changelog Entry

Fixes [#2512](https://github.com/microsoft/BotFramework-WebChat/issues/2512). Adds check to ensure Adaptive Card's content is an Object, by [@tdurnford](https://github.com/tdurnford) in PR [#25XX](https://github.com/microsoft/BotFramework-WebChat/pull/25XX)

## Description
In the `AdaptiveCardAttachement`, we pass the card content to Adaptive Card's parse function to create the card. If the content is not an Object, Adaptive Cards is supposed to push an error onto the `errors` array. This works fine in Chrome; however, in IE 11, the browser throws an 'argument is not object' error since the `Object.keys` method is expecting an object and we are passing something that is not an object. As a temporary workaround, I added a check in the `AdaptiveCardAttachement` component to make sure the Adaptive Card content is an object before parsing the card.

---

-  [ ] Testing Added
