### PR TITLE
Adds AdaptiveCardsComposer and AdaptiveCardsContext for composability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Bring your own Adaptive Cards package by specifying `adaptiveCardsPackage` prop, by [@compulim](https://github.com/compulim) in PR [#2543](https://github.com/microsoft/BotFramework-WebChat/pull/2543)
 -  Fixes [#2597](https://github.com/microsoft/BotFramework-WebChat/issues/2597). Modify `watch` script to `start` and add `tableflip` script for throwing `node_modules`, by [@corinagum](https://github.com/corinagum) in PR [#2598](https://github.com/microsoft/BotFramework-WebChat/pull/2598)
 -  Adds Arabic Language Support, by [@midineo](https://github.com/midineo), in PR [#2593](https://github.com/microsoft/BotFramework-WebChat/pull/2593)
+-  Adds `AdaptiveCardsComposer` and `AdaptiveCardsContext` for composability for Adaptive Cards, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Bring your own Adaptive Cards package by specifying `adaptiveCardsPackage` prop, by [@compulim](https://github.com/compulim) in PR [#2543](https://github.com/microsoft/BotFramework-WebChat/pull/2543)
 -  Fixes [#2597](https://github.com/microsoft/BotFramework-WebChat/issues/2597). Modify `watch` script to `start` and add `tableflip` script for throwing `node_modules`, by [@corinagum](https://github.com/corinagum) in PR [#2598](https://github.com/microsoft/BotFramework-WebChat/pull/2598)
 -  Adds Arabic Language Support, by [@midineo](https://github.com/midineo), in PR [#2593](https://github.com/microsoft/BotFramework-WebChat/pull/2593)
--  Adds `AdaptiveCardsComposer` and `AdaptiveCardsContext` for composability for Adaptive Cards, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Adds `AdaptiveCardsComposer` and `AdaptiveCardsContext` for composability for Adaptive Cards, by [@compulim](https://github.com/compulim), in PR [#2648](https://github.com/microsoft/BotFramework-WebChat/pull/2648)
 
 ### Fixed
 

--- a/packages/bundle/src/FullComposer.js
+++ b/packages/bundle/src/FullComposer.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+
+import AdaptiveCardsComposer from './adaptiveCards/AdaptiveCardsComposer';
+import { Components } from 'botframework-webchat-component';
+
+import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
+
+const { Composer } = Components;
+
+const FullComposer = ({ adaptiveCardsHostConfig, adaptiveCardsPackage, children, styleOptions, ...otherProps }) => {
+  const extraStyleSet = useMemo(() => createAdaptiveCardsStyleSet(styleOptions), [styleOptions]);
+
+  return (
+    <AdaptiveCardsComposer
+      adaptiveCardsHostConfig={adaptiveCardsHostConfig}
+      adaptiveCardsPackage={adaptiveCardsPackage}
+      styleOptions={styleOptions}
+    >
+      <Composer extraStyleSet={extraStyleSet} styleOptions={styleOptions} {...otherProps}>
+        {children}
+      </Composer>
+    </AdaptiveCardsComposer>
+  );
+};
+
+FullComposer.defaultProps = {
+  adaptiveCardsHostConfig: undefined,
+  adaptiveCardsPackage: undefined,
+  children: undefined,
+  styleOptions: undefined,
+  ...Composer.defaultProps
+};
+
+FullComposer.propTypes = {
+  adaptiveCardsHostConfig: PropTypes.any,
+  adaptiveCardsPackage: PropTypes.any,
+  children: PropTypes.any,
+  styleOptions: PropTypes.any,
+  ...Composer.propTypes
+};
+
+export default FullComposer;

--- a/packages/bundle/src/FullComposer.js
+++ b/packages/bundle/src/FullComposer.js
@@ -1,23 +1,23 @@
 import PropTypes from 'prop-types';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import AdaptiveCardsComposer from './adaptiveCards/AdaptiveCardsComposer';
 import { Components } from 'botframework-webchat-component';
 
-import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
+import useComposerProps from './useComposerProps';
 
 const { Composer } = Components;
 
-const FullComposer = ({ adaptiveCardsHostConfig, adaptiveCardsPackage, children, styleOptions, ...otherProps }) => {
-  const extraStyleSet = useMemo(() => createAdaptiveCardsStyleSet(styleOptions), [styleOptions]);
+const FullComposer = props => {
+  const { adaptiveCardsHostConfig, adaptiveCardsPackage, children, ...otherProps } = props;
+  const composerProps = useComposerProps(props);
 
   return (
     <AdaptiveCardsComposer
       adaptiveCardsHostConfig={adaptiveCardsHostConfig}
       adaptiveCardsPackage={adaptiveCardsPackage}
-      styleOptions={styleOptions}
     >
-      <Composer extraStyleSet={extraStyleSet} styleOptions={styleOptions} {...otherProps}>
+      <Composer {...otherProps} {...composerProps}>
         {children}
       </Composer>
     </AdaptiveCardsComposer>
@@ -25,19 +25,17 @@ const FullComposer = ({ adaptiveCardsHostConfig, adaptiveCardsPackage, children,
 };
 
 FullComposer.defaultProps = {
+  ...Composer.defaultProps,
   adaptiveCardsHostConfig: undefined,
   adaptiveCardsPackage: undefined,
-  children: undefined,
-  styleOptions: undefined,
-  ...Composer.defaultProps
+  children: undefined
 };
 
 FullComposer.propTypes = {
+  ...Composer.propTypes,
   adaptiveCardsHostConfig: PropTypes.any,
   adaptiveCardsPackage: PropTypes.any,
-  children: PropTypes.any,
-  styleOptions: PropTypes.any,
-  ...Composer.propTypes
+  children: PropTypes.any
 };
 
 export default FullComposer;

--- a/packages/bundle/src/FullReactWebChat.js
+++ b/packages/bundle/src/FullReactWebChat.js
@@ -1,12 +1,10 @@
-import * as defaultAdaptiveCardsPackage from 'adaptivecards';
 import BasicWebChat, { concatMiddleware } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
 
-import AdaptiveCardsContext from './adaptiveCards/AdaptiveCardsContext';
-import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardMiddleware';
-import createDefaultAdaptiveCardHostConfig from './adaptiveCards/Styles/adaptiveCardHostConfig';
-import createStyleSet from './adaptiveCards/Styles/createStyleSetWithAdaptiveCards';
+import AdaptiveCardsComposer from './adaptiveCards/AdaptiveCardsComposer';
+import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardsAttachmentMiddleware';
+import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
 import defaultRenderMarkdown from './renderMarkdown';
 
 // Add additional props to <WebChat>, so it support additional features
@@ -17,7 +15,6 @@ const FullReactWebChat = ({
   attachmentMiddleware,
   renderMarkdown,
   styleOptions,
-  styleSet,
   ...otherProps
 }) => {
   useEffect(() => {
@@ -27,67 +24,46 @@ const FullReactWebChat = ({
       );
   }, [adaptiveCardHostConfig]);
 
-  const patchedStyleSet = useMemo(() => styleSet || createStyleSet(styleOptions), [styleOptions, styleSet]);
-  const { options: patchedStyleOptions } = patchedStyleSet;
-
-  const patchedAdaptiveCardsHostConfig = useMemo(
-    () => adaptiveCardsHostConfig || adaptiveCardHostConfig || createDefaultAdaptiveCardHostConfig(patchedStyleOptions),
-    [adaptiveCardHostConfig, adaptiveCardsHostConfig, patchedStyleOptions]
-  );
-
-  const patchedAdaptiveCardsPackage = useMemo(() => adaptiveCardsPackage || defaultAdaptiveCardsPackage, [
-    adaptiveCardsPackage
-  ]);
-
-  const patchedRenderMarkdown = useMemo(
-    () => renderMarkdown || (markdown => defaultRenderMarkdown(markdown, patchedStyleOptions)),
-    [renderMarkdown, patchedStyleOptions]
-  );
-
   const patchedAttachmentMiddleware = useMemo(
     () => concatMiddleware(attachmentMiddleware, createAdaptiveCardsAttachmentMiddleware()),
     [attachmentMiddleware]
   );
 
-  const adaptiveCardsContext = useMemo(
-    () => ({
-      adaptiveCardsPackage: patchedAdaptiveCardsPackage,
-      hostConfig: patchedAdaptiveCardsHostConfig
-    }),
-    [patchedAdaptiveCardsHostConfig, patchedAdaptiveCardsPackage]
-  );
+  const extraStyleSet = useMemo(() => createAdaptiveCardsStyleSet(styleOptions), [styleOptions]);
 
   return (
-    <AdaptiveCardsContext.Provider value={adaptiveCardsContext}>
+    <AdaptiveCardsComposer
+      adaptiveCardsHostConfig={adaptiveCardsHostConfig}
+      adaptiveCardsPackage={adaptiveCardsPackage}
+    >
       <BasicWebChat
         attachmentMiddleware={patchedAttachmentMiddleware}
-        renderMarkdown={patchedRenderMarkdown}
-        styleOptions={styleOptions}
-        styleSet={patchedStyleSet}
+        extraStyleSet={extraStyleSet}
+        renderMarkdown={renderMarkdown || defaultRenderMarkdown}
         {...otherProps}
       />
-    </AdaptiveCardsContext.Provider>
+    </AdaptiveCardsComposer>
   );
 };
 
 FullReactWebChat.defaultProps = {
+  ...BasicWebChat.defaultProps,
   adaptiveCardHostConfig: undefined,
   adaptiveCardsHostConfig: undefined,
   adaptiveCardsPackage: undefined,
   attachmentMiddleware: undefined,
   renderMarkdown: undefined,
-  styleOptions: undefined,
-  styleSet: undefined
+  styleOptions: undefined
 };
 
 FullReactWebChat.propTypes = {
+  ...BasicWebChat.propTypes,
   adaptiveCardHostConfig: PropTypes.any,
   adaptiveCardsHostConfig: PropTypes.any,
   adaptiveCardsPackage: PropTypes.any,
   attachmentMiddleware: PropTypes.func,
   renderMarkdown: PropTypes.func,
-  styleOptions: PropTypes.any,
-  styleSet: PropTypes.any
+  styleOptions: PropTypes.any
 };
 
 export default FullReactWebChat;

--- a/packages/bundle/src/FullReactWebChat.js
+++ b/packages/bundle/src/FullReactWebChat.js
@@ -1,22 +1,14 @@
-import BasicWebChat, { concatMiddleware } from 'botframework-webchat-component';
+import BasicWebChat from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 
 import AdaptiveCardsComposer from './adaptiveCards/AdaptiveCardsComposer';
-import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardsAttachmentMiddleware';
-import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
-import defaultRenderMarkdown from './renderMarkdown';
+import useComposerProps from './useComposerProps';
 
 // Add additional props to <WebChat>, so it support additional features
-const FullReactWebChat = ({
-  adaptiveCardHostConfig,
-  adaptiveCardsHostConfig,
-  adaptiveCardsPackage,
-  attachmentMiddleware,
-  renderMarkdown,
-  styleOptions,
-  ...otherProps
-}) => {
+const FullReactWebChat = props => {
+  const { adaptiveCardHostConfig, adaptiveCardsHostConfig, adaptiveCardsPackage, ...otherProps } = props;
+
   useEffect(() => {
     adaptiveCardHostConfig &&
       console.warn(
@@ -24,24 +16,14 @@ const FullReactWebChat = ({
       );
   }, [adaptiveCardHostConfig]);
 
-  const patchedAttachmentMiddleware = useMemo(
-    () => concatMiddleware(attachmentMiddleware, createAdaptiveCardsAttachmentMiddleware()),
-    [attachmentMiddleware]
-  );
-
-  const extraStyleSet = useMemo(() => createAdaptiveCardsStyleSet(styleOptions), [styleOptions]);
+  const composerProps = useComposerProps(props);
 
   return (
     <AdaptiveCardsComposer
       adaptiveCardsHostConfig={adaptiveCardsHostConfig}
       adaptiveCardsPackage={adaptiveCardsPackage}
     >
-      <BasicWebChat
-        attachmentMiddleware={patchedAttachmentMiddleware}
-        extraStyleSet={extraStyleSet}
-        renderMarkdown={renderMarkdown || defaultRenderMarkdown}
-        {...otherProps}
-      />
+      <BasicWebChat {...otherProps} {...composerProps} />
     </AdaptiveCardsComposer>
   );
 };
@@ -51,9 +33,7 @@ FullReactWebChat.defaultProps = {
   adaptiveCardHostConfig: undefined,
   adaptiveCardsHostConfig: undefined,
   adaptiveCardsPackage: undefined,
-  attachmentMiddleware: undefined,
-  renderMarkdown: undefined,
-  styleOptions: undefined
+  renderMarkdown: undefined
 };
 
 FullReactWebChat.propTypes = {
@@ -61,9 +41,7 @@ FullReactWebChat.propTypes = {
   adaptiveCardHostConfig: PropTypes.any,
   adaptiveCardsHostConfig: PropTypes.any,
   adaptiveCardsPackage: PropTypes.any,
-  attachmentMiddleware: PropTypes.func,
-  renderMarkdown: PropTypes.func,
-  styleOptions: PropTypes.any
+  renderMarkdown: PropTypes.func
 };
 
 export default FullReactWebChat;

--- a/packages/bundle/src/adaptiveCards/AdaptiveCardsComposer.js
+++ b/packages/bundle/src/adaptiveCards/AdaptiveCardsComposer.js
@@ -1,0 +1,35 @@
+import * as defaultAdaptiveCardsPackage from 'adaptivecards';
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+
+import AdaptiveCardsContext from './AdaptiveCardsContext';
+
+const AdaptiveCardsComposer = ({ adaptiveCardsHostConfig, adaptiveCardsPackage, children }) => {
+  const patchedAdaptiveCardsPackage = useMemo(() => adaptiveCardsPackage || defaultAdaptiveCardsPackage, [
+    adaptiveCardsPackage
+  ]);
+
+  const adaptiveCardsContext = useMemo(
+    () => ({
+      adaptiveCardsPackage: patchedAdaptiveCardsPackage,
+      hostConfigFromProps: adaptiveCardsHostConfig
+    }),
+    [adaptiveCardsHostConfig, patchedAdaptiveCardsPackage]
+  );
+
+  return <AdaptiveCardsContext.Provider value={adaptiveCardsContext}>{children}</AdaptiveCardsContext.Provider>;
+};
+
+AdaptiveCardsComposer.defaultProps = {
+  adaptiveCardsHostConfig: undefined,
+  adaptiveCardsPackage: undefined,
+  children: undefined
+};
+
+AdaptiveCardsComposer.propTypes = {
+  adaptiveCardsHostConfig: PropTypes.any,
+  adaptiveCardsPackage: PropTypes.any,
+  children: PropTypes.any
+};
+
+export default AdaptiveCardsComposer;

--- a/packages/bundle/src/adaptiveCards/AdaptiveCardsContext.js
+++ b/packages/bundle/src/adaptiveCards/AdaptiveCardsContext.js
@@ -1,8 +1,5 @@
 import { createContext } from 'react';
 
-const AdaptiveCardHostConfigContext = createContext({
-  adaptiveCardsPackage: undefined,
-  hostConfig: undefined
-});
+const AdaptiveCardHostConfigContext = createContext();
 
 export default AdaptiveCardHostConfigContext;

--- a/packages/bundle/src/adaptiveCards/Attachment/HeroCardAttachment.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/HeroCardAttachment.js
@@ -32,9 +32,6 @@ HeroCardAttachment.propTypes = {
     content: PropTypes.shape({
       tap: PropTypes.any
     }).isRequired
-  }).isRequired,
-  styleSet: PropTypes.shape({
-    options: PropTypes.any.isRequired
   }).isRequired
 };
 

--- a/packages/bundle/src/adaptiveCards/Styles/createAdaptiveCardsStyleSet.js
+++ b/packages/bundle/src/adaptiveCards/Styles/createAdaptiveCardsStyleSet.js
@@ -1,4 +1,5 @@
-import { createStyleSet as createBasicStyleSet, defaultStyleOptions } from 'botframework-webchat-component';
+import { defaultStyleOptions } from 'botframework-webchat-component';
+
 import createAdaptiveCardRendererStyle from './StyleSet/AdaptiveCardRenderer';
 import createAnimationCardAttachmentStyle from './StyleSet/AnimationCardAttachment';
 import createAudioCardAttachmentStyle from './StyleSet/AudioCardAttachment';
@@ -7,15 +8,10 @@ import createAudioCardAttachmentStyle from './StyleSet/AudioCardAttachment';
 //       "styleSet" is actually CSS stylesheet and it is based on the DOM tree.
 //       DOM tree may change from time to time, thus, maintaining "styleSet" becomes a constant effort.
 
-export default function createStyleSet(options) {
+export default function createAdaptiveCardsStyleSet(options) {
   options = { ...defaultStyleOptions, ...options };
 
-  const basicStyleSet = createBasicStyleSet(options);
-
-  // Keep this list flat (no nested style) and serializable (no functions)
-
   return {
-    ...basicStyleSet,
     adaptiveCardRenderer: createAdaptiveCardRendererStyle(options),
     animationCardAttachment: createAnimationCardAttachmentStyle(options),
     audioCardAttachment: createAudioCardAttachmentStyle(options)

--- a/packages/bundle/src/adaptiveCards/Styles/createAdaptiveCardsStyleSet.spec.js
+++ b/packages/bundle/src/adaptiveCards/Styles/createAdaptiveCardsStyleSet.spec.js
@@ -1,6 +1,6 @@
-import createStyleSet from './createStyleSetWithAdaptiveCards';
+import createStyleSet from './createAdaptiveCardsStyleSet';
 
-describe('createStyleSetWithAdaptiveCards', () => {
+describe('createAdaptiveCardsStyleSet', () => {
   it('should contain Adaptive Card styles in createStyleSet', () => {
     const { adaptiveCardRenderer, animationCardAttachment, audioCardAttachment } = createStyleSet();
 

--- a/packages/bundle/src/adaptiveCards/createAdaptiveCardsAttachmentMiddleware.js
+++ b/packages/bundle/src/adaptiveCards/createAdaptiveCardsAttachmentMiddleware.js
@@ -11,8 +11,7 @@ import SignInCardAttachment from './Attachment/SignInCardAttachment';
 import ThumbnailCardAttachment from './Attachment/ThumbnailCardAttachment';
 import VideoCardAttachment from './Attachment/VideoCardAttachment';
 
-// TODO: [P4] Rename this file or the whole middleware, it looks either too simple or too comprehensive now
-export default function createAdaptiveCardMiddleware() {
+export default function createAdaptiveCardsAttachmentMiddleware() {
   return () => next => {
     function AdaptiveCardMiddleware({ activity, attachment }) {
       return attachment.contentType === 'application/vnd.microsoft.card.hero' ? (

--- a/packages/bundle/src/adaptiveCards/hooks/internal/useAdaptiveCardsContext.js
+++ b/packages/bundle/src/adaptiveCards/hooks/internal/useAdaptiveCardsContext.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import AdaptiveCardsContext from '../../AdaptiveCardsContext';
+
+export default function useAdaptiveCardsContext() {
+  const context = useContext(AdaptiveCardsContext);
+
+  if (!context) {
+    throw new Error('This hook can only be used on component that is decendants of <ComposerWithAdaptiveCards>');
+  }
+
+  return context;
+}

--- a/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsHostConfig.js
+++ b/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsHostConfig.js
@@ -1,9 +1,19 @@
-import { useContext } from 'react';
+import { hooks } from 'botframework-webchat-component';
+import { useMemo } from 'react';
 
-import AdaptiveCardsContext from '../AdaptiveCardsContext';
+import createDefaultAdaptiveCardHostConfig from '../Styles/adaptiveCardHostConfig';
+import useAdaptiveCardsContext from './internal/useAdaptiveCardsContext';
+
+const { useStyleOptions } = hooks;
 
 export default function useAdaptiveCardsHostConfig() {
-  const { hostConfig } = useContext(AdaptiveCardsContext);
+  const { hostConfigFromProps } = useAdaptiveCardsContext();
+  const [styleOptions] = useStyleOptions();
 
-  return [hostConfig];
+  const patchedHostConfig = useMemo(() => hostConfigFromProps || createDefaultAdaptiveCardHostConfig(styleOptions), [
+    hostConfigFromProps,
+    styleOptions
+  ]);
+
+  return [patchedHostConfig];
 }

--- a/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsPackage.js
+++ b/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsPackage.js
@@ -1,9 +1,7 @@
-import { useContext } from 'react';
-
-import AdaptiveCardsContext from '../AdaptiveCardsContext';
+import useAdaptiveCardsContext from './internal/useAdaptiveCardsContext';
 
 export default function useAdaptiveCardsPackage() {
-  const { adaptiveCardsPackage } = useContext(AdaptiveCardsContext);
+  const { adaptiveCardsPackage } = useAdaptiveCardsContext();
 
   return [adaptiveCardsPackage];
 }

--- a/packages/bundle/src/createFullStyleSet.js
+++ b/packages/bundle/src/createFullStyleSet.js
@@ -1,0 +1,13 @@
+import { createStyleSet } from 'botframework-webchat-component';
+import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
+
+// TODO: [P4] We should add a notice for people who want to use "styleSet" instead of "styleOptions".
+//       "styleSet" is actually CSS stylesheet and it is based on the DOM tree.
+//       DOM tree may change from time to time, thus, maintaining "styleSet" becomes a constant effort.
+
+export default function createFullStyleSet(options) {
+  return {
+    ...createStyleSet(options),
+    ...createAdaptiveCardsStyleSet(options)
+  };
+}

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -3,13 +3,15 @@
 
 export * from './index-minimal';
 
-import { hooks, version } from './index-minimal';
+import { Components as MinimalComponents, hooks, version } from './index-minimal';
 import addVersion from './addVersion';
 import coreRenderWebChat from './renderWebChat';
+import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardsAttachmentMiddleware';
 import createCognitiveServicesBingSpeechPonyfillFactory from './createCognitiveServicesBingSpeechPonyfillFactory';
 import createCognitiveServicesSpeechServicesPonyfillFactory from './createCognitiveServicesSpeechServicesPonyfillFactory';
-import createStyleSet from './adaptiveCards/Styles/createStyleSetWithAdaptiveCards';
+import createStyleSet from './createFullStyleSet';
 import defaultCreateDirectLine from './createDirectLine';
+import FullComposer from './FullComposer';
 import ReactWebChat from './FullReactWebChat';
 import renderMarkdown from './renderMarkdown';
 import useAdaptiveCardsHostConfig from './adaptiveCards/hooks/useAdaptiveCardsHostConfig';
@@ -31,9 +33,16 @@ const patchedHooks = {
   useAdaptiveCardsPackage
 };
 
+const Components = {
+  ...MinimalComponents,
+  Composer: FullComposer
+};
+
 export default ReactWebChat;
 
 export {
+  Components,
+  createAdaptiveCardsAttachmentMiddleware,
   createCognitiveServicesBingSpeechPonyfillFactory,
   createCognitiveServicesSpeechServicesPonyfillFactory,
   createStyleSet,
@@ -44,6 +53,7 @@ export {
 
 window['WebChat'] = {
   ...window['WebChat'],
+  createAdaptiveCardsAttachmentMiddleware,
   createCognitiveServicesBingSpeechPonyfillFactory,
   createCognitiveServicesSpeechServicesPonyfillFactory,
   createDirectLine,

--- a/packages/bundle/src/useComposerProps.js
+++ b/packages/bundle/src/useComposerProps.js
@@ -15,7 +15,8 @@ export default function useComposerProps({ attachmentMiddleware, renderMarkdown,
 
   // When styleSet is not specified, the styleOptions will be used to create Adaptive Cards styleSet and merged into useStyleSet.
   const extraStyleSet = useMemo(() => (styleSet ? undefined : createAdaptiveCardsStyleSet(patchedStyleOptions)), [
-    patchedStyleOptions
+    patchedStyleOptions,
+    styleSet
   ]);
 
   return {

--- a/packages/bundle/src/useComposerProps.js
+++ b/packages/bundle/src/useComposerProps.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { concatMiddleware } from 'botframework-webchat-component';
+import { concatMiddleware, defaultStyleOptions } from 'botframework-webchat-component';
 import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardsAttachmentMiddleware';
 import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
 import defaultRenderMarkdown from './renderMarkdown';
@@ -11,14 +11,16 @@ export default function useComposerProps({ attachmentMiddleware, renderMarkdown,
     [attachmentMiddleware]
   );
 
+  const patchedStyleOptions = useMemo(() => ({ ...defaultStyleOptions, ...styleOptions }), [styleOptions]);
+
   // When styleSet is not specified, the styleOptions will be used to create Adaptive Cards styleSet and merged into useStyleSet.
-  const extraStyleSet = useMemo(() => (styleSet ? undefined : createAdaptiveCardsStyleSet(styleOptions)), [
-    styleOptions
+  const extraStyleSet = useMemo(() => (styleSet ? undefined : createAdaptiveCardsStyleSet(patchedStyleOptions)), [
+    patchedStyleOptions
   ]);
 
   return {
     attachmentMiddleware: patchedAttachmentMiddleware,
     extraStyleSet,
-    renderMarkdown: renderMarkdown || (text => defaultRenderMarkdown(text, styleOptions))
+    renderMarkdown: renderMarkdown || (text => defaultRenderMarkdown(text, patchedStyleOptions))
   };
 }

--- a/packages/bundle/src/useComposerProps.js
+++ b/packages/bundle/src/useComposerProps.js
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { concatMiddleware } from 'botframework-webchat-component';
+import createAdaptiveCardsAttachmentMiddleware from './adaptiveCards/createAdaptiveCardsAttachmentMiddleware';
+import createAdaptiveCardsStyleSet from './adaptiveCards/Styles/createAdaptiveCardsStyleSet';
+import defaultRenderMarkdown from './renderMarkdown';
+
+export default function useComposerProps({ attachmentMiddleware, renderMarkdown, styleOptions, styleSet }) {
+  const patchedAttachmentMiddleware = useMemo(
+    () => concatMiddleware(attachmentMiddleware, createAdaptiveCardsAttachmentMiddleware()),
+    [attachmentMiddleware]
+  );
+
+  // When styleSet is not specified, the styleOptions will be used to create Adaptive Cards styleSet and merged into useStyleSet.
+  const extraStyleSet = useMemo(() => (styleSet ? undefined : createAdaptiveCardsStyleSet(styleOptions)), [
+    styleOptions
+  ]);
+
+  return {
+    attachmentMiddleware: patchedAttachmentMiddleware,
+    extraStyleSet,
+    renderMarkdown: renderMarkdown || (text => defaultRenderMarkdown(text, styleOptions))
+  };
+}

--- a/packages/component/src/BasicWebChat.js
+++ b/packages/component/src/BasicWebChat.js
@@ -127,12 +127,14 @@ export default class BasicWebChat extends React.Component {
 }
 
 BasicWebChat.defaultProps = {
+  ...Composer.defaultProps,
   activityMiddleware: undefined,
   attachmentMiddleware: undefined,
   className: ''
 };
 
 BasicWebChat.propTypes = {
+  ...Composer.propTypes,
   activityMiddleware: PropTypes.func,
   attachmentMiddleware: PropTypes.func,
   className: PropTypes.string

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -112,33 +112,9 @@ function createFocusSendBoxContext({ sendBoxRef }) {
   };
 }
 
-// TODO: [P3] Take this deprecation code out when releasing on or after 2019 December 11
-function patchStyleOptionsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }) {
-  let patchedStyleOptions = { ...styleOptions };
-
-  if (botAvatarInitials) {
-    patchedStyleOptions = { ...patchedStyleOptions, botAvatarInitials };
-
-    console.warn(
-      'Web Chat: "botAvatarInitials" is deprecated. Please use "styleOptions.botAvatarInitials" instead. "botAvatarInitials" will be removed on or after December 11 2019 .'
-    );
-  }
-
-  if (userAvatarInitials) {
-    patchedStyleOptions = { ...patchedStyleOptions, userAvatarInitials };
-
-    console.warn(
-      'Web Chat: "botAvatarInitials" is deprecated. Please use "styleOptions.botAvatarInitials" instead. "botAvatarInitials" will be removed on or after December 11 2019 .'
-    );
-  }
-
-  return patchedStyleOptions;
-}
-
 const Composer = ({
   activityRenderer,
   attachmentRenderer,
-  botAvatarInitials,
   cardActionMiddleware,
   children,
   directLine,
@@ -156,7 +132,6 @@ const Composer = ({
   sendTypingIndicator,
   styleOptions,
   styleSet,
-  userAvatarInitials,
   userID,
   username,
   webSpeechPonyfillFactory
@@ -177,11 +152,6 @@ const Composer = ({
 
     return sendTyping;
   }, [sendTyping, sendTypingIndicator]);
-
-  const patchedStyleOptions = useMemo(
-    () => patchStyleOptionsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }),
-    [botAvatarInitials, styleOptions, userAvatarInitials]
-  );
 
   useEffect(() => {
     dispatch(setLanguage(locale));
@@ -223,8 +193,8 @@ const Composer = ({
   const focusSendBoxContext = useMemo(() => createFocusSendBoxContext({ sendBoxRef }), [sendBoxRef]);
 
   const patchedStyleSet = useMemo(
-    () => styleSetToClassNames({ ...(styleSet || createStyleSet(patchedStyleOptions)), ...extraStyleSet }),
-    [extraStyleSet, patchedStyleOptions, styleSet]
+    () => styleSetToClassNames({ ...(styleSet || createStyleSet(styleOptions)), ...extraStyleSet }),
+    [extraStyleSet, styleOptions, styleSet]
   );
 
   const hoistedDispatchers = useMemo(
@@ -265,7 +235,7 @@ const Composer = ({
       sendBoxRef,
       sendTimeout,
       sendTypingIndicator: patchedSendTypingIndicator,
-      styleOptions: patchedStyleOptions,
+      styleOptions,
       styleSet: patchedStyleSet,
       userID,
       username,
@@ -283,12 +253,12 @@ const Composer = ({
       patchedGrammars,
       patchedSelectVoice,
       patchedSendTypingIndicator,
-      patchedStyleOptions,
       patchedStyleSet,
       renderMarkdown,
       scrollToEnd,
       sendBoxRef,
       sendTimeout,
+      styleOptions,
       userID,
       username,
       webSpeechPonyfill
@@ -336,7 +306,6 @@ export default ComposeWithStore;
 Composer.defaultProps = {
   activityRenderer: undefined,
   attachmentRenderer: undefined,
-  botAvatarInitials: undefined,
   cardActionMiddleware: undefined,
   children: undefined,
   disabled: false,
@@ -352,7 +321,6 @@ Composer.defaultProps = {
   sendTypingIndicator: false,
   styleOptions: {},
   styleSet: undefined,
-  userAvatarInitials: undefined,
   userID: '',
   username: '',
   webSpeechPonyfillFactory: undefined
@@ -361,7 +329,6 @@ Composer.defaultProps = {
 Composer.propTypes = {
   activityRenderer: PropTypes.func,
   attachmentRenderer: PropTypes.func,
-  botAvatarInitials: PropTypes.string,
   cardActionMiddleware: PropTypes.func,
   children: PropTypes.any,
   directLine: PropTypes.shape({
@@ -393,7 +360,6 @@ Composer.propTypes = {
   sendTypingIndicator: PropTypes.bool,
   styleOptions: PropTypes.any,
   styleSet: PropTypes.any,
-  userAvatarInitials: PropTypes.string,
   userID: PropTypes.string,
   username: PropTypes.string,
   webSpeechPonyfillFactory: PropTypes.func

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -3,8 +3,8 @@ import {
   FunctionContext as ScrollToBottomFunctionContext
 } from 'react-scroll-to-bottom';
 
-import { Provider } from 'react-redux';
 import { css } from 'glamor';
+import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import useReferenceGrammarID from './hooks/useReferenceGrammarID';
@@ -113,13 +113,11 @@ function createFocusSendBoxContext({ sendBoxRef }) {
 }
 
 // TODO: [P3] Take this deprecation code out when releasing on or after 2019 December 11
-function patchPropsForAvatarInitials({ botAvatarInitials, userAvatarInitials, ...props }) {
-  // This code will take out "botAvatarInitials" and "userAvatarInitials" from props
-
-  let { styleOptions } = props;
+function patchStyleOptionsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }) {
+  let patchedStyleOptions = { ...styleOptions };
 
   if (botAvatarInitials) {
-    styleOptions = { ...styleOptions, botAvatarInitials };
+    patchedStyleOptions = { ...patchedStyleOptions, botAvatarInitials };
 
     console.warn(
       'Web Chat: "botAvatarInitials" is deprecated. Please use "styleOptions.botAvatarInitials" instead. "botAvatarInitials" will be removed on or after December 11 2019 .'
@@ -127,17 +125,14 @@ function patchPropsForAvatarInitials({ botAvatarInitials, userAvatarInitials, ..
   }
 
   if (userAvatarInitials) {
-    styleOptions = { ...styleOptions, userAvatarInitials };
+    patchedStyleOptions = { ...patchedStyleOptions, userAvatarInitials };
 
     console.warn(
       'Web Chat: "botAvatarInitials" is deprecated. Please use "styleOptions.botAvatarInitials" instead. "botAvatarInitials" will be removed on or after December 11 2019 .'
     );
   }
 
-  return {
-    ...props,
-    styleOptions
-  };
+  return patchedStyleOptions;
 }
 
 const Composer = ({
@@ -148,6 +143,7 @@ const Composer = ({
   children,
   directLine,
   disabled,
+  extraStyleSet,
   grammars,
   groupTimestamp,
   locale,
@@ -183,7 +179,7 @@ const Composer = ({
   }, [sendTyping, sendTypingIndicator]);
 
   const patchedStyleOptions = useMemo(
-    () => patchPropsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }),
+    () => patchStyleOptionsForAvatarInitials({ botAvatarInitials, styleOptions, userAvatarInitials }),
     [botAvatarInitials, styleOptions, userAvatarInitials]
   );
 
@@ -226,10 +222,10 @@ const Composer = ({
 
   const focusSendBoxContext = useMemo(() => createFocusSendBoxContext({ sendBoxRef }), [sendBoxRef]);
 
-  const patchedStyleSet = useMemo(() => styleSetToClassNames(styleSet || createStyleSet(patchedStyleOptions)), [
-    patchedStyleOptions,
-    styleSet
-  ]);
+  const patchedStyleSet = useMemo(
+    () => styleSetToClassNames({ ...(styleSet || createStyleSet(patchedStyleOptions)), ...extraStyleSet }),
+    [createStyleSet, extraStyleSet, patchedStyleOptions, styleSet]
+  );
 
   const hoistedDispatchers = useMemo(
     () => mapMap(DISPATCHERS, dispatcher => (...args) => dispatch(dispatcher(...args))),
@@ -344,10 +340,11 @@ Composer.defaultProps = {
   cardActionMiddleware: undefined,
   children: undefined,
   disabled: false,
+  extraStyleSet: undefined,
   grammars: [],
   groupTimestamp: true,
   locale: window.navigator.language || 'en-US',
-  renderMarkdown: text => text,
+  renderMarkdown: undefined,
   selectVoice: undefined,
   sendBoxRef: undefined,
   sendTimeout: 20000,
@@ -381,6 +378,7 @@ Composer.propTypes = {
     token: PropTypes.string
   }).isRequired,
   disabled: PropTypes.bool,
+  extraStyleSet: PropTypes.any,
   grammars: PropTypes.arrayOf(PropTypes.string),
   groupTimestamp: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   locale: PropTypes.string,

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -224,7 +224,7 @@ const Composer = ({
 
   const patchedStyleSet = useMemo(
     () => styleSetToClassNames({ ...(styleSet || createStyleSet(patchedStyleOptions)), ...extraStyleSet }),
-    [createStyleSet, extraStyleSet, patchedStyleOptions, styleSet]
+    [extraStyleSet, patchedStyleOptions, styleSet]
   );
 
   const hoistedDispatchers = useMemo(

--- a/packages/component/src/hooks/useRenderMarkdownAsHTML.js
+++ b/packages/component/src/hooks/useRenderMarkdownAsHTML.js
@@ -1,7 +1,11 @@
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 
+import useStyleOptions from '../hooks/useStyleOptions';
 import WebChatUIContext from '../WebChatUIContext';
 
 export default function useRenderMarkdownAsHTML() {
-  return useContext(WebChatUIContext).renderMarkdown;
+  const { renderMarkdown } = useContext(WebChatUIContext);
+  const styleOptions = useStyleOptions();
+
+  return useCallback(markdown => renderMarkdown(markdown, styleOptions), [renderMarkdown, styleOptions]);
 }


### PR DESCRIPTION
## Changelog Entry

-  Adds `AdaptiveCardsComposer` and `AdaptiveCardsContext` for composability for Adaptive Cards, by [@compulim](https://github.com/compulim), in PR [#2648](https://github.com/microsoft/BotFramework-WebChat/pull/2648)

## Description

Today, we support UI recomposition, but not with Adaptive Cards. This is because we only expose a minimal `<Composer>` but not a full version which include Adaptive Cards support.

This PR will add UI composability for activities with Adaptive Cards. This is required for our "Smart Display" sample, which will be submitted later.

Goal: we will add a new `<Composer>` with enhancements specific for Adaptive Cards.

## Specific Changes

- Add internal `AdaptiveCardsComposer` and `AdaptiveCardsContext`, which store Adaptive Cards specific content
- When loading a full-bundle
   - Enhance `Composer` with `FullComposer`, which enhance by adding Adaptive Cards specific content, and load additional style set dedicated for Adaptive Cards
   - Enhance `createStyleSet` with `createFullStyleSet`, which enhance by adding Adaptive Cards specific styles
- Propagate `defaultProps` and `propTypes` from minimal `Composer` and `BasicWebChat`
- Default `renderMarkdown` to `undefined` instead of `text => text`

---

-  [ ] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
