### PR TITLE
Lock microsoft-cognitiveservices-speech-sdk to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
          -  `core-js@3.5.0`
          -  `sanitize-html@1.20.0`
       -  `component`
+         -  `microsoft-cognitiveservices-speech-sdk@1.9.1`
          -  `sanitize-html@1.20.1`
       -  `embed`
          -  `@babel/runtime@7.8.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2941](https://github.com/microsoft/BotFramework-WebChat/issues/2941), [#2921](https://github.com/microsoft/BotFramework-WebChat/issues/2921), and [#2948](https://github.com/microsoft/BotFramework-WebChat/issues/2948). Update documentation and fix redux sample, by [@corinagum](https://github.com/corinagum) in PR [#2968](https://github.com/microsoft/BotFramework-WebChat/pull/2968)
 -  Fixes [#2972](https://github.com/microsoft/BotFramework-WebChat/issues/2972). Compatibility fix for IE11, by [@compulim](https://github.com/compulim) in PR [#2973](https://github.com/microsoft/BotFramework-WebChat/pull/2973)
 -  Fixes [#2977](https://github.com/microsoft/BotFramework-WebChat/issues/2977). `sr-Cyrl` and `sr-Latn` should display Serbian texts, by [@compulim](https://github.com/compulim) in PR [#2978](https://github.com/microsoft/BotFramework-WebChat/pull/2978)
+-  Fixes [#2979](https://github.com/microsoft/BotFramework-WebChat/issues/2979). Lock `microsoft-cognitiveservices-speech-sdk` to `1.9.1`, by [@compulim](https://github.com/compulim) in PR [#2980](https://github.com/microsoft/BotFramework-WebChat/pull/2980)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#2941](https://github.com/microsoft/BotFramework-WebChat/issues/2941), [#2921](https://github.com/microsoft/BotFramework-WebChat/issues/2921), and [#2948](https://github.com/microsoft/BotFramework-WebChat/issues/2948). Update documentation and fix redux sample, by [@corinagum](https://github.com/corinagum) in PR [#2968](https://github.com/microsoft/BotFramework-WebChat/pull/2968)
 -  Fixes [#2972](https://github.com/microsoft/BotFramework-WebChat/issues/2972). Compatibility fix for IE11, by [@compulim](https://github.com/compulim) in PR [#2973](https://github.com/microsoft/BotFramework-WebChat/pull/2973)
 -  Fixes [#2977](https://github.com/microsoft/BotFramework-WebChat/issues/2977). `sr-Cyrl` and `sr-Latn` should display Serbian texts, by [@compulim](https://github.com/compulim) in PR [#2978](https://github.com/microsoft/BotFramework-WebChat/pull/2978)
--  Fixes [#2979](https://github.com/microsoft/BotFramework-WebChat/issues/2979). Lock `microsoft-cognitiveservices-speech-sdk` to `1.9.1`, by [@compulim](https://github.com/compulim) in PR [#2980](https://github.com/microsoft/BotFramework-WebChat/pull/2980)
+-  Fixes [#2979](https://github.com/microsoft/BotFramework-WebChat/issues/2979). Lock `microsoft-cognitiveservices-speech-sdk` to `1.8.1`, by [@compulim](https://github.com/compulim) in PR [#2980](https://github.com/microsoft/BotFramework-WebChat/pull/2980)
 
 ### Changed
 
@@ -144,7 +144,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
          -  `core-js@3.5.0`
          -  `sanitize-html@1.20.0`
       -  `component`
-         -  `microsoft-cognitiveservices-speech-sdk@1.9.1`
          -  `sanitize-html@1.20.1`
       -  `embed`
          -  `@babel/runtime@7.8.4`

--- a/packages/directlinespeech/package-lock.json
+++ b/packages/directlinespeech/package-lock.json
@@ -7449,15 +7449,15 @@
 			}
 		},
 		"microsoft-cognitiveservices-speech-sdk": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.9.1.tgz",
-			"integrity": "sha512-x6FSGjgx02U//D4HUjVN6JIkEMrCbAECM+mfcPYkjEmymag5IIy30RAQJYwNoCeHTZS7wWURkiW7rrHGIymzJg==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.8.1.tgz",
+			"integrity": "sha512-sXP43LjW+twcz5SZs8i6vg9r2QK6XidArVAQybb4bmNMv+t/U8Dj1CKoy/l83Db0JLdDiU3zXYs+znILAqnn9g==",
 			"requires": {
 				"asn1.js-rfc2560": "^5.0.0",
 				"asn1.js-rfc5280": "^3.0.0",
-				"https-proxy-agent": "^3.0.1",
+				"https-proxy-agent": "^3.0.0",
 				"simple-lru-cache": "0.0.2",
-				"ws": "^7.2.0"
+				"ws": "^7.1.1"
 			}
 		},
 		"miller-rabin": {

--- a/packages/directlinespeech/package-lock.json
+++ b/packages/directlinespeech/package-lock.json
@@ -7449,15 +7449,15 @@
 			}
 		},
 		"microsoft-cognitiveservices-speech-sdk": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.8.1.tgz",
-			"integrity": "sha512-sXP43LjW+twcz5SZs8i6vg9r2QK6XidArVAQybb4bmNMv+t/U8Dj1CKoy/l83Db0JLdDiU3zXYs+znILAqnn9g==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.9.1.tgz",
+			"integrity": "sha512-x6FSGjgx02U//D4HUjVN6JIkEMrCbAECM+mfcPYkjEmymag5IIy30RAQJYwNoCeHTZS7wWURkiW7rrHGIymzJg==",
 			"requires": {
 				"asn1.js-rfc2560": "^5.0.0",
 				"asn1.js-rfc5280": "^3.0.0",
-				"https-proxy-agent": "^3.0.0",
+				"https-proxy-agent": "^3.0.1",
 				"simple-lru-cache": "0.0.2",
-				"ws": "^7.1.1"
+				"ws": "^7.2.0"
 			}
 		},
 		"miller-rabin": {
@@ -10358,12 +10358,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-			"integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-			"requires": {
-				"async-limiter": "^1.0.0"
-			}
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+			"integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/packages/directlinespeech/package.json
+++ b/packages/directlinespeech/package.json
@@ -60,7 +60,7 @@
     "event-target-shim": "^5.0.1",
     "event-target-shim-es5": "1.0.1",
     "math-random": "^1.0.4",
-    "microsoft-cognitiveservices-speech-sdk": "1.9.1",
+    "microsoft-cognitiveservices-speech-sdk": "1.8.1",
     "p-defer": "^3.0.0",
     "p-defer-es5": "1.0.1",
     "web-speech-cognitive-services": "^6.0.0"

--- a/packages/directlinespeech/package.json
+++ b/packages/directlinespeech/package.json
@@ -60,7 +60,7 @@
     "event-target-shim": "^5.0.1",
     "event-target-shim-es5": "1.0.1",
     "math-random": "^1.0.4",
-    "microsoft-cognitiveservices-speech-sdk": "^1.8.1",
+    "microsoft-cognitiveservices-speech-sdk": "1.9.1",
     "p-defer": "^3.0.0",
     "p-defer-es5": "1.0.1",
     "web-speech-cognitive-services": "^6.0.0"


### PR DESCRIPTION
> Fixes #2979.

## Changelog Entry

### Fixed

-  Fixes [#2979](https://github.com/microsoft/BotFramework-WebChat/issues/2979). Lock `microsoft-cognitiveservices-speech-sdk` to `1.9.1`, by [@compulim](https://github.com/compulim) in PR [#2980](https://github.com/microsoft/BotFramework-WebChat/pull/2980)

## Description

`microsoft-cognitiveservices-speech-sdk` is currently `^1.8.1`, but latest `1.10.0` is not compatible with Direct Line Speech. Bumping and lock to `1.9.1`.

## Specific Changes

- Bump `microsoft-cognitiveservices-speech-sdk@1.9.1`

---

-  [x] Testing Added
   - Will manual testing
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
