### PR TITLE
Remove aria-labelledby if label is hidden

### DIFF
--- a/__tests__/html/toast.accessibility.html
+++ b/__tests__/html/toast.accessibility.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js"></script>
+    <script
+      crossorigin="anonymous"
+      src="https://unpkg.com/react-dom@16.8.6/umd/react-dom-test-utils.development.js"
+    ></script>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+    <script type="text/babel" data-presets="es2015,stage-3">
+      (async function() {
+        const { conditions, createStore, host, pageObjects, timeouts, token } = window.WebChatTest;
+
+        const store = createStore({}, ({ dispatch }) => next => action => {
+          if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
+            dispatch({
+              type: 'WEB_CHAT/SET_NOTIFICATION',
+              payload: {
+                id: 'toast1',
+                level: 'info',
+                message: 'This is first toast.'
+              }
+            });
+
+            dispatch({
+              type: 'WEB_CHAT/SET_NOTIFICATION',
+              payload: {
+                id: 'toast2',
+                level: 'info',
+                message: 'This is second toast.'
+              }
+            });
+          } else if (action.type === 'DIRECT_LINE/POST_ACTIVITY') {
+            dispatch({
+              type: 'WEB_CHAT/SET_NOTIFICATION',
+              payload: {
+                id: 'toast3',
+                level: 'info',
+                message: `This is third toast at ${Math.random()
+                  .toString(10)
+                  .substr(2, 3)}.`
+              }
+            });
+          }
+
+          return next(action);
+        });
+
+        window.WebChat.renderWebChat(
+          {
+            directLine: window.WebChat.createDirectLine({
+              token: await token.fetchDirectLineToken()
+            }),
+            store
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+        await pageObjects.wait(conditions.toastShown(), timeouts.ui);
+
+        await pageObjects.verifyDOMIntegrity();
+
+        await pageObjects.clickToasterHeader();
+
+        // After click on the toaster header, it will expand and two toasts will become visible.
+
+        await pageObjects.verifyDOMIntegrity();
+
+        await pageObjects.dismissToast(0);
+
+        // One toast left visible on the screen.
+
+        await pageObjects.verifyDOMIntegrity();
+
+        await pageObjects.dismissToast(0);
+
+        // All toasts have been dismissed.
+
+        await pageObjects.verifyDOMIntegrity();
+
+        await host.done();
+      })().catch(err => console.error(err));
+    </script>
+  </body>
+</html>

--- a/__tests__/html/toast.accessibility.js
+++ b/__tests__/html/toast.accessibility.js
@@ -1,0 +1,7 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('toast', () => {
+  test('should have valid aria-labelled-by.', () => runHTMLTest('toast.accessibility.html'));
+});

--- a/packages/component/src/BasicToaster.js
+++ b/packages/component/src/BasicToaster.js
@@ -65,12 +65,18 @@ const TOAST_ACCORDION_IDS = {
 };
 
 const BasicToaster = () => {
+  const instanceId = useMemo(randomId, []);
   const [{ toaster: toasterStyleSet }] = useStyleSet();
   const [debouncedNotifications] = useDebouncedNotifications();
   const [expanded, setExpanded] = useState(false);
   const localizeWithPlural = useLocalizer({ plural: true });
-  const expandableElementId = useMemo(() => `webchat__toaster__list__${randomId()}`, []);
-  const headerElementId = useMemo(() => `webchat__toaster__header__${randomId()}`, []);
+  const expandableElementId = useMemo(
+    () => (!expandable || expanded ? `webchat__toaster__list__${instanceId}` : undefined),
+    [expandable, expanded]
+  );
+  const headerElementId = useMemo(() => (expandable ? `webchat__toaster__header__${instanceId}` : undefined), [
+    expandable
+  ]);
   const renderToast = useRenderToast();
 
   const handleToggleExpand = useCallback(() => setExpanded(!expanded), [expanded, setExpanded]);
@@ -98,7 +104,7 @@ const BasicToaster = () => {
     <div
       aria-labelledby={headerElementId}
       aria-live="polite"
-      aria-relevant="additions text"
+      aria-relevant="all"
       className={classNames(ROOT_CSS + '', toasterStyleSet + '', 'webchat__toaster', {
         'webchat__toaster--expandable': expandable,
         'webchat__toaster--expanded': expanded,
@@ -132,7 +138,7 @@ const BasicToaster = () => {
       {(!expandable || expanded) && (
         <ul aria-labelledby={headerElementId} className="webchat__toaster__list" id={expandableElementId} role="region">
           {sortedNotificationsWithChildren.map(({ children, notification: { id } }) => (
-            <li className="webchat__toaster__listItem" key={id} role="none">
+            <li aria-atomic={true} className="webchat__toaster__listItem" key={id} role="none">
               {children}
             </li>
           ))}

--- a/packages/testharness/src/conditions/toastShown.js
+++ b/packages/testharness/src/conditions/toastShown.js
@@ -1,9 +1,10 @@
 import getToastElements from '../elements/toasts';
+import getToasterHeader from '../elements/toasterHeader';
 
 export default function toastShown(message) {
   const conditionMessage =
     typeof message === 'number'
-      ? `for number of toasts equals to ${message}`
+      ? `for number of visible toasts equals to ${message}`
       : !message
       ? 'for any toast to show'
       : message instanceof RegExp
@@ -16,9 +17,14 @@ export default function toastShown(message) {
       const targetMessages = [].map.call(getToastElements(), ({ innerText }) => innerText.trim());
 
       if (typeof message === 'number') {
-        return targetMessages.length === message;
+        if (message === 0) {
+          return !targetMessages.length && !getToasterHeader()
+        } else {
+          return targetMessages.length === message;
+        }
       } else if (!message) {
-        return targetMessages.length;
+        // For any number of toasts to show, it can be collapsed (toaster header), or singular (only one toast is shown).
+        return targetMessages.length || getToasterHeader();
       } else if (message instanceof RegExp) {
         return targetMessages.some(targetMessage => message.test(targetMessage));
       }

--- a/packages/testharness/src/elements/index.js
+++ b/packages/testharness/src/elements/index.js
@@ -1,5 +1,7 @@
 import connectivityStatus from './connectivityStatus';
 import sendBoxTextBox from './sendBoxTextBox';
+import toastDismissButtons from './toastDismissButtons';
+import toasterHeader from './toasterHeader';
 import toasts from './toasts';
 
-export { connectivityStatus, sendBoxTextBox, toasts };
+export { connectivityStatus, sendBoxTextBox, toasterHeader, toastDismissButtons, toasts };

--- a/packages/testharness/src/elements/toastDismissButtons.js
+++ b/packages/testharness/src/elements/toastDismissButtons.js
@@ -1,0 +1,3 @@
+export default function toastDismissButtons() {
+  return document.querySelectorAll('.webchat__toast__dismissButton');
+}

--- a/packages/testharness/src/elements/toasterHeader.js
+++ b/packages/testharness/src/elements/toasterHeader.js
@@ -1,0 +1,3 @@
+export default function toasterHeader() {
+  return document.querySelector('.webchat__toaster__header');
+}

--- a/packages/testharness/src/pageObjects/clickToasterHeader.js
+++ b/packages/testharness/src/pageObjects/clickToasterHeader.js
@@ -1,0 +1,19 @@
+import getToasterHeader from '../elements/toasterHeader';
+import getToasts from '../elements/toasts';
+import wait from './wait';
+
+const { Simulate } = window.ReactTestUtils;
+
+export default async function clickToasterHeader() {
+  const { length } = getToasts();
+  const toasterHeader = getToasterHeader();
+  const willExpand = !length;
+
+  if (!toasterHeader) {
+    throw new Error('Cannot click toaster header because the header cannot be found.');
+  }
+
+  Simulate.click(toasterHeader);
+
+  await wait(() => !!getToasts().length === willExpand);
+}

--- a/packages/testharness/src/pageObjects/dismissToast.js
+++ b/packages/testharness/src/pageObjects/dismissToast.js
@@ -1,0 +1,19 @@
+import getToastDismissButtons from '../elements/toastDismissButtons';
+import wait from './wait';
+
+const { Simulate } = window.ReactTestUtils;
+
+export default async function dismissToast(index) {
+  const toastDismissButtons = getToastDismissButtons();
+  const toastDismissButton = toastDismissButtons[index];
+
+  if (!toastDismissButton) {
+    throw new Error(
+      `Cannot find toast dismiss button of index ${index}, there are ${toastDismissButtons.length} dismiss buttons visually.`
+    );
+  }
+
+  Simulate.click(toastDismissButton);
+
+  await wait(() => getToastDismissButtons().length === toastDismissButtons.length - 1);
+}

--- a/packages/testharness/src/pageObjects/index.js
+++ b/packages/testharness/src/pageObjects/index.js
@@ -1,7 +1,19 @@
+import clickToasterHeader from './clickToasterHeader';
+import dismissToast from './dismissToast';
 import getActivities from './getActivities';
 import pingBot from './pingBot';
 import sendMessageViaSendBox from './sendMessageViaSendBox';
 import typeInSendBox from './typeInSendBox';
+import verifyDOMIntegrity from './verifyDOMIntegrity';
 import wait from './wait';
 
-export { getActivities, pingBot, sendMessageViaSendBox, typeInSendBox, wait };
+export {
+  clickToasterHeader,
+  dismissToast,
+  getActivities,
+  pingBot,
+  sendMessageViaSendBox,
+  typeInSendBox,
+  verifyDOMIntegrity,
+  wait
+};

--- a/packages/testharness/src/pageObjects/verifyDOMIntegrity.js
+++ b/packages/testharness/src/pageObjects/verifyDOMIntegrity.js
@@ -1,0 +1,45 @@
+// We are trying our best effort to check for DOM tree integrity.
+// When we extend this function, we should also consider using open source tools to verify.
+export default function verifyDOMIntegrity() {
+  // If an element has "aria-labelledby", the label element must be present on the screen.
+  [].forEach.call(document.querySelectorAll('[aria-labelledby]'), element => {
+    const labelId = element.getAttribute('aria-labelledby');
+    const labelElement = document.getElementById(labelId);
+
+    if (!labelElement) {
+      const message = `verifyDOMIntegrity: Cannot find element referenced by aria-labelledby attribute with ID "${labelId}".`;
+
+      console.warn(message, element);
+
+      throw new Error(message);
+    }
+  });
+
+  // No two elements can have the same ID.
+  [].forEach.call(document.querySelectorAll('[id]'), element => {
+    const id = element.getAttribute('id');
+    const elementsWithId = document.querySelectorAll(`#${id}`);
+
+    if (elementsWithId.length > 1) {
+      const message = `Only one element can have ID "${id}", we saw ${elementsWithId.length} elements sharing same ID.`;
+
+      console.warn(message, elementsWithId);
+
+      throw new Error(message);
+    }
+  });
+
+  // No class attribute should have the word "undefined" in it
+
+  [].forEach.call(document.querySelectorAll('[class]'), element => {
+    const className = element.getAttribute('class');
+
+    if (~className.indexOf('undefined')) {
+      const message = `No elements should have the keyword "undefined" in it, we saw "${className}".`;
+
+      console.warn(message, element);
+
+      throw new Error(message);
+    }
+  });
+}


### PR DESCRIPTION
> Fixes #3054.

## Changelog Entry

### Fixed

-  Fixes [#3054](https://github.com/microsoft/BotFramework-WebChat/issues/3054). Notification toast should have valid `aria-labelledby`, by [@compulim](https://github.com/compulim) in PR [#3098](https://github.com/microsoft/BotFramework-WebChat/issue/3098)

## Description

When the toaster header is hidden (e.g. no toast or 1 toast shown), the `aria-labelledby` should not referencing to a non-existing element. Instead, the `aria-labelledby` should be hidden.

## Specific Changes

- When 0 or 1 toast is shown, set `aria-labelledby` to `undefined`.

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
