### PR TITLE
Add Object.is polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2700](https://github.com/microsoft/BotFramework-WebChat/issues/2700). Enable `<SayComposer>` and Adaptive Cards in recompose story, in PR [#2649](https://github.com/microsoft/BotFramework-WebChat/pull/2649)
    -  Moved `<SayComposer>` from `<BasicTranscript>` to `<Composer>`
    -  Moved WebSpeechPonyfill patching code from `<BasicTranscript>` to `<Composer>`
--  Fixes [#2699](https://github.com/microsoft/BotFramework-WebChat/issues/2699). Disable speech recognition and synthesis when using Direct Line Speech under IE11, in PR [#2649](https://github.com/microsoft/BotFramework-WebChat/pull/2649)
--  Fixes [#2709](https://github.com/microsoft/BotFramework-WebChat/issues/2709). Reduce wasted render of activities by memoizing partial result of `<BasicTranscript>`, in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710)
--  Fixes [#2710](https://github.com/microsoft/BotFramework-WebChat/issues/2710). Suggested actions container should persist for AT, by [@corinagum](https://github.com/corinagum) in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710
+-  Fixes [#2699](https://github.com/microsoft/BotFramework-WebChat/issues/2699). Disable speech recognition and synthesis when using Direct Line Speech under IE11, by [@compulim](https://github.com/compulim), in PR [#2649](https://github.com/microsoft/BotFramework-WebChat/pull/2649)
+-  Fixes [#2709](https://github.com/microsoft/BotFramework-WebChat/issues/2709). Reduce wasted render of activities by memoizing partial result of `<BasicTranscript>`, by [@compulim](https://github.com/compulim) in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710)
+-  Fixes [#2710](https://github.com/microsoft/BotFramework-WebChat/issues/2710). Suggested actions container should persist for AT, by [@corinagum](https://github.com/corinagum) in PR [#2710](https://github.com/microsoft/BotFramework-WebChat/pull/2710)
+-  Fixes [#2718](https://github.com/microsoft/BotFramework-WebChat/issues/2718). Add `Object.is` polyfill for IE11, by [@compulim](https://github.com/compulim) in PR [#2719](https://github.com/microsoft/BotFramework-WebChat/pull/2719)
 
 ### Changed
 

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -13,6 +13,7 @@ import 'core-js/features/dom-collections';
 import 'core-js/features/math/sign';
 import 'core-js/features/number/is-finite';
 import 'core-js/features/object/assign';
+import 'core-js/features/object/is';
 import 'core-js/features/object/values';
 import 'core-js/features/promise';
 import 'core-js/features/promise/finally';


### PR DESCRIPTION
> Fixes #2718.

## Changelog Entry

### Fixed

-  Fixes [#2718](https://github.com/microsoft/BotFramework-WebChat/issues/2718). Add `Object.is` polyfill for IE11, by [@compulim](https://github.com/compulim) in PR [#2719](https://github.com/microsoft/BotFramework-WebChat/pull/2719)

## Description

Usage of `Object.is` was added in #2710 but the polyfill for ES5 browsers was not added.

## Specific Changes

- Add `corejs/features/object/is` to ES5 bundle

---

-  [x] Testing Added
   - Manual test steps
   1. Load ES5 bundle in IE11, the UI should show up
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
