### PR TITLE
Added tel protocol to allowedSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Fixes [#2737](https://github.com/microsoft/BotFramework-WebChat/issues/2737). Use `driver.wait` for conditions
    - Fixes [#2776](https://github.com/microsoft/BotFramework-WebChat/issues/2776). Wait until button is shown/hid before taking screenshot
    - Use a new timeout `fetchImage` for images
+-  Fixes [#2780](https://github.com/microsoft/BotFramework-WebChat/issues/2780). Added the `tel` protocol to the `allowedSchema` in the `sanitize-html` options, by [@tdurnford](https://github.com/tdurnford) in PR [#27XX](https://github.com/microsoft/BotFramework-WebChat/pull/27XX)
 
 ### Changed
 

--- a/packages/bundle/src/__tests__/renderMarkdown.spec.js
+++ b/packages/bundle/src/__tests__/renderMarkdown.spec.js
@@ -49,4 +49,11 @@ describe('renderMarkdown', () => {
       '<p><a href="sip:example@test.com" target="_blank">example@test.com</a></p>\n'
     );
   });
+
+  it('should render tel protocol links correctly', () => {
+    const options = { markdownRespectCRLF: true };
+    expect(renderMarkdown(`[(505)503-4455](tel:505-503-4455)`, options)).toBe(
+      '<p><a href="tel:505-503-4455" target="_blank">(505)503-4455</a></p>\n'
+    );
+  });
 });

--- a/packages/bundle/src/renderMarkdown.js
+++ b/packages/bundle/src/renderMarkdown.js
@@ -9,7 +9,7 @@ const SANITIZE_HTML_OPTIONS = {
     a: ['href', 'name', 'target', 'title'],
     img: ['alt', 'src']
   },
-  allowedSchemes: ['data', 'http', 'https', 'ftp', 'mailto', 'sip'],
+  allowedSchemes: ['data', 'http', 'https', 'ftp', 'mailto', 'sip', 'tel'],
   allowedTags: [
     'a',
     'b',


### PR DESCRIPTION
Fixes #2780
## Changelog Entry

Fixes [#2780](https://github.com/microsoft/BotFramework-WebChat/issues/2780). Added the `tel` protocol to the `allowedSchema` in the `sanitize-html` options, by [@tdurnford](https://github.com/tdurnford) in PR [#27XX](https://github.com/microsoft/BotFramework-WebChat/pull/27XX)

---

-  [X] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
