### PR TITLE
fix(#2655): Race condition in activity status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,8 +212,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2710](https://github.com/microsoft/BotFramework-WebChat/issues/2710). Suggested actions container should persist for AT, by [@corinagum](https://github.com/corinagum) in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710)
 -  Fixes [#2718](https://github.com/microsoft/BotFramework-WebChat/issues/2718). Add `Object.is` polyfill for IE11, by [@compulim](https://github.com/compulim) in PR [#2719](https://github.com/microsoft/BotFramework-WebChat/pull/2719)
 -  Fixes [#2723](https://github.com/microsoft/BotFramework-WebChat/issues/2723). Fix `renderMarkdown` should not be called if it is `undefined` in minimal bundle, by [@compulim](https://github.com/compulim) in PR [#2724](https://github.com/microsoft/BotFramework-WebChat/pull/2724)
--  Fixes [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/XXX). Patched something, by [@johndoe](https://github.com/johndoe) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
--  Fixes [#2655](https://github.com/microsoft/BotFramework-WebChat/issues/2655). Fix Racecondition in connectivity status, by [@curiousite](https://github.com/Curiousite) in PR [#2656](https://github.com/microsoft/BotFramework-WebChat/pull/2656)
+-  Fixes [#2655](https://github.com/microsoft/BotFramework-WebChat/issues/2655). "Taking longer than usual to connect" should not show up after reconnect succeeded, by [@curiousite](https://github.com/Curiousite) and [@compulim](https://github.com/compulim) in PR [#2656](https://github.com/microsoft/BotFramework-WebChat/pull/2656)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,7 +198,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Resolves [#2620](https://github.com/microsoft/BotFramework-WebChat/issues/2620). Adds Chinese localization files, by [@spyip](https://github.com/spyip) in PR [#2631](https://github.com/microsoft/BotFramework-WebChat/pull/2631)
 -  Fixes [#2639](https://github.com/microsoft/BotFramework-WebChat/issues/2639). Fix passed in prop time from string to boolean, by [@corinagum](https://github.com/corinagum) in PR [#2640](https://github.com/microsoft/BotFramework-WebChat/pull/2640)
 -  `component`: Updated timer to use functional component, by [@spyip](https://github.com/spyip) in PR [#2546](https://github.com/microsoft/BotFramework-WebChat/pull/2546)
--  Fixes [#2651](https://github.com/microsoft/BotFramework-WebChat/issues/2651). Add `ends-with` string module to es5 bundle, by [@corinagum](https://github.com/corinagum) in PR [#2654](https://github.com/microsoft/BotFramework-WebChat/pull/2654)
+-  Fixes [#2651](https://github.com/microsoft/BotFramework-WebChat/issues/2651). Add `ends-with` string module to ES5 bundle, by [@corinagum](https://github.com/corinagum) in PR [#2654](https://github.com/microsoft/BotFramework-WebChat/pull/2654)
 -  Fixes [#2658](https://github.com/microsoft/BotFramework-WebChat/issues/2658). Fix rendering of markdown images in IE11, by [@corinagum](https://github.com/corinagum) in PR [#2659](https://github.com/microsoft/BotFramework-WebChat/pull/2659)
 -  Fixes [#2662](https://github.com/microsoft/BotFramework-WebChat/issues/2662) and [#2666](https://github.com/microsoft/BotFramework-WebChat/issues/2666). Fix various issues related to Direct Line Speech, by [@compulim](https://github.com/compulim) in PR [#2671](https://github.com/microsoft/BotFramework-WebChat/pull/2671)
    -  Added triple-buffering to reduce pops/cracks.
@@ -212,6 +212,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2710](https://github.com/microsoft/BotFramework-WebChat/issues/2710). Suggested actions container should persist for AT, by [@corinagum](https://github.com/corinagum) in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710)
 -  Fixes [#2718](https://github.com/microsoft/BotFramework-WebChat/issues/2718). Add `Object.is` polyfill for IE11, by [@compulim](https://github.com/compulim) in PR [#2719](https://github.com/microsoft/BotFramework-WebChat/pull/2719)
 -  Fixes [#2723](https://github.com/microsoft/BotFramework-WebChat/issues/2723). Fix `renderMarkdown` should not be called if it is `undefined` in minimal bundle, by [@compulim](https://github.com/compulim) in PR [#2724](https://github.com/microsoft/BotFramework-WebChat/pull/2724)
+-  Fixes [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/XXX). Patched something, by [@johndoe](https://github.com/johndoe) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#2655](https://github.com/microsoft/BotFramework-WebChat/issues/2655). Fix Racecondition in connectivity status, by [@curiousite](https://github.com/Curiousite) in PR [#2656](https://github.com/microsoft/BotFramework-WebChat/pull/2656)
 
 ### Changed
 

--- a/packages/core/src/__tests__/detectSlowConnectionSaga.spec.js
+++ b/packages/core/src/__tests__/detectSlowConnectionSaga.spec.js
@@ -1,0 +1,146 @@
+/* eslint no-magic-numbers: "off" */
+
+import { fork } from 'redux-saga/effects';
+import Observable from 'core-js/features/observable';
+
+import connectionStatusUpdateSaga from '../sagas/connectionStatusUpdateSaga';
+import connectivityStatus from '../reducers/connectivityStatus';
+import connectSaga from '../sagas/connectSaga';
+import detectSlowConnectionSaga from '../sagas/detectSlowConnectionSaga';
+
+import createSagaMiddleware from 'redux-saga';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+
+let connectionStatusObserver;
+let directLine;
+let store;
+
+function share(observable) {
+  const observers = [];
+  let subscription;
+
+  return new Observable(observer => {
+    observers.push(observer);
+
+    if (!subscription) {
+      subscription = observable.subscribe({
+        complete: () => observers.forEach(observer => observer.complete()),
+        error: err => observers.forEach(observer => observer.error(err)),
+        next: value => observers.forEach(observer => observer.next(value))
+      });
+    }
+
+    return () => {
+      const index = observers.indexOf(observer);
+
+      ~index && observers.splice(index, 1);
+
+      if (!observers.length) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+    };
+  });
+}
+
+beforeEach(() => {
+  const sagaMiddleware = createSagaMiddleware();
+
+  store = createStore(
+    combineReducers({
+      actionTypes: (actionTypes = [], { type }) =>
+        /^DIRECT_LINE\/(DIS|RE)?CONNECT/u.test(type)
+          ? // We are only interested in CONNECT_*, RECONNECT_*, and DISCONNECT_* actions.
+            [...actionTypes, type]
+          : actionTypes,
+      connectivityStatus
+    }),
+    applyMiddleware(sagaMiddleware)
+  );
+
+  sagaMiddleware.run(function*() {
+    yield fork(connectSaga);
+    yield fork(connectionStatusUpdateSaga);
+    yield fork(detectSlowConnectionSaga);
+  });
+
+  directLine = {
+    activity$: new Observable(() => () => 0),
+    connectionStatus$: share(
+      new Observable(observer => {
+        connectionStatusObserver = observer;
+        observer.next(0);
+      })
+    ),
+    end: () => 0,
+    postActivity: () =>
+      new Observable(observer => {
+        observer.next({ id: '' });
+      })
+  };
+});
+
+jest.setTimeout(2000);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// This test verify the code will not regress bug #2655.
+test('Race condition between connect slow and connect', async () => {
+  store.dispatch({
+    type: 'DIRECT_LINE/CONNECT',
+    payload: { directLine }
+  });
+
+  // This line is critical.
+  await 0;
+
+  connectionStatusObserver.next(1);
+
+  // This line is critical.
+  await 0;
+
+  connectionStatusObserver.next(2);
+
+  // This line is critical.
+  await 0;
+
+  connectionStatusObserver.next(1);
+
+  // This line is critical.
+  await 0;
+
+  expect(store.getState().actionTypes).toEqual([
+    'DIRECT_LINE/CONNECT',
+    'DIRECT_LINE/CONNECT_PENDING',
+    'DIRECT_LINE/CONNECT_FULFILLING',
+    'DIRECT_LINE/CONNECT_FULFILLED',
+    'DIRECT_LINE/RECONNECT_PENDING'
+  ]);
+
+  // We have a bug that we ignored RECONNECT_FULFILLED in detectSlowConnectionSaga.js.
+  // Thus, after 15s passed, although it say it is connected, it turn back to "connecting slow".
+  connectionStatusObserver.next(2);
+  jest.advanceTimersByTime(15000);
+
+  // This line is critical.
+  await 0;
+
+  // We want to make sure, 15s after reconnecting, the status don't change to "connecting slow".
+  expect(store.getState().actionTypes).toEqual([
+    'DIRECT_LINE/CONNECT',
+    'DIRECT_LINE/CONNECT_PENDING',
+    'DIRECT_LINE/CONNECT_FULFILLING',
+    'DIRECT_LINE/CONNECT_FULFILLED',
+    'DIRECT_LINE/RECONNECT_PENDING',
+    'DIRECT_LINE/RECONNECT_FULFILLING',
+    'DIRECT_LINE/RECONNECT_FULFILLED'
+  ]);
+
+  expect(store.getState().connectivityStatus).toBe('reconnected');
+});

--- a/packages/core/src/reducers/connectivityStatus.js
+++ b/packages/core/src/reducers/connectivityStatus.js
@@ -31,7 +31,7 @@ export default function connectivityStatus(state = DEFAULT_STATE, { type, meta }
         break;
 
       case CONNECT_STILL_PENDING:
-        if (state === 'reconnecting') {
+        if (state === 'reconnecting' || state === DEFAULT_STATE) {
           state = 'connectingslow';
         }
         break;

--- a/packages/core/src/reducers/connectivityStatus.js
+++ b/packages/core/src/reducers/connectivityStatus.js
@@ -31,9 +31,7 @@ export default function connectivityStatus(state = DEFAULT_STATE, { type, meta }
         break;
 
       case CONNECT_STILL_PENDING:
-        if (state === 'reconnecting' || state === DEFAULT_STATE) {
-          state = 'connectingslow';
-        }
+        state = 'connectingslow';
         break;
 
       case DISCONNECT_FULFILLED:

--- a/packages/core/src/reducers/connectivityStatus.js
+++ b/packages/core/src/reducers/connectivityStatus.js
@@ -31,7 +31,9 @@ export default function connectivityStatus(state = DEFAULT_STATE, { type, meta }
         break;
 
       case CONNECT_STILL_PENDING:
-        state = 'connectingslow';
+        if (state === 'reconnecting') {
+          state = 'connectingslow';
+        }
         break;
 
       case DISCONNECT_FULFILLED:

--- a/packages/core/src/sagas/detectSlowConnectionSaga.js
+++ b/packages/core/src/sagas/detectSlowConnectionSaga.js
@@ -2,7 +2,7 @@ import { call, put, race, take } from 'redux-saga/effects';
 
 import { CONNECT_FULFILLED, CONNECT_PENDING, CONNECT_REJECTED, CONNECT_STILL_PENDING } from '../actions/connect';
 
-import { RECONNECT_PENDING } from '../actions/reconnect';
+import { RECONNECT_FULFILLED, RECONNECT_PENDING, RECONNECT_REJECTED } from '../actions/reconnect';
 import sleep from '../utils/sleep';
 
 const SLOW_CONNECTION_AFTER = 15000;
@@ -12,8 +12,8 @@ export default function* detectSlowConnectionSaga() {
     yield take([CONNECT_PENDING, RECONNECT_PENDING]);
 
     const connectivityRace = yield race({
-      fulfilled: take(CONNECT_FULFILLED),
-      rejected: take(CONNECT_REJECTED),
+      fulfilled: take([CONNECT_FULFILLED, RECONNECT_FULFILLED]),
+      rejected: take([CONNECT_REJECTED, RECONNECT_REJECTED]),
       slow: call(() => sleep(SLOW_CONNECTION_AFTER))
     });
 


### PR DESCRIPTION
## Changelog Entry

### Fixed

-  Fixes [#2655](https://github.com/microsoft/BotFramework-WebChat/issues/2655). "Taking longer than usual to connect" should not show up after reconnect succeeded, by [@curiousite](https://github.com/Curiousite) and [@compulim](https://github.com/compulim) in PR [#2656](https://github.com/microsoft/BotFramework-WebChat/pull/2656)

## Description
Added check to prevent race-condition in activity status. 
 <!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
Now state will only transfer to "connectingslow" if the previous state is "reconnecting". 
 <!-- Please list the changes in a concise manner. -->

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
