### PR TITLE
Fix DLJS version in packages/core

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2456,26 +2456,23 @@
 			"optional": true
 		},
 		"botframework-directlinejs": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.5.tgz",
-			"integrity": "sha512-/opsuIEshKnk70idpPWnfIBceMrUn6U0wBxeiXDMR5PrUOofBqsyrDfMKCHjpqUJqU9uF7awm6RPSjwvfS5MGQ==",
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.11.6.tgz",
+			"integrity": "sha512-IpMTaaf1jGHVjstYX7IqRCr21adNvKAhAVVLFLmnlqF4WZVpzVy3X14ZgttBmCPJTNuu2MhugOTzh0YxpjtqVQ==",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.6.0",
 				"rxjs": "^5.0.3"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-					"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+					"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+					"dev": true,
 					"requires": {
-						"regenerator-runtime": "^0.12.0"
+						"regenerator-runtime": "^0.13.2"
 					}
-				},
-				"regenerator-runtime": {
-					"version": "0.12.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 				}
 			}
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^10.3.3",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-version-transform": "^1.0.0",
-    "botframework-directlinejs": "^0.11.5",
+    "botframework-directlinejs": "^0.11.6",
     "concurrently": "^4.0.1",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.17.1",


### PR DESCRIPTION
## Changelog Entry

Fix DLJS version in packages/core

## Description

Fix DLJS version in packages/core

## Specific Changes

Update package.json to use DLJS 0.11.6 in core
