### PR TITLE
Add download attribute to file attachment link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2945](https://github.com/microsoft/BotFramework-WebChat/issues/2945). Toast should not overlap with each other, by [@compulim](https://github.com/compulim) in PR [#2952](https://github.com/microsoft/BotFramework-WebChat/pull/2952)
 -  Fixes [#2946](https://github.com/microsoft/BotFramework-WebChat/issues/2946). Updated JSON filenames for localization strings, by [@compulim](https://github.com/compulim) in PR [#2949](https://github.com/microsoft/BotFramework-WebChat/pull/2949)
 -  Fixes [#2560](https://github.com/microsoft/BotFramework-WebChat/issues/2560). Bumped to [`react-dictate-button@1.2.2`](https://npmjs.com/package/react-dictate-button) to workaround [a bug from Angular/zone.js](https://github.com/angular/angular/issues/31750), by [@compulim](https://github.com/compulim) in PR [#2960](https://github.com/microsoft/BotFramework-WebChat/issues/2960)
+-  Fixes [#2923](https://github.com/microsoft/BotFramework-WebChat/issues/2923). Added `download` attribute to file attachment (`<FileContent>`), by [@compulim](https://github.com/compulim) in PR [#2963](https://github.com/microsoft/BotFramework-WebChat/pull/2963)
 
 ### Changed
 

--- a/__tests__/fileAttachment.js
+++ b/__tests__/fileAttachment.js
@@ -58,9 +58,19 @@ test('show ZIP files with contentUrl', async () => {
   ).resolves.toEqual('https://example.org/');
   await expect(
     driver.executeScript(() =>
+      document.querySelector('[role="listitem"]:nth-child(1) a[target="_blank"]').getAttribute('download')
+    )
+  ).resolves.toEqual('empty.zip');
+  await expect(
+    driver.executeScript(() =>
       document.querySelector('[role="listitem"]:nth-child(2) a[target="_blank"]').getAttribute('href')
     )
   ).resolves.toEqual('https://example.org/');
+  await expect(
+    driver.executeScript(() =>
+      document.querySelector('[role="listitem"]:nth-child(2) a[target="_blank"]').getAttribute('download')
+    )
+  ).resolves.toEqual('empty.zip');
 });
 
 test('show ZIP files without contentUrl', async () => {
@@ -110,5 +120,8 @@ test('show ZIP files without contentUrl', async () => {
   ).resolves.toBeFalsy();
   await expect(
     driver.executeScript(() => !!document.querySelector('[role="listitem"]:nth-child(2) a'))
+  ).resolves.toBeFalsy();
+  await expect(
+    driver.executeScript(() => !!document.querySelector('[role="listitem"]:nth-child(1) a'))
   ).resolves.toBeFalsy();
 });

--- a/packages/component/src/Attachment/FileContent.js
+++ b/packages/component/src/Attachment/FileContent.js
@@ -90,6 +90,7 @@ const FileContent = ({ className, href, fileName, size }) => {
         <a
           aria-hidden={true}
           className="webchat__fileContent__buttonLink"
+          download={fileName}
           href={href}
           rel="noopener noreferrer"
           target="_blank"


### PR DESCRIPTION
> Fixes #2923

## Changelog Entry

-  Fixes [#2923](https://github.com/microsoft/BotFramework-WebChat/issues/2923). Added `download` attribute to file attachment (`<FileContent>`), by [@compulim](https://github.com/compulim) in PR [#2963](https://github.com/microsoft/BotFramework-WebChat/pull/2963)

## Description

Add `download` attribute to file attachment link in `<FileContent>`.

## Specific Changes

- Add `download` attribute to file attachment link in `<FileContent>`

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
