### PR TITLE
Pass aria labels as props to StackedLayout

### DIFF
--- a/packages/component/src/Activity/StackedLayout.js
+++ b/packages/component/src/Activity/StackedLayout.js
@@ -91,7 +91,8 @@ const StackedLayout = ({ activity, children, timestampClassName }) => {
     from: { role } = {},
     text,
     textFormat,
-    timestamp
+    timestamp,
+    ariaLabels = {}
   } = activity;
 
   const activityDisplayText = messageBackDisplayText || text;
@@ -100,16 +101,23 @@ const StackedLayout = ({ activity, children, timestampClassName }) => {
   const plainText = remarkStripMarkdown(text);
   const indented = fromUser ? bubbleFromUserNubSize : bubbleNubSize;
 
-  const botRoleLabel = useLocalize('BotSent');
-  const userRoleLabel = useLocalize('UserSent');
+  const defaultBotRoleLabel = useLocalize('BotSent');
+  const defaultUserRoleLabel = useLocalize('UserSent');
+
+  const botRoleLabel = ariaLabels.botRoleLabel || defaultBotRoleLabel;
+  const userRoleLabel = ariaLabels.userRoleLabel || defaultUserRoleLabel;
 
   const roleLabel = fromUser ? botRoleLabel : userRoleLabel;
 
-  const botAriaLabel = useLocalize('Bot said something', initials, plainText);
-  const userAriaLabel = useLocalize('User said something', initials, plainText);
-  const sentAtTimestamp = useLocalize('SentAt') + useLocalizeDate(timestamp);
+  const defaultBotAriaLabel = useLocalize('Bot said something', initials, plainText);
+  const defaultUserAriaLabel = useLocalize('User said something', initials, plainText);
+
+  const botAriaLabel = ariaLabels.botAriaLabel || defaultBotAriaLabel;
+  const userAriaLabel = ariaLabels.userAriaLabel || defaultUserAriaLabel;
 
   const someoneSaidString = (fromUser ? userAriaLabel : botAriaLabel).trim();
+
+  const sentAtTimestamp = useLocalize('SentAt') + useLocalizeDate(timestamp);
 
   const ariaLabel = someoneSaidString + (someoneSaidString.endsWith('.') ? '' : '.') + ' ' + sentAtTimestamp;
 
@@ -182,7 +190,13 @@ StackedLayout.propTypes = {
     text: PropTypes.string,
     textFormat: PropTypes.string,
     timestamp: PropTypes.string,
-    type: PropTypes.string.isRequired
+    type: PropTypes.string.isRequired,
+    ariaLabels: PropTypes.shape({
+      botAriaLabel: PropTypes.string,
+      userAriaLabel: PropTypes.string,
+      botRoleLabel: PropTypes.string,
+      userRoleLabel: PropTypes.string
+    })
   }).isRequired,
   children: PropTypes.any,
   timestampClassName: PropTypes.string


### PR DESCRIPTION
Fixes #2820 

## Changelog Entry

 <!-- Please paste your new entry from CHANGELOG.MD here -->
Allows props to change aria labels to be passed down to StackedLayout component. We can then pass values through using `activityMiddleware`

## Description

 <!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
We needed a way to change the default aria-label announced by React WebChat on our app, as it begins each message with either "Bot says..." or "User says...", and "Bot says..." doesn't make sense to our screen reader users in the context of our application.

## Specific Changes

 <!-- Please list the changes in a concise manner. -->
Allows props to change aria labels to be passed down to StackedLayout component

---

-  [ ] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
