### PR TITLE
Add 4.8.0 to servicingPlan.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  `embed`
          - [`@babel/runtime@7.8.7`](https://npmjs.com/package/@babel/runtime)
          - [`core-js@3.6.4`](https://npmjs.com/package/core-js)
-- Bumped Chrome Docker image to `3.141.59-zirconium` (Chrome 80.0.3987.106), by [@compulim](https://github.com/compulim) in PR [#2992](https://github.com/microsoft/BotFramework-WebChat/pull/2992)
-         
+-  Bumped Chrome Docker image to `3.141.59-zirconium` (Chrome 80.0.3987.106), by [@compulim](https://github.com/compulim) in PR [#2992](https://github.com/microsoft/BotFramework-WebChat/pull/2992)
+-  Added `4.8.0` to `embed/servicingPlan.json`, by [@compulim](https://github.com/compulim) in PR [#2986](https://github.com/microsoft/BotFramework-WebChat/pull/2986)
+
 ## Samples
 -  Resolves [#2806](https://github.com/microsoft/BotFramework-WebChat/issues/2806), added [Single sign-on with On Behalf Of Token Authentication](https://webchat-sample-obo.azurewebsites.net/) sample, by [@tdurnford](https://github.com/tdurnford) in [#2865](https://github.com/microsoft/BotFramework-WebChat/pull/2865)
 

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -125,6 +125,18 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.8": {
+      "redirects": [
+        ["*", "4.8.0"]
+      ]
+    },
+    "4.8.0": {
+      "assets": [
+        ["https://cdn.botframework.com/botframework-webchat/4.8.0/webchat-es5.js", "sha384-kBFopxfE3U3wq2fCUCdxNFihClv3I5jnxsQqqeShIPDs7wpWg9K8NSKUINSzPuJs"]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "3": {
       "redirects": [
         ["*", "0.15.1-v3.748a85f"]


### PR DESCRIPTION
## Changelog Entry

### Changed

-  Added `4.8.0` to `embed/servicingPlan.json`, by [@compulim](https://github.com/compulim) in PR [#2986](https://github.com/microsoft/BotFramework-WebChat/pull/2986)

## Description

After release 4.8.0 to CDN, we need to include it in `servicingPlan.json` to surface it to IFRAME users.

It will be up to the service team to bump everyone to 4.8.0.

## Specific Changes

- Add 4.8.0 to `embed/servicingPlan.json`

---

-  [x] ~Testing Added~
   -  No tests added for `servicingPlan.json`
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
