### PR TITLE
Fix observeOnce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Resolves [#2897](https://github.com/microsoft/BotFramework-WebChat/issues/2897). Moved from JUnit to VSTest reporter with file attachments, by [@compulim](https://github.com/compulim) in PR [#2990](https://github.com/microsoft/BotFramework-WebChat/pull/2990)
 
+### Fixed
+
+-  Fixes [#2989](https://github.com/microsoft/BotFramework-WebChat/issues/2989). Fix `observeOnce` to use ES Observable call pattern, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ### Changed
 
 -  Bumped all dependencies to latest versions, by [@compulim](https://github.com/compulim) in PR [#2985](https://github.com/microsoft/BotFramework-WebChat/pull/2985)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#2989](https://github.com/microsoft/BotFramework-WebChat/issues/2989). Fix `observeOnce` to use ES Observable call pattern, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#2989](https://github.com/microsoft/BotFramework-WebChat/issues/2989). Fix `observeOnce` to use ES Observable call pattern, by [@compulim](https://github.com/compulim) in PR [#2993](https://github.com/microsoft/BotFramework-WebChat/pull/2993)
 
 ### Changed
 

--- a/packages/core/src/__tests__/observeOnce.spec.js
+++ b/packages/core/src/__tests__/observeOnce.spec.js
@@ -16,9 +16,7 @@ describe('observeOnce', () => {
   beforeEach(() => {
     unsubscribe = jest.fn();
     observable = {
-      subscribe: jest.fn((...args) => {
-        const { complete, error, next } = args;
-
+      subscribe: jest.fn(({ complete, error, next }) => {
         onComplete = complete;
         onError = error;
         onNext = next;

--- a/packages/core/src/__tests__/observeOnce.spec.js
+++ b/packages/core/src/__tests__/observeOnce.spec.js
@@ -17,7 +17,11 @@ describe('observeOnce', () => {
     unsubscribe = jest.fn();
     observable = {
       subscribe: jest.fn((...args) => {
-        [onNext, onError, onComplete] = args;
+        const { complete, error, next } = args;
+
+        onComplete = complete;
+        onError = error;
+        onNext = next;
 
         return {
           unsubscribe

--- a/packages/core/src/sagas/effects/observeOnce.js
+++ b/packages/core/src/sagas/effects/observeOnce.js
@@ -8,7 +8,11 @@ export default function observeOnceEffect(observable) {
       return yield call(
         () =>
           new Promise((resolve, reject) => {
-            subscription = observable.subscribe(resolve, reject, resolve);
+            subscription = observable.subscribe({
+              complete: resolve,
+              error: reject,
+              next: resolve
+            });
           })
       );
     } finally {


### PR DESCRIPTION
> Fixes #2989.

## Changelog Entry

### Fixed

-  Fixes [#2989](https://github.com/microsoft/BotFramework-WebChat/issues/2989). Fix `observeOnce` to use ES Observable call pattern, by [@compulim](https://github.com/compulim) in PR [#2993](https://github.com/microsoft/BotFramework-WebChat/pull/2993)

## Description

`observeOnce` was using an older signature which is only used in RxJS but not ES Observable. This cause tests in DirectLineSpeech to fail.

## Specific Changes

- Update `observeOnce` to use the newer call signature

---

-  [x] Testing Added
   -  Updated tests
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
