### PR TITLE
Add 4.7.0 and 4.7.1 to embed servicing plan

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -106,6 +106,25 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.7": {
+      "redirects": [
+        ["*", "4.7.1"]
+      ]
+    },
+    "4.7.0": {
+      "assets": [
+        ["https://cdn.botframework.com/botframework-webchat/4.7.0/webchat-es5.js", "sha384-D+O/WIE8WCupSBNZr0o0vf13eHWXaAj/HJkS6PFUgWgaHhVcJKWiBt5xq1UE1URM"]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
+    "4.7.1": {
+      "assets": [
+        ["https://cdn.botframework.com/botframework-webchat/4.7.1/webchat-es5.js", "sha384-SLg/iz1Y+04Iie1JbZIc6ahBCa24SGjD5QHACU5r7iJgjmO7WBRpsy3j4rpEyFoT"]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "3": {
       "redirects": [
         ["*", "0.15.1-v3.748a85f"]


### PR DESCRIPTION
## Changelog Entry

No changelog for servicing plan bump.

## Description

This will add 4.7.0 and 4.7.1 to servicing plan. It will not enable them and not conflicting with #2733.

## Specific Changes

- Modify `servicingPlan.json` to add 4.7.0 and 4.7.1

---

-  [x] ~Testing Added~
   -  No tests added for bumping servicing plan
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
