### PR TITLE
Set Web Chat 4.6.0 as the default version in Embed package

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -7,8 +7,8 @@
     },
     "4": {
       "redirects": [
-        ["feature:nextminor", "4.3"],
-        ["*", "4.3"]
+        ["feature:nextminor", "4.6"],
+        ["*", "4.6"]
       ]
     },
     "4.1": {


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Changelog Entry

 Set Webchat 4.6.0 as the default version in Embed package

## Description

Embed WebChat is still using 4.3.0 (default). Moving up this version to 4.6.0.
