### PR TITLE
Compatibility fix for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2904](https://github.com/microsoft/BotFramework-WebChat/issues/2904). Fixed border radius when rendering bubble nub in RTL, by [@compulim](https://github.com/compulim) in PR [#2943](https://github.com/microsoft/BotFramework-WebChat/pull/2943)
 -  Fixes [#2966](https://github.com/microsoft/BotFramework-WebChat/issues/2966). Collapsed toast should show at most 2 lines of text, by [@compulim](https://github.com/compulim) in PR [#2967](https://github.com/microsoft/BotFramework-WebChat/issues/2967)
 -  Fixes [#2941](https://github.com/microsoft/BotFramework-WebChat/issues/2941), [#2921](https://github.com/microsoft/BotFramework-WebChat/issues/2921), and [#2948](https://github.com/microsoft/BotFramework-WebChat/issues/2948). Update documentation and fix redux sample, by [@corinagum](https://github.com/corinagum) in PR [#2968](https://github.com/microsoft/BotFramework-WebChat/pull/2968)
+-  Fixes [#2972](https://github.com/microsoft/BotFramework-WebChat/issues/2972). Compatibility fix for IE11, by [@compulim](https://github.com/compulim) in PR [#2973](https://github.com/microsoft/BotFramework-WebChat/pull/2973)
 
 ### Changed
 

--- a/packages/bundle/src/index-es5.ts
+++ b/packages/bundle/src/index-es5.ts
@@ -19,6 +19,7 @@ import 'core-js/features/object/is';
 import 'core-js/features/object/values';
 import 'core-js/features/promise';
 import 'core-js/features/promise/finally';
+import 'core-js/features/set';
 import 'core-js/features/string/ends-with';
 import 'core-js/features/string/starts-with';
 import 'core-js/features/symbol';

--- a/packages/component/src/Composer.js
+++ b/packages/component/src/Composer.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import updateIn from 'simple-update-in';
 
+import createCustomEvent from './Utils/createCustomEvent';
 import ErrorBoundary from './ErrorBoundary';
 import getAllLocalizedStrings from './Localization/getAllLocalizedStrings';
 import isObject from './Utils/isObject';
@@ -432,12 +433,7 @@ const Composer = ({
 const ComposeWithStore = ({ onTelemetry, store, ...props }) => {
   const handleError = useCallback(
     ({ error }) => {
-      const event = new Event('exception');
-
-      event.error = error;
-      event.fatal = true;
-
-      onTelemetry && onTelemetry(event);
+      onTelemetry && onTelemetry(createCustomEvent('exception', { error, fatal: true }));
     },
     [onTelemetry]
   );
@@ -458,10 +454,12 @@ const ComposeWithStore = ({ onTelemetry, store, ...props }) => {
 };
 
 ComposeWithStore.defaultProps = {
+  onTelemetry: undefined,
   store: undefined
 };
 
 ComposeWithStore.propTypes = {
+  onTelemetry: PropTypes.func,
   store: PropTypes.any
 };
 

--- a/packages/component/src/ErrorBoundary.js
+++ b/packages/component/src/ErrorBoundary.js
@@ -12,7 +12,9 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    return this.props.children;
+    const { children } = this.props;
+
+    return children;
   }
 }
 

--- a/packages/component/src/Utils/InlineMarkdown.js
+++ b/packages/component/src/Utils/InlineMarkdown.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useMemo } from 'react';
 import updateIn from 'simple-update-in';
 
+import createCustomEvent from '../Utils/createCustomEvent';
 import randomId from './randomId';
 import useInternalMarkdownIt from '../hooks/internal/useInternalMarkdownIt';
 import useStyleOptions from '../hooks/useStyleOptions';
@@ -104,14 +105,7 @@ const InlineMarkdown = ({ children, onReference, references }) => {
 
       const href = event.target.getAttribute('data-markdown-href');
 
-      if (href) {
-        const referenceEvent = new Event('reference');
-
-        // referenceEvent.data = ref;
-        referenceEvent.data = hrefToRef[href];
-
-        onReference && onReference(referenceEvent);
-      }
+      href && onReference && onReference(createCustomEvent('reference', { data: hrefToRef[href] }));
     },
     [hrefToRef, onReference]
   );

--- a/packages/component/src/Utils/createCustomEvent.js
+++ b/packages/component/src/Utils/createCustomEvent.js
@@ -1,0 +1,17 @@
+export default function createCustomEvent(name, eventInitDict) {
+  let event;
+
+  if (typeof CustomEvent === 'function') {
+    event = new CustomEvent(name);
+  } else {
+    event = document.createEvent('Event');
+
+    event.initEvent(name, true, true);
+  }
+
+  Object.entries(eventInitDict).forEach(([key, value]) => {
+    event[key] = value;
+  });
+
+  return event;
+}

--- a/packages/component/src/hooks/useSubmitSendBox.js
+++ b/packages/component/src/hooks/useSubmitSendBox.js
@@ -9,7 +9,8 @@ export default function useSubmitSendBox() {
 
   return useCallback(
     (...args) => {
-      const [method = 'keyboard'] = args;
+      // We cannot use spread operator as it broke in Angular.
+      const method = args[0] || 'keyboard';
 
       trackEvent('submitSendBox', method);
 

--- a/packages/component/src/hooks/useSubmitSendBox.js
+++ b/packages/component/src/hooks/useSubmitSendBox.js
@@ -9,7 +9,7 @@ export default function useSubmitSendBox() {
 
   return useCallback(
     (...args) => {
-      // We cannot use spread operator as it broke in Angular.
+      // We cannot use spread operator as it broken in Angular.
       const method = args[0] || 'keyboard';
 
       trackEvent('submitSendBox', method);

--- a/packages/component/src/hooks/useTrackEvent.js
+++ b/packages/component/src/hooks/useTrackEvent.js
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import createCustomEvent from '../Utils/createCustomEvent';
 import useReadTelemetryDimensions from './internal/useReadTelemetryDimensions';
 import useWebChatUIContext from './internal/useWebChatUIContext';
 
@@ -35,14 +36,8 @@ export default function useTrackEvent() {
         }
       }
 
-      const event = new Event('event');
-
-      event.data = data;
-      event.dimensions = readTelemetryDimensions();
-      event.level = level;
-      event.name = name;
-
-      onTelemetry && onTelemetry(event);
+      onTelemetry &&
+        onTelemetry(createCustomEvent('event', { data, dimensions: readTelemetryDimensions(), level, name }));
     },
     [onTelemetry, readTelemetryDimensions]
   );

--- a/packages/component/src/hooks/useTrackException.js
+++ b/packages/component/src/hooks/useTrackException.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import createCustomEvent from '../Utils/createCustomEvent';
 import useReadTelemetryDimensions from './internal/useReadTelemetryDimensions';
 import useWebChatUIContext from './internal/useWebChatUIContext';
 
@@ -15,13 +16,14 @@ export default function useTrackException() {
         );
       }
 
-      const event = new Event('exception');
-
-      event.dimensions = { ...readTelemetryDimensions() };
-      event.error = error;
-      event.fatal = !!fatal;
-
-      onTelemetry && onTelemetry(event);
+      onTelemetry &&
+        onTelemetry(
+          createCustomEvent('exception', {
+            dimensions: { ...readTelemetryDimensions() },
+            error,
+            fatal: !!fatal
+          })
+        );
     },
     [onTelemetry, readTelemetryDimensions]
   );

--- a/packages/component/src/hooks/useTrackTiming.js
+++ b/packages/component/src/hooks/useTrackTiming.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import createCustomEvent from '../Utils/createCustomEvent';
 import randomId from '../Utils/randomId';
 import useReadTelemetryDimensions from './internal/useReadTelemetryDimensions';
 import useTrackException from './useTrackException';
@@ -23,13 +24,15 @@ export default function useTrackTiming() {
       }
 
       const timingId = randomId();
-      const timingStartEvent = new Event('timingstart');
 
-      timingStartEvent.dimensions = readTelemetryDimensions();
-      timingStartEvent.name = name;
-      timingStartEvent.timingId = timingId;
-
-      onTelemetry && onTelemetry(timingStartEvent);
+      onTelemetry &&
+        onTelemetry(
+          createCustomEvent('timingstart', {
+            dimensions: readTelemetryDimensions(),
+            name,
+            timingId
+          })
+        );
 
       const startTime = Date.now();
 
@@ -42,14 +45,15 @@ export default function useTrackTiming() {
       } finally {
         const duration = Date.now() - startTime;
 
-        const timingEndEvent = new Event('timingend');
-
-        timingEndEvent.dimensions = readTelemetryDimensions();
-        timingEndEvent.duration = duration;
-        timingEndEvent.name = name;
-        timingStartEvent.timingId = timingId;
-
-        onTelemetry && onTelemetry(timingEndEvent);
+        onTelemetry &&
+          onTelemetry(
+            createCustomEvent('timingend', {
+              dimensions: readTelemetryDimensions(),
+              duration,
+              name,
+              timingId
+            })
+          );
       }
     },
     [onTelemetry, readTelemetryDimensions, trackException]


### PR DESCRIPTION
> Fixes #2972.

## Changelog Entry

-  Fixes [#2972](https://github.com/microsoft/BotFramework-WebChat/issues/2972). Compatibility fix for IE11, by [@compulim](https://github.com/compulim) in PR [#2973](https://github.com/microsoft/BotFramework-WebChat/pull/2973)

## Description

Some APIs we used are lacking in IE11, requires polyfill or use legacy approach.

## Specific Changes

- `Set` is not a full implementation, missing `Symbol.iterator`
   - Use `core-js` to polyfill `Set`
- `CustomEvent.constructor` is missing
   - Use `document.createEvent` and `Event.initEvent` instead

---

-  [x] Testing Added
   -  IE11 requires manual testing
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
