### PR TITLE
Add border radius style to SendBox styleSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Resolves [#2753](https://github.com/microsoft/BotFramework-WebChat/issues/2753). Added support for updating an activity by the ID, by [@compulim](https://github.com/compulim) in PR [#2825](https://github.com/microsoft/BotFramework-WebChat/pull/2825)
 -  Added custom hooks - `useTimer` and `useIntervalSince` - to replace the headless `Timer` component, by [@tdurnford](https://github.com/tdurnford), in PR [#2771](https://github.com/microsoft/BotFramework-WebChat/pull/2771)
 -  Resolves [#2720](https://github.com/Microsoft/BotFramework-WebChat/issues/2720), added customizable activity status using `activityStatusMiddleware` props, by [@compulim](https://github.com/compulim), in PR [#2788](https://github.com/microsoft/BotFramework-WebChat/pull/2788)
+- Added sendBoxBorderRadius to SendBox style component, by [@rtransat](https://github.com/rtransat), in PR [#2878](https://github.com/microsoft/BotFramework-WebChat/pull/2878)
 
 ### Fixed
 

--- a/packages/component/src/Styles/StyleSet/SendBox.js
+++ b/packages/component/src/Styles/StyleSet/SendBox.js
@@ -3,6 +3,7 @@ export default function createSendBoxStyle({
   sendBoxHeight,
   sendBoxBorderBottom,
   sendBoxBorderLeft,
+  sendBoxBorderRadius,
   sendBoxBorderRight,
   sendBoxBorderTop
 }) {
@@ -12,6 +13,7 @@ export default function createSendBoxStyle({
       backgroundColor: sendBoxBackground,
       borderBottom: sendBoxBorderBottom,
       borderLeft: sendBoxBorderLeft,
+      borderRadius: sendBoxBorderRadius,
       borderRight: sendBoxBorderRight,
       borderTop: sendBoxBorderTop,
       minHeight: sendBoxHeight


### PR DESCRIPTION
## Changelog Entry

Added sendBoxBorderRadius to SendBox style component, by [@rtransat](https://github.com/rtransat), in PR [#2878](https://github.com/microsoft/BotFramework-WebChat/pull/2878)

## Description

Add the ability to define a border radius to SendBox component
