### PR TITLE
Bump to adaptivecards@1.2.6 and disable tabindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+-  Bumped Adaptive Cards dependencies, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+   -  [`adaptivecards@1.2.6`](https://npmjs.com/package/adaptivecards)
 -  Bumped dependencies due to [a bug in Babel and Node.js](https://github.com/nodejs/node/issues/32852), by [@compulim](https://github.com/compulim) in PR [#3177](https://github.com/microsoft/BotFramework-WebChat/pull/3177)
    -  Development dependencies
       -  [`@babel/preset-env@7.10.0`](https://npmjs.com/package/@babel/preset-env)

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -2365,9 +2365,9 @@
 			"dev": true
 		},
 		"adaptivecards": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.5.tgz",
-			"integrity": "sha512-Rj+QK0qtBOfLGy3ClXylKxL4ze/a6mtPiJL7Ctjyc1Uso9O1x/LAAu49F36ZQbgAa8vWkKW91RKcwBBOxk3HDg=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.6.tgz",
+			"integrity": "sha512-/l34rvdRzQ20QdGLk+awRUotexu3N4Ih3O0qR8cM+2wWe0pggvWhmFdwVFmM+YgIS5pWtl2u7XAJynUaFIQAIw=="
 		},
 		"agent-base": {
 			"version": "4.3.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.8.7",
-    "adaptivecards": "1.2.5",
+    "adaptivecards": "1.2.6",
     "botframework-directlinejs": "0.11.6",
     "botframework-directlinespeech-sdk": "0.0.0-0",
     "botframework-webchat-component": "0.0.0-0",

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
@@ -218,7 +218,7 @@ function saveInputValues(element) {
 
 const AdaptiveCardRenderer = ({ actionPerformedClassName, adaptiveCard, disabled: disabledFromProps, tapAction }) => {
   const [{ adaptiveCardRenderer: adaptiveCardRendererStyleSet }] = useStyleSet();
-  const [{ HostConfig }] = useAdaptiveCardsPackage();
+  const [{ GlobalSettings, HostConfig }] = useAdaptiveCardsPackage();
   const [actionsPerformed, setActionsPerformed] = useState([]);
   const [adaptiveCardsHostConfig] = useAdaptiveCardsHostConfig();
   const [disabledFromComposer] = useDisabled();
@@ -324,6 +324,9 @@ const AdaptiveCardRenderer = ({ actionPerformedClassName, adaptiveCard, disabled
         ? new HostConfig(adaptiveCardsHostConfig)
         : adaptiveCardsHostConfig;
     }
+
+    // For accessibility issue #1340, `tabindex="0"` must not be set for the root container if it is non-interactive.
+    GlobalSettings.setTabIndexAtCardRoot = !!tapAction;
 
     const { failures } = adaptiveCard.validateProperties();
 


### PR DESCRIPTION
Fixes #1340.

## Changelog Entry

### Fixed

-  Fixes [#1340](https://github.com/microsoft/BotFramework-WebChat/issues/1340). Card container should not be focusable if they do not have `tapAction`, by [@compulim](https://github.compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/XXX)

### Changed

-  Bumped Adaptive Cards dependencies, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
   -  [`adaptivecards@1.2.6`](https://npmjs.com/package/adaptivecards)

## Description

Card container should not be focusable (no `tabIndex="0"`) if they do not have `tapAction`. This requires bumping to Adaptive Cards 1.2.6 plus a global settings.

## Specific Changes

- Bump to `adaptivecards@1.2.6`
- Set `AdaptiveCards.GlobalSettings.setTabIndexAtCardRoot` to `true` if the card has `tapAction` prop, otherwise `false`

---

-  [ ] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
