### PR TITLE
Bump to react-dictate-button@1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
          -  `core-js@3.5.0`
          -  `sanitize-html@1.20.0`
       -  `component`
-         -  `react-dictate-button@1.2.2`
          -  `sanitize-html@1.20.1`
       -  `embed`
          -  `@babel/runtime@7.8.4`
@@ -140,6 +139,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Resolves [#2748](https://github.com/microsoft/BotFramework-WebChat/issues/2748), updated build scripts and CI pipeline, by [@compulim](https://github.com/compulim), in PR [#2767](https://github.com/microsoft/BotFramework-WebChat/pull/2767)
 -  `component`: Bumps [`react-film@2.0.2`](https://npmjs.com/package/react-film/), by [@tdurnford](https://github.com/tdurnford) in PR [#2801](https://github.com/microsoft/BotFramework-WebChat/pull/2801)
 -  Removes `sendTyping` and deprecation notes in PR [#2845](https://github.com/microsoft/BotFramework-WebChat/pull/2845), by [@corinagum](https://github.com/corinagum), in PR [#2918](https://github.com/microsoft/BotFramework-WebChat/pull/2918)
+-  `component`: Bumps [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button/), by [@compulim](https://github.com/compulim) in PR [#2960](https://github.com/microsoft/BotFramework-WebChat/pull/2960)
 
 ### Samples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2757](https://github.com/microsoft/BotFramework-WebChat/issues/2757). New message indicator should only show up for new messages, by [@compulim](https://github.com/compulim) in PR [#2915](https://github.com/microsoft/BotFramework-WebChat/pull/2915)
 -  Fixes [#2945](https://github.com/microsoft/BotFramework-WebChat/issues/2945). Toast should not overlap with each other, by [@compulim](https://github.com/compulim) in PR [#2952](https://github.com/microsoft/BotFramework-WebChat/pull/2952)
 -  Fixes [#2946](https://github.com/microsoft/BotFramework-WebChat/issues/2946). Updated JSON filenames for localization strings, by [@compulim](https://github.com/compulim) in PR [#2949](https://github.com/microsoft/BotFramework-WebChat/pull/2949)
+-  Fixes [#2560](https://github.com/microsoft/BotFramework-WebChat/issues/2560). Bumped to [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button) to workaround [a bug from Angular/zone.js](https://github.com/angular/angular/issues/31750), by [@compulim](https://github.com/compulim) in PR [#2960](https://github.com/microsoft/BotFramework-WebChat/issues/2960)
 
 ### Changed
 
@@ -131,6 +132,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
          -  `core-js@3.5.0`
          -  `sanitize-html@1.20.0`
       -  `component`
+         -  `react-dictate-button@1.2.2`
          -  `sanitize-html@1.20.1`
       -  `embed`
          -  `@babel/runtime@7.8.4`

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -8019,9 +8019,9 @@
 			}
 		},
 		"react-dictate-button": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.2.1.tgz",
-			"integrity": "sha512-jabur/PWLgPCorXXmrTc4GnxTFCEhbNadL6lT5xTXdNkM1r7cow2RRI3z7YV+p+24fNbIO0DTTKUog+aTCm1Lg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.2.2.tgz",
+			"integrity": "sha512-YWP8J9W5WkSqXKxMenH0WRZPXce+aFqyhGfbliKOGLBSccNBM0BJ0CUwoqnUR6qUhLq5PInpY03NiTrV2rYz2g==",
 			"requires": {
 				"classnames": "^2.2.6",
 				"glamor": "^2.20.40",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -63,7 +63,7 @@
     "math-random": "^1.0.4",
     "memoize-one": "^5.1.1",
     "prop-types": "^15.7.2",
-    "react-dictate-button": "^1.2.1",
+    "react-dictate-button": "^1.2.2",
     "react-film": "^2.0.2",
     "react-redux": "^7.1.1",
     "react-say": "^2.0.0",


### PR DESCRIPTION
> Fixes #2560. Fixes #2597.

## Changelog Entry

### Fixed

-  Fixes [#2560](https://github.com/microsoft/BotFramework-WebChat/issues/2560). Bumped to [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button) to workaround [a bug from Angular/zone.js](https://github.com/angular/angular/issues/31750), by [@compulim](https://github.com/compulim) in PR [#2960](https://github.com/microsoft/BotFramework-WebChat/issues/2960)

### Changed

-  `component`: Bumps [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button/), by [@compulim](https://github.com/compulim) in PR [#2960](https://github.com/microsoft/BotFramework-WebChat/pull/2960)

## Description

Bump to [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button), [diff here](https://github.com/compulim/react-dictate-button/compare/v1.2.1...v1.2.2).

It [picked up a change](https://github.com/compulim/react-dictate-button/issues/12) to workaround a long-time Angular bug.

## Specific Changes

- Bump to [`react-dictate-button@1.2.2`](https://github.com/compulim/react-dictate-button/releases/tag/v1.2.2)

---

-  [x] ~Testing Added~
   - Manual testing done, we don't test Angular in an automated way
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
