### PR TITLE
[HIGH] 4.9.1 Post-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.9.1",
+  "version": "4.9.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.9.1",
+  "version": "4.9.2-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -156,6 +156,13 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.9.1": {
+      "assets": [
+        ["https://cdn.botframework.com/botframework-webchat/4.9.1/webchat-es5.js", "sha384-7GOIvwVvb++zeyLdIJlXOit8VaYsDJFo0VWa1hgXnVsUnidOjkGlNYOZfuBaepS5"]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "3": {
       "redirects": [
         ["*", "0.15.1-v3.748a85f"]

--- a/samples/05.custom-components/l.disable-adaptive-cards/index.html
+++ b/samples/05.custom-components/l.disable-adaptive-cards/index.html
@@ -16,8 +16,7 @@
       This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
       https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
     -->
-    <!-- <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script> -->
-    <script crossorigin="anonymous" src="/webchat-es5.js"></script>
+    <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <style>
       html,
       body {


### PR DESCRIPTION
Post-release work for 4.9.1:

- Bump to `4.9.2-0`
- Update `servicingPlan.json` to include `4.9.1`
- Update samples which use daily build to `4.9.1` build