### PR TITLE
Bump Smart Display sample to 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Samples
+
+-  Bump samples to Web Chat 4.7.0, by [@compulim](https://github.com/compulim) in PR [#2726](https://github.com/Microsoft/BotFramework-WebChat/issues/2726)
+
+## [4.7.0] - 2019-12-12
+
 ### Breaking changes
 
 -  `adaptiveCardHostConfig` is being renamed to `adaptiveCardsHostConfig`

--- a/samples/13.b.customization-smart-display/package-lock.json
+++ b/samples/13.b.customization-smart-display/package-lock.json
@@ -1205,6 +1205,63 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -1384,9 +1441,9 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
     },
     "@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "12.12.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
+      "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -1735,20 +1792,15 @@
         "acorn-walk": "^6.0.1"
       }
     },
-    "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
-    },
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
     },
     "adaptivecards": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0.tgz",
-      "integrity": "sha512-rfB3dr2/yNMgJHiGCFH247RtLXkKcNwhGbI1GrXSITfyqfo12esTWDLkRLe62b0oGZxPKJZo5187BY9xORZYsg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.3.tgz",
+      "integrity": "sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g=="
     },
     "address": {
       "version": "1.1.2",
@@ -2608,19 +2660,6 @@
         "rxjs": "^5.0.3"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-        },
         "rxjs": {
           "version": "5.5.12",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
@@ -2636,42 +2675,85 @@
         }
       }
     },
-    "botframework-webchat": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/botframework-webchat/-/botframework-webchat-4.6.0.tgz",
-      "integrity": "sha512-oj1tL50gbsqfcG3gKyfqTO3bAxWTW0jTMym/PnYgaDAx4j3wNbfEtzKvTZWfDuZBPqGi7wu+gFHnVSApEjIPwQ==",
+    "botframework-directlinespeech-sdk": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/botframework-directlinespeech-sdk/-/botframework-directlinespeech-sdk-4.7.0.tgz",
+      "integrity": "sha512-OOrPd47z7gMz2TonyG+L5y8cLSLcRED4y1+c7NmIS3YzAf0D9pAuT19qiWT1MmGM8EIacWs0hiucyoqopZl7Xw==",
       "requires": {
-        "@babel/runtime": "^7.5.4",
-        "adaptivecards": "1.2.0",
+        "@babel/runtime": "^7.6.2",
+        "base64-arraybuffer": "^0.2.0",
+        "event-as-promise": "^1.0.5",
+        "math-random": "^1.0.4",
+        "microsoft-cognitiveservices-speech-sdk": "^1.8.1",
+        "web-speech-cognitive-services": "^6.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "microsoft-cognitiveservices-speech-sdk": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.8.1.tgz",
+          "integrity": "sha512-sXP43LjW+twcz5SZs8i6vg9r2QK6XidArVAQybb4bmNMv+t/U8Dj1CKoy/l83Db0JLdDiU3zXYs+znILAqnn9g==",
+          "requires": {
+            "asn1.js-rfc2560": "^5.0.0",
+            "asn1.js-rfc5280": "^3.0.0",
+            "https-proxy-agent": "^3.0.0",
+            "simple-lru-cache": "0.0.2",
+            "ws": "^7.1.1"
+          }
+        },
+        "ws": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+          "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
+          "requires": {
+            "async-limiter": "^1.0.0"
+          }
+        }
+      }
+    },
+    "botframework-webchat": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/botframework-webchat/-/botframework-webchat-4.7.0.tgz",
+      "integrity": "sha512-IVX7IdltteMaukZAeFGbJaHsDoyYzCr+E86yDCyfLqeSIkOMvxqyck6DnZhOor2ZL6u86IILuJCgl0f6n52brg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "adaptivecards": "1.2.3",
         "botframework-directlinejs": "^0.11.6",
-        "botframework-webchat-component": "4.6.0",
-        "botframework-webchat-core": "4.6.0",
-        "core-js": "^3.1.4",
-        "eslint": "^5.16.0",
-        "markdown-it": "^8.4.2",
+        "botframework-directlinespeech-sdk": "4.7.0",
+        "botframework-webchat-component": "4.7.0",
+        "botframework-webchat-core": "4.7.0",
+        "core-js": "^3.3.6",
+        "markdown-it": "^10.0.0",
         "markdown-it-for-inline": "^0.1.1",
-        "memoize-one": "^5.0.2",
+        "memoize-one": "^5.1.1",
         "microsoft-cognitiveservices-speech-sdk": "1.6.0",
         "microsoft-speech-browser-sdk": "^0.0.12",
         "prop-types": "^15.7.2",
         "sanitize-html": "^1.19.0",
-        "url-search-params-polyfill": "^5.0.0",
-        "web-speech-cognitive-services": "5.0.1",
+        "url-search-params-polyfill": "^7.0.0",
+        "web-speech-cognitive-services": "^6.0.0",
         "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
         },
         "core-js": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
-          "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg=="
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+          "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
         },
         "prop-types": {
           "version": "15.7.2",
@@ -2682,79 +2764,36 @@
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
           }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
     "botframework-webchat-component": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/botframework-webchat-component/-/botframework-webchat-component-4.6.0.tgz",
-      "integrity": "sha512-aVNauZKdCmCJNf4lXotdYnJZoRZomT+ELsdSP3ThtL9w2hPI8THQtsEpgL9A0Kj1vui2Oqtg+bOx22rnllVeNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/botframework-webchat-component/-/botframework-webchat-component-4.7.0.tgz",
+      "integrity": "sha512-sNb0I/NlmiGkGejgc4RpO0I7mTyoZr7LEL+KEPIi8PCBHzaErzzl+bBqknRb1E1MvMLA+kzdBYNzizaQ7Lok9Q==",
       "requires": {
-        "botframework-webchat-core": "4.6.0",
-        "bytes": "^3.0.0",
+        "botframework-webchat-core": "4.7.0",
+        "bytes": "^3.1.0",
         "classnames": "^2.2.6",
-        "eslint": "^5.16.0",
-        "eslint-plugin-react": "^7.13.0",
         "glamor": "^2.20.40",
-        "memoize-one": "^5.0.2",
+        "memoize-one": "^5.1.1",
         "prop-types": "^15.7.2",
-        "react-dictate-button": "^1.1.3",
+        "react-dictate-button": "^1.2.1",
         "react-film": "^1.3.0",
-        "react-redux": "^7.1.0",
-        "react-say": "^1.2.0",
+        "react-redux": "^7.1.1",
+        "react-say": "^2.0.0",
         "react-scroll-to-bottom": "~1.3.2",
         "redux": "^4.0.4",
-        "remark": "^10.0.1",
-        "sanitize-html": "^1.18.2",
-        "simple-update-in": "^1.3.0",
-        "strip-markdown": "^3.0.4"
+        "remark": "10.0.1",
+        "sanitize-html": "^1.20.1",
+        "simple-update-in": "^2.1.1",
+        "strip-markdown": "3.0.4"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "eslint-plugin-react": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
-          "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
-          "requires": {
-            "array-includes": "^3.0.3",
-            "doctrine": "^2.1.0",
-            "has": "^1.0.3",
-            "jsx-ast-utils": "^2.2.1",
-            "object.entries": "^1.1.0",
-            "object.fromentries": "^2.0.0",
-            "object.values": "^1.1.0",
-            "prop-types": "^15.7.2",
-            "resolve": "^1.12.0"
-          }
-        },
-        "jsx-ast-utils": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
-          "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
-          "requires": {
-            "array-includes": "^3.0.3",
-            "object.assign": "^4.1.0"
-          }
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
         "prop-types": {
           "version": "15.7.2",
@@ -2764,62 +2803,28 @@
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
-          }
-        },
-        "react-redux": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.3.tgz",
-          "integrity": "sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "hoist-non-react-statics": "^3.3.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.9.0"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.12.0",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-              "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "requires": {
-            "path-parse": "^1.0.6"
           }
         }
       }
     },
     "botframework-webchat-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/botframework-webchat-core/-/botframework-webchat-core-4.6.0.tgz",
-      "integrity": "sha512-q9vP4oLRuc9JM6nIUm6Iyh2USQrIpdX7NVwaIKxqoTB6RMu6wItPCGLgk5avnF5vgWe1ihJGMJlrnp1CUngURQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/botframework-webchat-core/-/botframework-webchat-core-4.7.0.tgz",
+      "integrity": "sha512-z3krhg5w/bcral5uEHo8LkhVzGu2/esB1si1vFe0FqgG8qav0pdqYEJcqQay6/NGZMTdlzoq814z4LhrE66ihQ==",
       "requires": {
-        "@babel/runtime": "^7.5.4",
-        "eslint": "^5.16.0",
-        "jsonwebtoken": "^8.3.0",
+        "@babel/runtime": "^7.6.3",
+        "jsonwebtoken": "^8.5.1",
         "math-random": "^1.0.4",
         "mime": "2.4.3",
         "redux": "^4.0.4",
-        "redux-saga": "^0.16.0",
-        "simple-update-in": "^1.3.0"
+        "redux-saga": "^1.1.1",
+        "simple-update-in": "^2.1.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -2828,11 +2833,6 @@
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
           "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -5017,70 +5017,6 @@
         }
       }
     },
-    "eslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.9.1",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.1",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
-        "js-yaml": "^3.13.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.11",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.2.3",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "import-fresh": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-        }
-      }
-    },
     "eslint-config-react-app": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz",
@@ -5439,28 +5375,10 @@
         "estraverse": "^4.1.1"
       }
     },
-    "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
-      "requires": {
-        "eslint-visitor-keys": "^1.0.0"
-      }
-    },
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
-    },
-    "espree": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
-      "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
-      }
     },
     "esprima": {
       "version": "4.0.1",
@@ -6623,9 +6541,9 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -6770,41 +6688,6 @@
       "requires": {
         "bowser": "^1.7.3",
         "css-in-js-utils": "^2.0.0"
-      }
-    },
-    "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
-      "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "internal-ip": {
@@ -8761,15 +8644,22 @@
       "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
     },
     "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "markdown-it-for-inline": {
@@ -8925,6 +8815,23 @@
         "ws": "^6.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -11146,9 +11053,9 @@
       }
     },
     "react-dictate-button": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.1.3.tgz",
-      "integrity": "sha512-4Od7sTAEIvPKpZbpy1tCv7qqfRNwLnZom9hrLnNvr1FIWjSOYC94ekAP8S5kevqnVaFvSqwFisCmjd3uLmvsrA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.2.1.tgz",
+      "integrity": "sha512-jabur/PWLgPCorXXmrTc4GnxTFCEhbNadL6lT5xTXdNkM1r7cow2RRI3z7YV+p+24fNbIO0DTTKUog+aTCm1Lg==",
       "requires": {
         "classnames": "^2.2.6",
         "glamor": "^2.20.40",
@@ -11156,9 +11063,9 @@
       },
       "dependencies": {
         "memoize-one": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
-          "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
         }
       }
     },
@@ -11237,29 +11144,23 @@
       }
     },
     "react-say": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-say/-/react-say-1.2.0.tgz",
-      "integrity": "sha512-MVYakQuqAGqUJH9NPdcvIpaGcgSjG8VM4bqq9+qGTqlpu4U7hoNPKad7mzDHLhrRwJk8BHCAmN/Sijoo5ONExQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-say/-/react-say-2.0.0.tgz",
+      "integrity": "sha512-jHtvt5Q+v5W1iqnQROEF3DL20zZYqz319ZkcVgQyyLyx/1GZ4Nr3gXaGvf0JHBpp+/UcETdtFTgOEzpDCaOL6Q==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
+        "@babel/runtime": "^7.7.2",
         "classnames": "^2.2.6",
-        "event-as-promise": "^1.0.3",
-        "glamor": "^2.20.40",
-        "memoize-one": "^5.0.4"
+        "event-as-promise": "^1.0.5",
+        "memoize-one": "^5.1.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -11592,9 +11493,14 @@
       },
       "dependencies": {
         "memoize-one": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
-          "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+        },
+        "simple-update-in": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.4.0.tgz",
+          "integrity": "sha512-gb8cWM8KxvF0TbBSFagp0Bw13dk5HBjBVLx8N8pXg4CcVyLiEuu3xxYHLfFEZRn+bYjMCkxjEB8upbWmAVOIyQ=="
         }
       }
     },
@@ -11667,9 +11573,12 @@
       }
     },
     "redux-saga": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.2.tgz",
-      "integrity": "sha512-iIjKnRThI5sKPEASpUvySemjzwqwI13e3qP7oLub+FycCRDysLSAOwt958niZW6LhxfmS6Qm1BzbU70w/Koc4w=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "requires": {
+        "@redux-saga/core": "^1.1.3"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -12518,9 +12427,9 @@
       }
     },
     "simple-update-in": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-1.4.0.tgz",
-      "integrity": "sha512-gb8cWM8KxvF0TbBSFagp0Bw13dk5HBjBVLx8N8pXg4CcVyLiEuu3xxYHLfFEZRn+bYjMCkxjEB8upbWmAVOIyQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-2.1.1.tgz",
+      "integrity": "sha512-Iw4tMvOoibV6XqOqKgKgpMnFdgEtafhZv2KxNhHPAgXBtKrCTY6QFxMpvmSSuRHMK5uJ9hb6X+zniiTHVD7Sig=="
     },
     "sisteransi": {
       "version": "1.0.4",
@@ -13009,15 +12918,10 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
     "strip-markdown": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-3.1.1.tgz",
-      "integrity": "sha512-Q83C2WWWxASuJm7XuSqS9PGYQb8yTSxPtxE6bjCj/8kwuk4IY5qi9aEQkfyeqky0E5uCQpl1pDgOvQRh90FyMg=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-3.0.4.tgz",
+      "integrity": "sha512-O+0DAu96wofH82JPZN4RkGdi3Lruo0yveDCeXUg0uRNWztPcn/s1AD85584OYUsAcjW0qR4pBlh8OBl/hH4Erw=="
     },
     "style-loader": {
       "version": "1.0.0",
@@ -13405,6 +13309,27 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
+    },
     "ua-parser-js": {
       "version": "0.7.20",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
@@ -13690,9 +13615,9 @@
       }
     },
     "url-search-params-polyfill": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.1.0.tgz",
-      "integrity": "sha512-yjFY7uw2xRf9e8Mg4ZVkZwtp8dMCC4cbBkEIZiTDpuSY2WJ9+Quw0wRhxncv32qaMQwmBQT+P847rO8PrFhhDA=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz",
+      "integrity": "sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ=="
     },
     "use": {
       "version": "3.1.1",
@@ -13867,9 +13792,9 @@
       }
     },
     "web-speech-cognitive-services": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-5.0.1.tgz",
-      "integrity": "sha512-d+7DaeSr9JjOrJjWe7VY5IQ3KW12oisSt4Ou7kxn/xl9q1k2ogBF00kxhIMzMdUP4XMP2PsfpSb9VzFuL4mceQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-6.0.0.tgz",
+      "integrity": "sha512-JVsFybLP8XOV8cQNVhfa857jBPDCEngIY5y79tG07bq7iSQoU5t+pQWU9LXj0kXj9wZBa/TSO2mLqVVB+UjYTg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "base64-arraybuffer": "^0.2.0",
@@ -13879,26 +13804,6 @@
         "microsoft-cognitiveservices-speech-sdk": "1.6.0",
         "on-error-resume-next": "^1.1.0",
         "simple-update-in": "^2.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-          "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-        },
-        "simple-update-in": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/simple-update-in/-/simple-update-in-2.1.1.tgz",
-          "integrity": "sha512-Iw4tMvOoibV6XqOqKgKgpMnFdgEtafhZv2KxNhHPAgXBtKrCTY6QFxMpvmSSuRHMK5uJ9hb6X+zniiTHVD7Sig=="
-        }
       }
     },
     "webidl-conversions": {

--- a/samples/13.b.customization-smart-display/package.json
+++ b/samples/13.b.customization-smart-display/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://microsoft.github.io/BotFramework-WebChat/13.b.customization-smart-display/",
   "dependencies": {
-    "botframework-webchat": "^4.6.0",
+    "botframework-webchat": "^4.7.0",
     "classnames": "^2.2.6",
     "react": "16.8.6",
     "react-dom": "16.8.6",


### PR DESCRIPTION
## Changelog Entry

-  Bump samples to Web Chat 4.7.0, by [@compulim](https://github.com/compulim) in PR [#2726](https://github.com/Microsoft/BotFramework-WebChat/issues/2726)

## Description

Bumping to Web Chat 4.7.0 for one of our highlighted sample for Direct Line Speech.

## Specific Changes

- Bump to Web Chat 4.7.0 in sample `13.b.customization-smart-display`

---

-  [x] Testing Added
   -  No tests needed currently, we should write automated tests for every sample
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
