### PR TITLE
Fix samples/index.html for IE11

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -2,37 +2,24 @@
 <html lang="en-US">
   <head>
     <title>Web Chat samples</title>
+    <script crossorigin="anonymous" src="https://unpkg.com/core-js@2/client/core.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/markdown-it/dist/markdown-it.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/whatwg-fetch"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>
     <script>
-      function loadScript(src) {
-        return new Promise((resolve, reject) => {
-          const element = document.createElement('script');
+      'use strict';
 
-          element.async = true;
-          element.onerror = reject;
-          element.onload = resolve;
-          element.src = src;
+      fetch('README.md')
+        .then(function (res) { return res.text(); })
+        .then(function (markdown) {
+          const element = document.createElement('div');
 
-          document.head.appendChild(element);
+          element.innerHTML = window.markdownit().render(markdown);
+          document.body.appendChild(element);
         });
-      }
-
-      (async function() {
-        'use strict';
-
-        const [markdown] = await Promise.all([
-          fetch('README.md').then(res => res.text()),
-          loadScript('https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.4.2/markdown-it.min.js')
-        ]);
-
-        const element = document.createElement('div');
-
-        element.innerHTML = window.markdownit().render(markdown);
-        document.body.appendChild(element);
-      })().catch(err => console.error(err));
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Changelog Entry

No changelog because this is doc work.

## Description

This will enable IE11 users on https://microsoft.github.io/BotFramework-WebChat.

## Specific Changes

Updated `/samples/index.html` to render correctly under IE11.

---

# Manual testing

In IE11, browse to `/samples/`. It should see the README.md rendered in HTML.