### PR TITLE
Use markdown-it-attrs-es5 bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 -  Resolves [#2897](https://github.com/microsoft/BotFramework-WebChat/issues/2897). Moved from JUnit to VSTest reporter with file attachments, by [@compulim](https://github.com/compulim) in PR [#2990](https://github.com/microsoft/BotFramework-WebChat/pull/2990)
--  Added `aria-label` attribute support for built-in Markdown engine, by [@patniko](https://github.com/patniko) in PR [#3022](https://github.com/microsoft/BotFramework-WebChat/pull/3022)
+-  Added `aria-label` attribute support for default Markdown engine, by [@patniko](https://github.com/patniko) in PR [#3022](https://github.com/microsoft/BotFramework-WebChat/pull/3022)
 
 ### Fixed
 
 -  Fixes [#2989](https://github.com/microsoft/BotFramework-WebChat/issues/2989). Fix `observeOnce` to use ES Observable call pattern, by [@compulim](https://github.com/compulim) in PR [#2993](https://github.com/microsoft/BotFramework-WebChat/pull/2993)
+-  Fixes [#3024](https://github.com/microsoft/BotFramework-WebChat/issues/3024). Using bridge package [`markdown-it-attrs-es5`](https://npmjs.com/package/markdown-it-attrs-es5) for consuming [`markdown-it-attrs`](https://npmjs.com/package/markdown-it-attrs) for IE11, by [@compulim](https://github.com/compulim) in PR [#3025](https://github.com/microsoft/BotFramework-WebChat/pull/3025)
 
 ### Changed
 

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -42,7 +42,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
 			"integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
-			"dev": true,
 			"requires": {
 				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
@@ -53,7 +52,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
 			"integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.8.7",
@@ -76,7 +74,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -85,7 +82,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -97,7 +93,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -108,7 +103,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -117,7 +111,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -126,7 +119,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -136,14 +128,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -154,7 +144,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -171,7 +160,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -181,8 +169,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -210,7 +197,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
 			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			},
@@ -219,7 +205,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -232,7 +217,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
 			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-explode-assignable-expression": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -242,7 +226,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -278,7 +261,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz",
 			"integrity": "sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.8.3",
 				"@babel/traverse": "^7.8.3",
@@ -289,7 +271,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -298,7 +279,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -310,7 +290,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -321,7 +300,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -330,7 +308,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -339,7 +316,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -349,14 +325,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -367,7 +341,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -384,7 +357,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -394,8 +366,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -403,7 +374,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
 			"integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.8.6",
 				"browserslist": "^4.9.1",
@@ -515,7 +485,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
 			"integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3",
@@ -526,7 +495,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
 			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/types": "^7.8.3",
@@ -537,7 +505,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -546,7 +513,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -557,7 +523,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -566,7 +531,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -576,14 +540,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -594,7 +556,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -607,7 +568,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
 			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
-			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -617,7 +577,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -626,7 +585,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -638,7 +596,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -649,7 +606,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -658,7 +614,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -667,7 +622,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -677,14 +631,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -695,7 +647,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -712,7 +663,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -722,8 +672,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -751,7 +700,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
 			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			},
@@ -760,7 +708,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -773,7 +720,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			},
@@ -782,7 +728,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -795,7 +740,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			},
@@ -804,7 +748,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -817,7 +760,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
 			"integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -832,7 +774,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -841,7 +782,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -853,7 +793,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -864,7 +803,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -873,7 +811,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 					"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-member-expression-to-functions": "^7.8.3",
 						"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -885,7 +822,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -894,7 +830,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -904,14 +839,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -922,7 +855,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -939,7 +871,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -949,8 +880,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -958,7 +888,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			},
@@ -967,7 +896,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -986,7 +914,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
 			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.13"
 			}
@@ -995,7 +922,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
 			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-wrap-function": "^7.8.3",
@@ -1008,7 +934,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -1017,7 +942,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -1029,7 +953,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -1040,7 +963,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1049,7 +971,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1058,7 +979,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -1068,14 +988,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -1086,7 +1004,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -1103,7 +1020,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -1113,8 +1029,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1122,7 +1037,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
 			"integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -1134,7 +1048,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -1143,7 +1056,6 @@
 					"version": "7.8.4",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
 					"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3",
 						"jsesc": "^2.5.1",
@@ -1155,7 +1067,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -1166,7 +1077,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1175,7 +1085,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1184,7 +1093,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -1194,14 +1102,12 @@
 				"@babel/parser": {
 					"version": "7.8.4",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-					"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-					"dev": true
+					"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
 				},
 				"@babel/template": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
 					"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.3",
@@ -1212,7 +1118,6 @@
 					"version": "7.8.4",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
 					"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.4",
@@ -1229,7 +1134,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -1239,8 +1143,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1248,7 +1151,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -1258,7 +1160,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -1267,7 +1168,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -1277,14 +1177,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -1295,7 +1193,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -1317,7 +1214,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
 			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -1329,7 +1225,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -1338,7 +1233,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -1350,7 +1244,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -1361,7 +1254,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1370,7 +1262,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1379,7 +1270,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -1389,14 +1279,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -1407,7 +1295,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -1424,7 +1311,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -1434,8 +1320,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1443,7 +1328,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
 			"integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.8.4",
@@ -1454,7 +1338,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -1463,7 +1346,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -1475,7 +1357,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -1486,7 +1367,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1495,7 +1375,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -1504,7 +1383,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -1514,14 +1392,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -1532,7 +1408,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -1549,7 +1424,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -1559,8 +1433,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -1585,7 +1458,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
 			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-remap-async-to-generator": "^7.8.3",
@@ -1595,8 +1467,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1622,7 +1493,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
 			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
@@ -1631,8 +1501,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1640,7 +1509,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
 			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-json-strings": "^7.8.0"
@@ -1649,8 +1517,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1658,7 +1525,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
 			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
@@ -1667,8 +1533,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1676,7 +1541,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
@@ -1685,8 +1549,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1694,7 +1557,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
 			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
@@ -1703,8 +1565,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1712,7 +1573,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
 			"integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
@@ -1721,8 +1581,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1730,7 +1589,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
 			"integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1739,8 +1597,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1748,7 +1605,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1756,8 +1612,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1765,7 +1620,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
 			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1773,8 +1627,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1782,7 +1635,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1790,8 +1642,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1816,7 +1667,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
 			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1824,8 +1674,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1833,7 +1682,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1841,8 +1689,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1850,7 +1697,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
 			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1858,8 +1704,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1867,7 +1712,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
 			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1875,8 +1719,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1884,7 +1727,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
 			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -1892,8 +1734,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1918,7 +1759,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
 			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -1926,8 +1766,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1935,7 +1774,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
 			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
@@ -1945,8 +1783,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1954,7 +1791,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
 			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -1962,8 +1798,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1971,7 +1806,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
 			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"lodash": "^4.17.13"
@@ -1980,8 +1814,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -1989,7 +1822,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
 			"integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-define-map": "^7.8.3",
@@ -2005,7 +1837,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -2014,7 +1845,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
 					"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
@@ -2026,7 +1856,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -2037,7 +1866,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -2045,14 +1873,12 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				},
 				"@babel/helper-replace-supers": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 					"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-member-expression-to-functions": "^7.8.3",
 						"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -2064,7 +1890,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -2073,7 +1898,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -2083,14 +1907,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -2101,7 +1923,6 @@
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/generator": "^7.8.6",
@@ -2118,7 +1939,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -2128,8 +1948,7 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -2137,7 +1956,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
 			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2145,8 +1963,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2154,7 +1971,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
 			"integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2162,8 +1978,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2171,7 +1986,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
 			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2180,8 +1994,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2189,7 +2002,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
 			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2197,8 +2009,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2206,7 +2017,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
 			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2215,8 +2025,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2224,7 +2033,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
 			"integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2232,8 +2040,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2241,7 +2048,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
 			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2251,7 +2057,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
@@ -2260,7 +2065,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.8.3",
 						"@babel/template": "^7.8.3",
@@ -2271,7 +2075,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -2279,14 +2082,12 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				},
 				"@babel/highlight": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
 						"esutils": "^2.0.2",
@@ -2296,14 +2097,12 @@
 				"@babel/parser": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
-					"dev": true
+					"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
 				},
 				"@babel/template": {
 					"version": "7.8.6",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
 						"@babel/parser": "^7.8.6",
@@ -2314,7 +2113,6 @@
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -2327,7 +2125,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
 			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2335,8 +2132,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2344,7 +2140,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
 			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2352,8 +2147,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2361,7 +2155,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
 			"integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
@@ -2371,8 +2164,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2380,7 +2172,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
 			"integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
@@ -2391,8 +2182,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2400,7 +2190,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
 			"integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.8.3",
 				"@babel/helper-module-transforms": "^7.8.3",
@@ -2411,8 +2200,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2420,7 +2208,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
 			"integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2429,8 +2216,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2438,7 +2224,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
 			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
 			}
@@ -2447,7 +2232,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
 			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2455,8 +2239,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2464,7 +2247,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
 			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.3"
@@ -2473,8 +2255,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2482,7 +2263,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.7.tgz",
 			"integrity": "sha512-brYWaEPTRimOctz2NDA3jnBbDi7SVN2T4wYuu0aqSzxC3nozFZngGaw29CJ9ZPweB7k+iFmZuoG3IVPIcXmD2g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.8.7",
 				"@babel/helper-get-function-arity": "^7.8.3",
@@ -2493,7 +2273,6 @@
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-					"dev": true,
 					"requires": {
 						"@babel/types": "^7.8.3"
 					}
@@ -2501,14 +2280,12 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				},
 				"@babel/types": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -2521,7 +2298,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
 			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2529,8 +2305,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2610,7 +2385,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
 			"integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
 			}
@@ -2619,7 +2393,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
 			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2627,8 +2400,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2656,7 +2428,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
 			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2664,8 +2435,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2673,7 +2443,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
 			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2681,8 +2450,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2690,7 +2458,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
 			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3"
@@ -2699,8 +2466,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2708,7 +2474,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
 			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2717,8 +2482,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2726,7 +2490,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
 			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			},
@@ -2734,8 +2497,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2918,7 +2680,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
 			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -2927,8 +2688,7 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				}
 			}
 		},
@@ -2936,7 +2696,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
 			"integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.8.6",
 				"@babel/helper-compilation-targets": "^7.8.7",
@@ -3000,14 +2759,12 @@
 				"@babel/helper-plugin-utils": {
 					"version": "7.8.3",
 					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-					"dev": true
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 				},
 				"@babel/types": {
 					"version": "7.8.7",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
@@ -3323,7 +3080,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
 			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
@@ -3333,26 +3089,22 @@
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
-			"dev": true
+			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
-			"dev": true
+			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
-			"dev": true
+			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
 		},
 		"@webassemblyjs/helper-code-frame": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
 			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/wast-printer": "1.8.5"
 			}
@@ -3360,14 +3112,12 @@
 		"@webassemblyjs/helper-fsm": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
-			"dev": true
+			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
 		},
 		"@webassemblyjs/helper-module-context": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
 			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"mamacro": "^0.0.3"
@@ -3376,14 +3126,12 @@
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
-			"dev": true
+			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
 			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-buffer": "1.8.5",
@@ -3395,7 +3143,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
 			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
-			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -3404,7 +3151,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
 			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -3412,14 +3158,12 @@
 		"@webassemblyjs/utf8": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
-			"dev": true
+			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
 			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-buffer": "1.8.5",
@@ -3435,7 +3179,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
 			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
@@ -3448,7 +3191,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
 			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-buffer": "1.8.5",
@@ -3460,7 +3202,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
 			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-api-error": "1.8.5",
@@ -3474,7 +3215,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
 			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
@@ -3488,7 +3228,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
 			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/wast-parser": "1.8.5",
@@ -3498,14 +3237,12 @@
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"acorn": {
 			"version": "7.1.1",
@@ -3546,7 +3283,6 @@
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
 			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3557,14 +3293,12 @@
 		"ajv-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 		},
 		"ajv-keywords": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-			"dev": true
+			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
 		},
 		"ansi-escapes": {
 			"version": "4.3.1",
@@ -3586,8 +3320,7 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-			"dev": true
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -3601,7 +3334,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -3611,7 +3343,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -3621,8 +3352,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -3635,20 +3365,17 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-includes": {
 			"version": "3.1.1",
@@ -3669,8 +3396,7 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"asn1.js": {
 			"version": "5.2.0",
@@ -3702,7 +3428,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
 			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"util": "0.10.3"
@@ -3711,14 +3436,12 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
 				},
 				"util": {
 					"version": "0.10.3",
 					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-					"dev": true,
 					"requires": {
 						"inherits": "2.0.1"
 					}
@@ -3728,8 +3451,7 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
@@ -3749,8 +3471,7 @@
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-			"dev": true
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
 		},
 		"async-limiter": {
 			"version": "1.0.1",
@@ -3760,14 +3481,48 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"babel-loader": {
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+			"requires": {
+				"find-cache-dir": "^2.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"pify": "^4.0.1"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				}
+			}
 		},
 		"babel-plugin-dynamic-import-node": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
 			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
-			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
 			}
@@ -3794,14 +3549,12 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -3816,7 +3569,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -3825,7 +3577,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3834,7 +3585,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3843,7 +3593,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -3860,26 +3609,22 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-			"dev": true
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
 		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
@@ -3888,8 +3633,7 @@
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"dev": true
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -3909,7 +3653,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3919,7 +3662,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -3937,7 +3679,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -3947,14 +3688,12 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -3968,7 +3707,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -3979,7 +3717,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -3991,7 +3728,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
@@ -4001,7 +3737,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.1",
 				"browserify-rsa": "^4.0.0",
@@ -4016,7 +3751,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
 			}
@@ -4025,7 +3759,6 @@
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
 			"integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001030",
 				"electron-to-chromium": "^1.3.363",
@@ -4036,7 +3769,6 @@
 			"version": "4.9.2",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
 			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
@@ -4046,20 +3778,17 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"cacache": {
 			"version": "13.0.1",
@@ -4102,7 +3831,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -4124,14 +3852,12 @@
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001032",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001032.tgz",
-			"integrity": "sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA==",
-			"dev": true
+			"integrity": "sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -4153,7 +3879,6 @@
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
 			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -4172,14 +3897,12 @@
 		"chownr": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
-			"dev": true
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
 			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -4188,7 +3911,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -4198,7 +3920,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -4210,7 +3931,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -4242,7 +3962,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
@@ -4253,7 +3972,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -4281,26 +3999,22 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-			"dev": true
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -4312,7 +4026,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4326,14 +4039,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -4380,20 +4091,17 @@
 		"console-browserify": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-			"dev": true
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			},
@@ -4401,8 +4109,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
 		},
@@ -4410,7 +4117,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -4423,8 +4129,7 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "3.6.4",
@@ -4435,7 +4140,6 @@
 			"version": "3.6.4",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
 			"integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
-			"dev": true,
 			"requires": {
 				"browserslist": "^4.8.3",
 				"semver": "7.0.0"
@@ -4444,22 +4148,19 @@
 				"semver": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-					"dev": true
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
 				}
 			}
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-ecdh": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -4469,7 +4170,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -4482,7 +4182,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -4496,7 +4195,6 @@
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-			"dev": true,
 			"requires": {
 				"nice-try": "^1.0.4",
 				"path-key": "^2.0.1",
@@ -4509,7 +4207,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -4533,8 +4230,7 @@
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-			"dev": true
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"date-fns": {
 			"version": "2.10.0",
@@ -4546,7 +4242,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -4554,14 +4249,12 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -4573,7 +4266,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -4582,7 +4274,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -4592,7 +4283,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4601,7 +4291,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4610,7 +4299,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -4623,7 +4311,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
 			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -4632,14 +4319,12 @@
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-			"dev": true
+			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -4674,8 +4359,7 @@
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
 			"version": "1.3.1",
@@ -4703,7 +4387,6 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
 			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -4715,7 +4398,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4729,14 +4411,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -4746,14 +4426,12 @@
 		"electron-to-chromium": {
 			"version": "1.3.370",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.370.tgz",
-			"integrity": "sha512-399cXDE9C7qoVF2CUgCA/MLflfvxbo1F0kB/pkB94426freL/JgZ0HNaloomsOfnE+VC/qgTFZqzmivSdaNfPQ==",
-			"dev": true
+			"integrity": "sha512-399cXDE9C7qoVF2CUgCA/MLflfvxbo1F0kB/pkB94426freL/JgZ0HNaloomsOfnE+VC/qgTFZqzmivSdaNfPQ=="
 		},
 		"elliptic": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
 			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -4767,20 +4445,17 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -4789,7 +4464,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
 			"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.5.0",
@@ -4800,7 +4474,6 @@
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
 					"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-					"dev": true,
 					"requires": {
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
@@ -4810,7 +4483,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4824,14 +4496,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -4847,7 +4517,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -5094,7 +4763,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
 			}
@@ -5102,14 +4770,12 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"event-as-promise": {
 			"version": "1.0.5",
@@ -5125,7 +4791,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -5135,7 +4800,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.0",
 				"get-stream": "^4.0.0",
@@ -5150,7 +4814,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -5165,7 +4828,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -5174,7 +4836,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -5183,7 +4844,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5191,8 +4851,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -5200,7 +4859,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
@@ -5209,7 +4867,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -5219,7 +4876,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -5241,7 +4897,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -5257,7 +4912,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -5266,7 +4920,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5275,7 +4928,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5284,7 +4936,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5293,7 +4944,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -5305,8 +4955,7 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -5317,8 +4966,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -5329,8 +4977,7 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
-			"dev": true
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
 		},
 		"figures": {
 			"version": "3.2.0",
@@ -5354,14 +5001,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -5373,7 +5018,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5412,7 +5056,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -5421,7 +5064,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
 			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
 				"is-glob": "^4.0.0",
@@ -5450,7 +5092,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
 			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
@@ -5460,7 +5101,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5474,14 +5114,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5491,14 +5129,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -5507,7 +5143,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -5517,7 +5152,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5531,14 +5165,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5564,7 +5196,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -5576,7 +5207,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5590,14 +5220,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5607,14 +5235,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.11",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
 			"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -5625,25 +5251,21 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -5653,13 +5275,11 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -5669,37 +5289,31 @@
 				"chownr": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "3.2.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -5708,25 +5322,21 @@
 				"deep-extend": {
 					"version": "0.6.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.6.0"
@@ -5735,13 +5345,11 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5757,7 +5365,6 @@
 				"glob": {
 					"version": "7.1.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5771,13 +5378,11 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -5786,7 +5391,6 @@
 				"ignore-walk": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -5795,7 +5399,6 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5805,19 +5408,16 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -5826,13 +5426,11 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -5841,13 +5439,11 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
@@ -5857,7 +5453,6 @@
 				"minizlib": {
 					"version": "1.3.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.9.0"
@@ -5866,7 +5461,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -5875,13 +5469,11 @@
 				"ms": {
 					"version": "2.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^3.2.6",
@@ -5892,7 +5484,6 @@
 				"node-pre-gyp": {
 					"version": "0.14.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -5910,7 +5501,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5920,7 +5510,6 @@
 				"npm-bundled": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"npm-normalize-package-bin": "^1.0.1"
@@ -5929,13 +5518,11 @@
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.7",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -5945,7 +5532,6 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5957,19 +5543,16 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"wrappy": "1"
@@ -5978,19 +5561,16 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -6000,19 +5580,16 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.6.0",
@@ -6024,7 +5601,6 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -6032,7 +5608,6 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -6047,7 +5622,6 @@
 				"rimraf": {
 					"version": "2.7.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -6056,43 +5630,36 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -6103,7 +5670,6 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -6112,7 +5678,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -6121,13 +5686,11 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.13",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.1.1",
@@ -6142,13 +5705,11 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2 || 2"
@@ -6157,13 +5718,11 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -6171,8 +5730,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -6183,20 +5741,17 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-			"dev": true
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"dev": true,
 			"requires": {
 				"pump": "^3.0.0"
 			}
@@ -6204,14 +5759,12 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"glob": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
 			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -6225,7 +5778,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -6235,7 +5787,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -6246,7 +5797,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"dev": true,
 			"requires": {
 				"global-prefix": "^3.0.0"
 			},
@@ -6255,7 +5805,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
 					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-					"dev": true,
 					"requires": {
 						"ini": "^1.3.5",
 						"kind-of": "^6.0.2",
@@ -6268,7 +5817,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
 				"homedir-polyfill": "^1.0.1",
@@ -6280,14 +5828,12 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"graceful-fs": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-			"dev": true
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
 		},
 		"has": {
 			"version": "1.0.3",
@@ -6306,14 +5852,12 @@
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -6324,7 +5868,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -6334,7 +5877,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6345,7 +5887,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -6355,7 +5896,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -6365,7 +5905,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -6376,7 +5915,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
 			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -6410,8 +5948,7 @@
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"https-proxy-agent": {
 			"version": "2.2.4",
@@ -6444,14 +5981,12 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-			"dev": true
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -6473,7 +6008,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
 			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -6483,7 +6017,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0"
 					}
@@ -6493,8 +6026,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"indent-string": {
 			"version": "4.0.0",
@@ -6505,14 +6037,12 @@
 		"infer-owner": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-			"dev": true
+			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6526,8 +6056,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "7.0.6",
@@ -6663,14 +6192,12 @@
 		"interpret": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-			"dev": true
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -6678,14 +6205,12 @@
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-			"dev": true
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6694,7 +6219,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6711,7 +6235,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -6719,8 +6242,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -6732,7 +6254,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6741,7 +6262,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6758,7 +6278,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -6768,34 +6287,29 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -6804,7 +6318,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6813,7 +6326,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6824,7 +6336,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -6847,8 +6358,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.5",
@@ -6868,32 +6378,27 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -6969,20 +6474,17 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -6994,7 +6496,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
 			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
 			}
@@ -7012,14 +6513,12 @@
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"dev": true,
 			"requires": {
 				"invert-kv": "^2.0.0"
 			}
@@ -7027,14 +6526,12 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
 		},
 		"levenary": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
 			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-			"dev": true,
 			"requires": {
 				"leven": "^3.1.0"
 			}
@@ -7060,14 +6557,12 @@
 		"loader-runner": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
-			"dev": true
+			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 		},
 		"loader-utils": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
 			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
@@ -7078,7 +6573,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
 					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
 					}
@@ -7086,8 +6580,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -7095,7 +6588,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -7104,8 +6596,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -7150,7 +6641,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
 			"requires": {
 				"yallist": "^3.0.2"
 			},
@@ -7158,8 +6648,7 @@
 				"yallist": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				}
 			}
 		},
@@ -7167,7 +6656,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-			"dev": true,
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
@@ -7176,22 +6664,19 @@
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				}
 			}
 		},
 		"mamacro": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-			"dev": true
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -7199,14 +6684,12 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -7228,6 +6711,18 @@
 			"resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-3.0.2.tgz",
 			"integrity": "sha512-q45vdXU9TSWaHgFkWEFM97YHEoCmOyG9csLLdv3oVC6ARjT77u4wfng9rRtSOMb5UpxzT7zTX5GBbwm15H40dw=="
 		},
+		"markdown-it-attrs-es5": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-attrs-es5/-/markdown-it-attrs-es5-1.0.0.tgz",
+			"integrity": "sha512-bI1fNQIX/6/a2yw4OYWNkx7R2Zlt8n3IxnbaJhfcDAUimhnJ2eAG9GENqGaePewU8pAWz/hx9AM630WlCY0z5g==",
+			"requires": {
+				"@babel/core": "^7",
+				"@babel/preset-env": "^7",
+				"babel-loader": "^8",
+				"webpack": "^4",
+				"webpack-cli": "^3"
+			}
+		},
 		"markdown-it-for-inline": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz",
@@ -7237,7 +6732,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -7253,7 +6747,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
 			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-			"dev": true,
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
 				"mimic-fn": "^2.0.0",
@@ -7269,7 +6762,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
@@ -7279,7 +6771,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -7293,14 +6784,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -7317,7 +6806,6 @@
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -7355,7 +6843,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -7364,8 +6851,7 @@
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -7375,14 +6861,12 @@
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -7390,8 +6874,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minipass": {
 			"version": "3.1.1",
@@ -7433,7 +6916,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
 			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -7451,7 +6933,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -7461,7 +6942,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -7472,7 +6952,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -7480,8 +6959,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
 		},
@@ -7489,7 +6967,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -7514,14 +6991,12 @@
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
 			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -7545,20 +7020,17 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-			"dev": true
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
 			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
-			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -7588,14 +7060,12 @@
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -7610,7 +7080,6 @@
 							"version": "1.1.1",
 							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
 							}
@@ -7620,8 +7089,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
 		},
@@ -7629,7 +7097,6 @@
 			"version": "1.1.50",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
 			"integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
-			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -7637,8 +7104,7 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -7657,14 +7123,12 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -7683,7 +7147,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -7694,7 +7157,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -7703,7 +7165,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7719,14 +7180,12 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -7735,7 +7194,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -7771,7 +7229,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -7797,7 +7254,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -7828,14 +7284,12 @@
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-locale": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
 			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"dev": true,
 			"requires": {
 				"execa": "^1.0.0",
 				"lcid": "^2.0.0",
@@ -7851,26 +7305,22 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-			"dev": true
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-			"dev": true
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
 			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -7879,7 +7329,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -7896,20 +7345,17 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
 			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
-			"dev": true,
 			"requires": {
 				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
@@ -7920,7 +7366,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -7934,14 +7379,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -7961,7 +7404,6 @@
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
 			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
-			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -7975,7 +7417,6 @@
 					"version": "4.10.1",
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 					"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-					"dev": true,
 					"requires": {
 						"bn.js": "^4.0.0",
 						"inherits": "^2.0.1",
@@ -7997,56 +7438,47 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-			"dev": true
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-			"dev": true
+			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -8109,8 +7541,7 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
 			"version": "7.0.25",
@@ -8156,20 +7587,17 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-			"dev": true
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -8180,8 +7608,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"prop-types": {
 			"version": "15.7.2",
@@ -8196,14 +7623,12 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -8217,7 +7642,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -8227,7 +7651,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -8238,7 +7661,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -8249,26 +7671,22 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8277,7 +7695,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -8313,7 +7730,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
@@ -8324,7 +7740,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -8338,14 +7753,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -8355,14 +7768,12 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerate-unicode-properties": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
 			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -8376,7 +7787,6 @@
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
 			"integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.4",
 				"private": "^0.1.8"
@@ -8386,7 +7796,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -8412,7 +7821,6 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
 			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
 				"regenerate-unicode-properties": "^8.1.0",
@@ -8425,14 +7833,12 @@
 		"regjsgen": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-			"dev": true
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
 		},
 		"regjsparser": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
 			"integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -8440,46 +7846,39 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"dev": true
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"resolve": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
 			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -8488,7 +7887,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			},
@@ -8496,8 +7894,7 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -8505,7 +7902,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
@@ -8515,7 +7911,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-					"dev": true,
 					"requires": {
 						"global-prefix": "^1.0.1",
 						"is-windows": "^1.0.1",
@@ -8533,8 +7928,7 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
 			"version": "3.1.0",
@@ -8549,14 +7943,12 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -8565,7 +7957,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -8584,7 +7975,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -8606,7 +7996,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -8647,26 +8036,22 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"serialize-javascript": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -8678,7 +8063,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -8688,14 +8072,12 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -8705,7 +8087,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -8713,8 +8094,7 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"side-channel": {
 			"version": "1.0.2",
@@ -8729,8 +8109,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-lru-cache": {
 			"version": "0.0.2",
@@ -8763,7 +8142,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -8779,7 +8157,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -8788,7 +8165,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -8797,7 +8173,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -8805,14 +8180,12 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -8820,7 +8193,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -8831,7 +8203,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -8840,7 +8211,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -8849,7 +8219,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -8858,7 +8227,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -8871,7 +8239,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -8880,7 +8247,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8890,8 +8256,7 @@
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
+			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -8912,7 +8277,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -8925,7 +8289,6 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
 			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -8934,8 +8297,7 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
@@ -8979,7 +8341,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -9012,7 +8373,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -9022,7 +8382,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -9033,7 +8392,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
 			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -9043,7 +8401,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -9057,14 +8414,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -9075,7 +8430,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -9085,7 +8439,6 @@
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -9098,7 +8451,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -9112,14 +8464,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -9129,14 +8479,12 @@
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-			"dev": true
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"string-width": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
@@ -9189,7 +8537,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			}
@@ -9197,8 +8544,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-json-comments": {
 			"version": "3.0.1",
@@ -9234,14 +8580,12 @@
 		"tapable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-			"dev": true
+			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
 		},
 		"terser": {
 			"version": "4.6.6",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
 			"integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
-			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -9251,8 +8595,7 @@
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				}
 			}
 		},
@@ -9328,7 +8671,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
@@ -9338,7 +8680,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -9352,14 +8693,12 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -9370,7 +8709,6 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
 			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
-			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -9387,20 +8725,17 @@
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -9409,7 +8744,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -9420,7 +8754,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -9432,7 +8765,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -9447,8 +8779,7 @@
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -9462,8 +8793,7 @@
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -9483,8 +8813,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
 			"version": "3.8.3",
@@ -9500,14 +8829,12 @@
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -9516,20 +8843,17 @@
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-			"dev": true
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
-			"dev": true
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
 		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -9541,7 +8865,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -9550,7 +8873,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -9559,7 +8881,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -9569,7 +8890,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -9580,7 +8900,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -9590,22 +8909,19 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -9613,14 +8929,12 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -9629,8 +8943,7 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 				}
 			}
 		},
@@ -9642,14 +8955,12 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
 			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
 			},
@@ -9657,8 +8968,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				}
 			}
 		},
@@ -9670,8 +8980,7 @@
 		"v8-compile-cache": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
-			"dev": true
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -9686,14 +8995,12 @@
 		"vm-browserify": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-			"dev": true
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
 		},
 		"watchpack": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-			"dev": true,
 			"requires": {
 				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
@@ -9719,7 +9026,6 @@
 			"version": "4.42.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
 			"integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
@@ -9749,14 +9055,12 @@
 				"acorn": {
 					"version": "6.4.1",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
+					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 				},
 				"cacache": {
 					"version": "12.0.3",
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
 					"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
-					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.5",
 						"chownr": "^1.1.1",
@@ -9779,7 +9083,6 @@
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
 					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
@@ -9789,7 +9092,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
 					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"make-dir": "^2.0.0",
@@ -9800,7 +9102,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0"
 					}
@@ -9809,7 +9110,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
 					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
@@ -9820,7 +9120,6 @@
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
 					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1"
 					}
@@ -9829,7 +9128,6 @@
 					"version": "1.4.3",
 					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
 					"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
-					"dev": true,
 					"requires": {
 						"cacache": "^12.0.2",
 						"find-cache-dir": "^2.1.0",
@@ -9848,7 +9146,6 @@
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
 			"integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.2",
 				"cross-spawn": "6.0.5",
@@ -9867,7 +9164,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
 					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"memory-fs": "^0.4.0",
@@ -9878,7 +9174,6 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9887,7 +9182,6 @@
 					"version": "13.2.4",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
 					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-					"dev": true,
 					"requires": {
 						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
@@ -9908,7 +9202,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
 			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -9929,7 +9222,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -9937,8 +9229,7 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -9950,7 +9241,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
 			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -9959,7 +9249,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
@@ -9969,8 +9258,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -9997,8 +9285,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yallist": {
 			"version": "4.0.0",
@@ -10028,7 +9315,6 @@
 			"version": "13.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
 			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -38,6 +38,7 @@
     "core-js": "^3.6.4",
     "markdown-it": "^10.0.0",
     "markdown-it-attrs": "^3.0.2",
+    "markdown-it-attrs-es5": "^1.0.0",
     "markdown-it-for-inline": "^0.1.1",
     "memoize-one": "^5.1.1",
     "microsoft-cognitiveservices-speech-sdk": "1.6.0",

--- a/packages/bundle/src/renderMarkdown.js
+++ b/packages/bundle/src/renderMarkdown.js
@@ -2,7 +2,7 @@
 
 import iterator from 'markdown-it-for-inline';
 import MarkdownIt from 'markdown-it';
-import markdownItAttrs from 'markdown-it-attrs';
+import markdownItAttrs from 'markdown-it-attrs-es5';
 import sanitizeHTML from 'sanitize-html';
 
 const SANITIZE_HTML_OPTIONS = {


### PR DESCRIPTION
> Fixes #3024.

## Changelog Entry

### Fixed

-  Fixes [#3024](https://github.com/microsoft/BotFramework-WebChat/issues/3024). Using bridge package [`markdown-it-attrs-es5`](https://npmjs.com/package/markdown-it-attrs-es5) for consuming [`markdown-it-attrs`](https://npmjs.com/package/markdown-it-attrs) for IE11, by [@compulim](https://github.com/compulim) in PR [#3025](https://github.com/microsoft/BotFramework-WebChat/pull/3025)

## Description

[`markdown-it-attrs`](https://npmjs.com/package/markdown-it-attrs) introduced in #3022 is not compatible with IE11. We need to add a bridging package [`markdown-it-attrs-es5`](https://npmjs.com/package/markdown-it-attrs-es5) which transpile it on-install.

It is normal that a lot of changes in `package.json` because `dev: true` is removed. Although the package include `babel-loader` as dev dependencies, it's transient dependencies of a prod dependency. Thus, all dev dependencies starting from `babel-loader` and down the tree will have their `dev: true` removed.

In other words, `dev: true` is only for "truly/fully dev dependencies".

## Specific Changes

- Add [`markdown-it-attrs-es5`](https://npmjs.com/package/markdown-it-attrs-es5)

---

-  [x] ~Testing Added~
   -  Existing manual test will cover this case
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
