### PR TITLE
Fix version is not showing up in Direct Line Speech adapter

### DIFF
--- a/packages/directlinespeech/.babelrc.js
+++ b/packages/directlinespeech/.babelrc.js
@@ -7,7 +7,7 @@ const CONFIG = {
     [
       'babel-plugin-transform-inline-environment-variables',
       {
-        include: ['NPM_PACKAGE_VERSION']
+        include: ['npm_package_version']
       }
     ]
   ],


### PR DESCRIPTION
## Description

Fix build script problem that version is not showing up when using Direct Line Speech adapter.

## Specific Changes

- Update `package/directlinespeech/.babelrc` to use `npm_package_version` (lowercase)

---

-  [x] Testing Added
   -  No tests were added for build scripts
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
