### PR TITLE
Add "noopener noreferrer" to card action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixed [#3196](https://github.com/microsoft/BotFramework-WebChat/issues/3196). Cards with `tapAction` should be executable by <kbd>ENTER</kbd> or <kbd>SPACEBAR</kbd> key, by [@compulim](https://github.com/compulim) in PR [#3197](https://github.com/microsoft/BotFramework-WebChat/pull/3197)
 -  Fixed [#3203](https://github.com/microsoft/BotFramework-WebChat/issues/3203). "New messages" button should be narrated by assistive technology, by [@compulim](https://github.com/compulim) in PR [#3204](https://github.com/microsoft/BotFramework-WebChat/pull/3204)
 -  Fixed [#3217](https://github.com/microsoft/BotFramework-WebChat/issues/3217). Make sure `rel="noopener noreferrer` is not sanitized, by [@compulim](https://github.com/compulim) in PR [#3220](https://github.com/microsoft/BotFramework-WebChat/pull/3220)
--  Fixed [#3223](https://github.com/microsoft/BotFramework-WebChat/issues/3223). Tap an `openUrl` card action should open URL in a new tab with `noopener noreferrer` set, by [@compulim] in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixed [#3223](https://github.com/microsoft/BotFramework-WebChat/issues/3223). Tap an `openUrl` card action should open URL in a new tab with `noopener noreferrer` set, by [@compulim](https://github.com/compulim) in PR [#3224](https://github.com/microsoft/BotFramework-WebChat/pull/3224)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#1340](https://github.com/microsoft/BotFramework-WebChat/issues/1340). Card container should not be focusable if they do not have `tapAction`, by [@compulim](https://github.com/compulim) in PR [#3193](https://github.com/microsoft/BotFramework-WebChat/issues/3193)
+-  Fixes [#1340](https://github.com/microsoft/BotFramework-WebChat/issues/1340). Card container should not be focusable if they do not have `tapAction`, by [@compulim](https://github.com/compulim) in PR [#3193](https://github.com/microsoft/BotFramework-WebChat/pull/3193)
 -  Fixed [#3196](https://github.com/microsoft/BotFramework-WebChat/issues/3196). Cards with `tapAction` should be executable by <kbd>ENTER</kbd> or <kbd>SPACEBAR</kbd> key, by [@compulim](https://github.com/compulim) in PR [#3197](https://github.com/microsoft/BotFramework-WebChat/pull/3197)
 -  Fixed [#3203](https://github.com/microsoft/BotFramework-WebChat/issues/3203). "New messages" button should be narrated by assistive technology, by [@compulim](https://github.com/compulim) in PR [#3204](https://github.com/microsoft/BotFramework-WebChat/pull/3204)
--  Fixed [#3217](https://github.com/microsoft/BotFramework-WebChat/issues/3217). Make sure `rel="noopener noreferrer` is not sanitized, by [@compulim](https://github.com/compulim) in PR [#3220](https://github.com/microsoft/BotFramework-WebChat/issues/3220)
+-  Fixed [#3217](https://github.com/microsoft/BotFramework-WebChat/issues/3217). Make sure `rel="noopener noreferrer` is not sanitized, by [@compulim](https://github.com/compulim) in PR [#3220](https://github.com/microsoft/BotFramework-WebChat/pull/3220)
+-  Fixed [#3223](https://github.com/microsoft/BotFramework-WebChat/issues/3223). Tap an `openUrl` card action should open URL in a new tab with `noopener noreferrer` set, by [@compulim] in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Changed
 

--- a/__tests__/html/cardAction.adaptiveCard.openURL.html
+++ b/__tests__/html/cardAction.adaptiveCard.openURL.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const {
+        conditions,
+        createRunHookActivityMiddleware,
+        createStore,
+        elements,
+        expect,
+        host,
+        pageObjects,
+        timeouts,
+        token
+      } = window.WebChatTest;
+
+      function stringToArrayBuffer(value) {
+        // This assume the string is ASCII (0-127).
+
+        const { length } = value;
+        const byteArray = new Array(length);
+
+        for (let index = 0; index < length; index++) {
+          const charCode = value.charCodeAt(index);
+
+          if (charCode > 127) {
+            throw new Error('Only ASCII characters are supported.');
+          }
+
+          byteArray[index] = charCode;
+        }
+
+        return new Uint8Array(byteArray).buffer;
+      }
+
+      (async function() {
+        window.WebChat.renderWebChat(
+          {
+            activityMiddleware: createRunHookActivityMiddleware(),
+            directLine: window.WebChat.createDirectLine({ token: await token.fetchDirectLineToken() }),
+            store: createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+
+        const fileBlob = new Blob([
+          stringToArrayBuffer(
+            JSON.stringify(
+              {
+                contentType: 'application/vnd.microsoft.card.adaptive',
+                content: {
+                  type: 'AdaptiveCard',
+                  body: [
+                    {
+                      type: 'TextBlock',
+                      size: 'Medium',
+                      text: 'Tap on this Adaptive Card will open Bing.com.'
+                    }
+                  ],
+                  $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+                  version: '1.2',
+                  selectAction: {
+                    type: 'Action.OpenUrl',
+                    url: 'https://bing.com/'
+                  }
+                }
+              },
+              null,
+              2
+            )
+          )
+        ]);
+
+        fileBlob.name = 'openurl-card.attachmentjson';
+
+        await pageObjects.runHook(({ useSendFiles }) => useSendFiles()([fileBlob]));
+        await pageObjects.wait(conditions.minNumActivitiesShown(2), timeouts.directLine);
+
+        const calls = [];
+
+        window.open = (url, windowName, windowFeatures) => calls.push([url, windowName, windowFeatures]);
+
+        const adaptiveCard = elements.activities()[1].querySelector('.ac-adaptiveCard');
+
+        adaptiveCard.click();
+
+        expect(calls).toHaveProperty('length', 1);
+        expect(calls[0][0]).toEqual('https://bing.com/');
+        expect(calls[0][1]).toEqual('_blank');
+
+        const windowFeatures = (calls[0][2] || '').split(new RegExp('\\s+', 'gu'));
+
+        expect(windowFeatures.includes('noopener')).toBe(true);
+        expect(windowFeatures.includes('noreferrer')).toBe(true);
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/cardAction.adaptiveCard.openURL.js
+++ b/__tests__/html/cardAction.adaptiveCard.openURL.js
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('"openUrl" action on Adaptive Card', () => {
+  test('should open URL in a new tab with "noopener" and "noreferrer"', () =>
+    runHTMLTest('cardAction.adaptiveCard.openURL.html'));
+});

--- a/__tests__/html/cardAction.heroCard.openURL.html
+++ b/__tests__/html/cardAction.heroCard.openURL.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const {
+        conditions,
+        createRunHookActivityMiddleware,
+        createStore,
+        elements,
+        expect,
+        host,
+        pageObjects,
+        timeouts,
+        token
+      } = window.WebChatTest;
+
+      function stringToArrayBuffer(value) {
+        // This assume the string is ASCII (0-127).
+
+        const { length } = value;
+        const byteArray = new Array(length);
+
+        for (let index = 0; index < length; index++) {
+          const charCode = value.charCodeAt(index);
+
+          if (charCode > 127) {
+            throw new Error('Only ASCII characters are supported.');
+          }
+
+          byteArray[index] = charCode;
+        }
+
+        return new Uint8Array(byteArray).buffer;
+      }
+
+      (async function() {
+        window.WebChat.renderWebChat(
+          {
+            activityMiddleware: createRunHookActivityMiddleware(),
+            directLine: window.WebChat.createDirectLine({ token: await token.fetchDirectLineToken() }),
+            store: createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+
+        const fileBlob = new Blob([
+          stringToArrayBuffer(
+            JSON.stringify(
+              {
+                contentType: 'application/vnd.microsoft.card.hero',
+                content: {
+                  tap: {
+                    type: 'openUrl',
+                    value: 'https://bing.com/'
+                  },
+                  title: 'Tap on this hero card will open Bing.com.'
+                }
+              },
+              null,
+              2
+            )
+          )
+        ]);
+
+        fileBlob.name = 'openurl-card.attachmentjson';
+
+        await pageObjects.runHook(({ useSendFiles }) => useSendFiles()([fileBlob]));
+        await pageObjects.wait(conditions.minNumActivitiesShown(2), timeouts.directLine);
+
+        const calls = [];
+
+        window.open = (url, windowName, windowFeatures) => calls.push([url, windowName, windowFeatures]);
+
+        const adaptiveCard = elements.activities()[1].querySelector('.ac-adaptiveCard');
+
+        adaptiveCard.click();
+
+        expect(calls).toHaveProperty('length', 1);
+        expect(calls[0][0]).toEqual('https://bing.com/');
+        expect(calls[0][1]).toEqual('_blank');
+
+        const windowFeatures = (calls[0][2] || '').split(new RegExp('\\s+', 'gu'));
+
+        expect(windowFeatures.includes('noopener')).toBe(true);
+        expect(windowFeatures.includes('noreferrer')).toBe(true);
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/cardAction.heroCard.openURL.js
+++ b/__tests__/html/cardAction.heroCard.openURL.js
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('"openUrl" action on hero card', () => {
+  test('should open URL in a new tab with "noopener" and "noreferrer"', () =>
+    runHTMLTest('cardAction.heroCard.openURL.html'));
+});

--- a/packages/component/src/Middleware/CardAction/createCoreMiddleware.js
+++ b/packages/component/src/Middleware/CardAction/createCoreMiddleware.js
@@ -31,7 +31,7 @@ export default function createDefaultCardActionMiddleware() {
       case 'playAudio':
       case 'playVideo':
       case 'showImage':
-        window.open(value);
+        window.open(value, '_blank', 'noopener noreferrer');
         break;
 
       case 'signin': {


### PR DESCRIPTION
> Fixes #3223.

## Changelog Entry

### Fixed

-  Fixed [#3223](https://github.com/microsoft/BotFramework-WebChat/issues/3223). Tap an `openUrl` card action should open URL in a new tab with `noopener noreferrer` set, by [@compulim](https://github.com/compulim) in PR [#3224](https://github.com/microsoft/BotFramework-WebChat/pull/3224)

## Description

Add `noopener noreferrer` to `openUrl` card action. This card action is used by Adaptive Card, hero card, suggested actions, etc.

## Specific Changes

- Modify the default card action middleware
   - When a card action of `openUrl` is being executed, it should open using `window.open(url, '_blank', 'noopener noreferrer')`

---

-  [x] Testing Added
   <!-- If you are adding a new feature to a library, you must include tests for your new code. -->
