### PR TITLE
Add React Hooks for customization (part 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  PR [#2552](https://github.com/microsoft/BotFramework-WebChat/pull/2552): `useFocusSendBox`, `useScrollToEnd`, `useSendBoxValue`, `useSubmitSendBox`, `useTextBoxSubmit`, `useTextBoxValue`
    -  PR [#2553](https://github.com/microsoft/BotFramework-WebChat/pull/2553): `useDictateInterims`, `useDictateState`, `useGrammars`, `useMarkActivityAsSpoken`, `useMicrophoneButton`, `useShouldSpeakIncomingActivity`, `useStartDictate`, `useStopDictate`, `useVoiceSelector`, `useWebSpeechPonyfill`
    -  PR [#2554](https://github.com/microsoft/BotFramework-WebChat/pull/2554): `useRenderActivity`, `useRenderAttachment`
-   -  PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX): Added `internal/useWebChatUIContext` for cleaner code
+   -  PR [#2644](https://github.com/microsoft/BotFramework-WebChat/pull/2644): Added `internal/useWebChatUIContext` for cleaner code
 -  Bring your own Adaptive Cards package by specifying `adaptiveCardsPackage` prop, by [@compulim](https://github.com/compulim) in PR [#2543](https://github.com/microsoft/BotFramework-WebChat/pull/2543)
 -  Fixes [#2597](https://github.com/microsoft/BotFramework-WebChat/issues/2597). Modify `watch` script to `start` and add `tableflip` script for throwing `node_modules`, by [@corinagum](https://github.com/corinagum) in PR [#2598](https://github.com/microsoft/BotFramework-WebChat/pull/2598)
 -  Adds Arabic Language Support, by [@midineo](https://github.com/midineo), in PR [#2593](https://github.com/microsoft/BotFramework-WebChat/pull/2593)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  PR [#2552](https://github.com/microsoft/BotFramework-WebChat/pull/2552): `useFocusSendBox`, `useScrollToEnd`, `useSendBoxValue`, `useSubmitSendBox`, `useTextBoxSubmit`, `useTextBoxValue`
    -  PR [#2553](https://github.com/microsoft/BotFramework-WebChat/pull/2553): `useDictateInterims`, `useDictateState`, `useGrammars`, `useMarkActivityAsSpoken`, `useMicrophoneButton`, `useShouldSpeakIncomingActivity`, `useStartDictate`, `useStopDictate`, `useVoiceSelector`, `useWebSpeechPonyfill`
    -  PR [#2554](https://github.com/microsoft/BotFramework-WebChat/pull/2554): `useRenderActivity`, `useRenderAttachment`
+   -  PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX): Added `internal/useWebChatUIContext` for cleaner code
 -  Bring your own Adaptive Cards package by specifying `adaptiveCardsPackage` prop, by [@compulim](https://github.com/compulim) in PR [#2543](https://github.com/microsoft/BotFramework-WebChat/pull/2543)
 -  Fixes [#2597](https://github.com/microsoft/BotFramework-WebChat/issues/2597). Modify `watch` script to `start` and add `tableflip` script for throwing `node_modules`, by [@corinagum](https://github.com/corinagum) in PR [#2598](https://github.com/microsoft/BotFramework-WebChat/pull/2598)
 -  Adds Arabic Language Support, by [@midineo](https://github.com/midineo), in PR [#2593](https://github.com/microsoft/BotFramework-WebChat/pull/2593)

--- a/packages/component/src/hooks/internal/useMarkActivity.js
+++ b/packages/component/src/hooks/internal/useMarkActivity.js
@@ -1,4 +1,4 @@
-import useWebChatUIContext from './internal/useWebChatUIContext';
+import useWebChatUIContext from './useWebChatUIContext';
 
 export default function useMarkActivity() {
   return useWebChatUIContext().markActivity;

--- a/packages/component/src/hooks/internal/useMarkActivity.js
+++ b/packages/component/src/hooks/internal/useMarkActivity.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useMarkActivity() {
-  return useContext(WebChatUIContext).markActivity;
+  return useWebChatUIContext().markActivity;
 }

--- a/packages/component/src/hooks/internal/useSetDictateState.js
+++ b/packages/component/src/hooks/internal/useSetDictateState.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSetDictateState() {
-  return useContext(WebChatUIContext).setDictateState;
+  return useWebChatUIContext().setDictateState;
 }

--- a/packages/component/src/hooks/internal/useSetDictateState.js
+++ b/packages/component/src/hooks/internal/useSetDictateState.js
@@ -1,4 +1,4 @@
-import useWebChatUIContext from './internal/useWebChatUIContext';
+import useWebChatUIContext from './useWebChatUIContext';
 
 export default function useSetDictateState() {
   return useWebChatUIContext().setDictateState;

--- a/packages/component/src/hooks/internal/useWebChatUIContext.js
+++ b/packages/component/src/hooks/internal/useWebChatUIContext.js
@@ -6,7 +6,7 @@ export default function useWebChatUIContext() {
   const context = useContext(WebChatUIContext);
 
   if (!context) {
-    throw new Error('This hook can only be used on component that is decendants of <Composer>');
+    throw new Error('This hook can only be used on a component that is a descendant of <Composer>');
   }
 
   return context;

--- a/packages/component/src/hooks/internal/useWebChatUIContext.js
+++ b/packages/component/src/hooks/internal/useWebChatUIContext.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import WebChatUIContext from '../../WebChatUIContext';
+
+export default function useWebChatUIContext() {
+  const context = useContext(WebChatUIContext);
+
+  if (!context) {
+    throw new Error('This hook can only be used on component that is decendants of <Composer>');
+  }
+
+  return context;
+}

--- a/packages/component/src/hooks/useDictateInterims.js
+++ b/packages/component/src/hooks/useDictateInterims.js
@@ -1,8 +1,6 @@
-import { useContext } from 'react';
-
 import { useSelector } from '../WebChatReduxContext';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useDictateInterims() {
-  return [useSelector(({ dictateInterims }) => dictateInterims) || [], useContext(WebChatUIContext).setDictateInterims];
+  return [useSelector(({ dictateInterims }) => dictateInterims) || [], useWebChatUIContext().setDictateInterims];
 }

--- a/packages/component/src/hooks/useDisabled.js
+++ b/packages/component/src/hooks/useDisabled.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useDisabled() {
-  return [useContext(WebChatUIContext).disabled];
+  return [useWebChatUIContext().disabled];
 }

--- a/packages/component/src/hooks/useEmitTypingIndicator.js
+++ b/packages/component/src/hooks/useEmitTypingIndicator.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useEmitTypingIndicator() {
-  return useContext(WebChatUIContext).emitTypingIndicator;
+  return useWebChatUIContext().emitTypingIndicator;
 }

--- a/packages/component/src/hooks/useFocusSendBox.js
+++ b/packages/component/src/hooks/useFocusSendBox.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useFocusSendBox() {
-  return useContext(WebChatUIContext).focusSendBox;
+  return useWebChatUIContext().focusSendBox;
 }

--- a/packages/component/src/hooks/useGrammars.js
+++ b/packages/component/src/hooks/useGrammars.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useGrammars() {
-  return [useContext(WebChatUIContext).grammars];
+  return [useWebChatUIContext().grammars];
 }

--- a/packages/component/src/hooks/useGroupTimestamp.js
+++ b/packages/component/src/hooks/useGroupTimestamp.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useGroupTimestamp() {
-  return [useContext(WebChatUIContext).groupTimestamp];
+  return [useWebChatUIContext().groupTimestamp];
 }

--- a/packages/component/src/hooks/usePerformCardAction.js
+++ b/packages/component/src/hooks/usePerformCardAction.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function usePerformCardAction() {
-  return useContext(WebChatUIContext).onCardAction;
+  return useWebChatUIContext().onCardAction;
 }

--- a/packages/component/src/hooks/usePostActivity.js
+++ b/packages/component/src/hooks/usePostActivity.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function usePostActivity() {
-  return useContext(WebChatUIContext).postActivity;
+  return useWebChatUIContext().postActivity;
 }

--- a/packages/component/src/hooks/useRenderMarkdownAsHTML.js
+++ b/packages/component/src/hooks/useRenderMarkdownAsHTML.js
@@ -1,10 +1,10 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import useStyleOptions from '../hooks/useStyleOptions';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useRenderMarkdownAsHTML() {
-  const { renderMarkdown } = useContext(WebChatUIContext);
+  const { renderMarkdown } = useWebChatUIContext();
   const [styleOptions] = useStyleOptions();
 
   return useCallback(markdown => renderMarkdown(markdown, styleOptions), [renderMarkdown, styleOptions]);

--- a/packages/component/src/hooks/useScrollToEnd.js
+++ b/packages/component/src/hooks/useScrollToEnd.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useScrollToEnd() {
-  return useContext(WebChatUIContext).scrollToEnd;
+  return useWebChatUIContext().scrollToEnd;
 }

--- a/packages/component/src/hooks/useSendBoxValue.js
+++ b/packages/component/src/hooks/useSendBoxValue.js
@@ -1,8 +1,6 @@
-import { useContext } from 'react';
-
 import { useSelector } from '../WebChatReduxContext';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSendBoxValue() {
-  return [useSelector(({ sendBoxValue }) => sendBoxValue), useContext(WebChatUIContext).setSendBox];
+  return [useSelector(({ sendBoxValue }) => sendBoxValue), useWebChatUIContext().setSendBox];
 }

--- a/packages/component/src/hooks/useSendEvent.js
+++ b/packages/component/src/hooks/useSendEvent.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSendEvent() {
-  return useContext(WebChatUIContext).sendEvent;
+  return useWebChatUIContext().sendEvent;
 }

--- a/packages/component/src/hooks/useSendFiles.js
+++ b/packages/component/src/hooks/useSendFiles.js
@@ -1,8 +1,8 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import downscaleImageToDataURL from '../Utils/downscaleImageToDataURL';
 import useStyleOptions from '../hooks/useStyleOptions';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 async function makeThumbnail(file, width, height, contentType, quality) {
   if (/\.(gif|jpe?g|png)$/iu.test(file.name)) {
@@ -15,7 +15,7 @@ async function makeThumbnail(file, width, height, contentType, quality) {
 }
 
 export default function useSendFiles() {
-  const { sendFiles } = useContext(WebChatUIContext);
+  const { sendFiles } = useWebChatUIContext();
   const [
     {
       enableUploadThumbnail,

--- a/packages/component/src/hooks/useSendMessage.js
+++ b/packages/component/src/hooks/useSendMessage.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSendMessage() {
-  return useContext(WebChatUIContext).sendMessage;
+  return useWebChatUIContext().sendMessage;
 }

--- a/packages/component/src/hooks/useSendMessageBack.js
+++ b/packages/component/src/hooks/useSendMessageBack.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSendMessageBack() {
-  return useContext(WebChatUIContext).sendMessageBack;
+  return useWebChatUIContext().sendMessageBack;
 }

--- a/packages/component/src/hooks/useSendPostBack.js
+++ b/packages/component/src/hooks/useSendPostBack.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSendPostBack() {
-  return useContext(WebChatUIContext).sendPostBack;
+  return useWebChatUIContext().sendPostBack;
 }

--- a/packages/component/src/hooks/useShouldSpeakIncomingActivity.js
+++ b/packages/component/src/hooks/useShouldSpeakIncomingActivity.js
@@ -1,10 +1,10 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import { useSelector } from '../WebChatReduxContext';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useShouldSpeakIncomingActivity() {
-  const { startSpeakingActivity, stopSpeakingActivity } = useContext(WebChatUIContext);
+  const { startSpeakingActivity, stopSpeakingActivity } = useWebChatUIContext();
 
   return [
     useSelector(({ shouldSpeakIncomingActivity }) => shouldSpeakIncomingActivity),

--- a/packages/component/src/hooks/useStartDictate.js
+++ b/packages/component/src/hooks/useStartDictate.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useStartDictate() {
-  return useContext(WebChatUIContext).startDictate;
+  return useWebChatUIContext().startDictate;
 }

--- a/packages/component/src/hooks/useStopDictate.js
+++ b/packages/component/src/hooks/useStopDictate.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useStopDictate() {
-  return useContext(WebChatUIContext).stopDictate;
+  return useWebChatUIContext().stopDictate;
 }

--- a/packages/component/src/hooks/useStyleSet.js
+++ b/packages/component/src/hooks/useStyleSet.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useStyleSet() {
-  return [useContext(WebChatUIContext).styleSet];
+  return [useWebChatUIContext().styleSet];
 }

--- a/packages/component/src/hooks/useSubmitSendBox.js
+++ b/packages/component/src/hooks/useSubmitSendBox.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSubmitSendbox() {
-  return useContext(WebChatUIContext).submitSendBox;
+  return useWebChatUIContext().submitSendBox;
 }

--- a/packages/component/src/hooks/useSuggestedActions.js
+++ b/packages/component/src/hooks/useSuggestedActions.js
@@ -1,11 +1,11 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import { useSelector } from '../WebChatReduxContext';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useSuggestedActions() {
   const value = useSelector(({ suggestedActions }) => suggestedActions);
-  const { clearSuggestedActions } = useContext(WebChatUIContext);
+  const { clearSuggestedActions } = useWebChatUIContext();
 
   return [
     value,

--- a/packages/component/src/hooks/useTimeoutForSend.js
+++ b/packages/component/src/hooks/useTimeoutForSend.js
@@ -1,8 +1,6 @@
-import { useContext } from 'react';
-
 import { useSelector } from '../WebChatReduxContext';
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useTimeoutForSend() {
-  return [useSelector(({ sendTimeout }) => sendTimeout), useContext(WebChatUIContext).setSendTimeout];
+  return [useSelector(({ sendTimeout }) => sendTimeout), useWebChatUIContext().setSendTimeout];
 }

--- a/packages/component/src/hooks/useUserID.js
+++ b/packages/component/src/hooks/useUserID.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useUserID() {
-  return [useContext(WebChatUIContext).userID];
+  return [useWebChatUIContext().userID];
 }

--- a/packages/component/src/hooks/useUsername.js
+++ b/packages/component/src/hooks/useUsername.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useUsername() {
-  return [useContext(WebChatUIContext).username];
+  return [useWebChatUIContext().username];
 }

--- a/packages/component/src/hooks/useVoiceSelector.js
+++ b/packages/component/src/hooks/useVoiceSelector.js
@@ -1,9 +1,8 @@
-import { useCallback, useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import { useCallback } from 'react';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useVoiceSelector(activity) {
-  const context = useContext(WebChatUIContext);
+  const context = useWebChatUIContext();
 
   return useCallback(voices => context.selectVoice(voices, activity), [activity, context]);
 }

--- a/packages/component/src/hooks/useWebSpeechPonyfill.js
+++ b/packages/component/src/hooks/useWebSpeechPonyfill.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-
-import WebChatUIContext from '../WebChatUIContext';
+import useWebChatUIContext from './internal/useWebChatUIContext';
 
 export default function useWebSpeechPonyfill() {
-  return [useContext(WebChatUIContext).webSpeechPonyfill];
+  return [useWebChatUIContext().webSpeechPonyfill];
 }


### PR DESCRIPTION
> Related to #2539

## Changelog Entry

-  Resolves [#2539](https://github.com/Microsoft/BotFramework-WebChat/issues/2539), added React hooks for customization, by [@compulim](https://github.com/compulim), in the following PRs:
   -  PR [#2644](https://github.com/microsoft/BotFramework-WebChat/pull/2644): Added `internal/useWebChatUIContext` for cleaner code

## Description

Cleaning up some code by adding a new `useWebChatUIContext`. This hook is for internal use only.

## Specific Changes

- Added `component/src/hooks/useWebChatUIContext.js`
   - Updated other hooks that call `useContext(WebChatUIContext)` to call `useWebChatUIContext` instead

---

-  [x] Testing Added
   - No tests added because it should be covered by other tests
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
