### PR TITLE
Fix package-lock.json in samples to resolve `p-defer` as peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Samples
 
 -  Added Content Security Policy sample, by [@compulim](https://github.com/compulim), in PR [#3443](https://github.com/microsoft/BotFramework-WebChat/pull/3443)
+-  Update `create-react-app`-based samples to resolve `p-defer` as peer dependency, by [@compulim](https://github.com/compulim), in PR [#3457](https://github.com/microsoft/BotFramework-WebChat/pull/3457)
 
 ## [4.10.0] - 2020-08-18
 

--- a/samples/04.api/e.piping-to-redux/package-lock.json
+++ b/samples/04.api/e.piping-to-redux/package-lock.json
@@ -5574,7 +5574,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -5756,11 +5757,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5913,11 +5909,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",
@@ -10550,7 +10541,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -15686,6 +15678,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-defer-es5": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/p-defer-es5/-/p-defer-es5-1.2.1.tgz",
@@ -20286,7 +20283,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -21842,11 +21840,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/04.api/f.selectable-activity/package-lock.json
+++ b/samples/04.api/f.selectable-activity/package-lock.json
@@ -5793,11 +5793,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5951,11 +5946,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "redux": {
           "version": "4.0.4",
@@ -16963,6 +16953,11 @@
         }
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -21568,11 +21563,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/04.api/g.chat-send-history/package-lock.json
+++ b/samples/04.api/g.chat-send-history/package-lock.json
@@ -5756,11 +5756,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5887,11 +5882,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "redux": {
           "version": "4.0.4",
@@ -17146,6 +17136,11 @@
         }
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -21829,11 +21824,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/04.api/h.clear-after-idle/package-lock.json
+++ b/samples/04.api/h.clear-after-idle/package-lock.json
@@ -5756,11 +5756,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5887,11 +5882,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "redux": {
           "version": "4.0.4",
@@ -17146,6 +17136,11 @@
         }
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -21829,11 +21824,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/06.recomposing-ui/a.minimizable-web-chat/package-lock.json
+++ b/samples/06.recomposing-ui/a.minimizable-web-chat/package-lock.json
@@ -5756,11 +5756,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5887,11 +5882,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "redux": {
           "version": "4.0.4",
@@ -17146,6 +17136,11 @@
         }
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -21829,11 +21824,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/06.recomposing-ui/b.speech-ui/package-lock.json
+++ b/samples/06.recomposing-ui/b.speech-ui/package-lock.json
@@ -5631,11 +5631,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -5830,11 +5825,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",
@@ -16051,6 +16041,11 @@
         }
       }
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -20570,11 +20565,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/06.recomposing-ui/c.smart-display/package-lock.json
+++ b/samples/06.recomposing-ui/c.smart-display/package-lock.json
@@ -5581,7 +5581,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -5767,11 +5768,6 @@
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",
@@ -5964,11 +5960,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",
@@ -10487,7 +10478,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -15436,6 +15428,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-defer-es5": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/p-defer-es5/-/p-defer-es5-1.2.1.tgz",
@@ -18606,9 +18603,9 @@
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
     "react-film": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-film/-/react-film-1.3.0.tgz",
-      "integrity": "sha512-pNqOFzv+RZN0Laz3HFp30KRx1Jrw3TUyp6EuCa1quaUnCBE5RaIkkiBvjTu4RRdgFNe8B2fk5ZvsDzRwjA8qoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-film/-/react-film-2.1.0.tgz",
+      "integrity": "sha512-C9+oOF+JILeJ/0CqQAW2PI+xIVRl70vVVEEPooh9Oc/Tfl/PUDGUGd2RuDKVREHyYo2MJ1jCjJbUMivbCQ+ALg==",
       "requires": {
         "classnames": "^2.2.6",
         "glamor": "^2.20.40",
@@ -19966,7 +19963,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -21449,11 +21447,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "p-defer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
         },
         "regenerator-runtime": {
           "version": "0.13.7",

--- a/samples/06.recomposing-ui/d.plain-ui/package-lock.json
+++ b/samples/06.recomposing-ui/d.plain-ui/package-lock.json
@@ -5747,7 +5747,6 @@
 				"event-target-shim-es5": "1.2.0",
 				"math-random": "2.0.0",
 				"microsoft-cognitiveservices-speech-sdk": "1.10.1",
-				"p-defer": "3.0.0",
 				"p-defer-es5": "1.2.1",
 				"web-speech-cognitive-services": "7.0.1"
 			},
@@ -5764,11 +5763,6 @@
 					"version": "3.6.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
 					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-				},
-				"p-defer": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-					"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 				},
 				"regenerator-runtime": {
 					"version": "0.13.7",
@@ -5903,11 +5897,6 @@
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
-				},
-				"p-defer": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-					"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 				},
 				"redux": {
 					"version": "4.0.4",
@@ -17050,6 +17039,11 @@
 				}
 			}
 		},
+		"p-defer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+		},
 		"p-each-series": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -21729,11 +21723,6 @@
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
-				},
-				"p-defer": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-					"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 				},
 				"regenerator-runtime": {
 					"version": "0.13.7",


### PR DESCRIPTION
## Changelog Entry

### Samples

-  Update `create-react-app`-based samples to resolve `p-defer` as peer dependency, by [@compulim](https://github.com/compulim), in PR [#3457](https://github.com/microsoft/BotFramework-WebChat/pull/3457)

## Description

Some samples were failed to build because their `package-lock.json` resolve `p-defer` not as peer dependency.

## Design

Some samples did not resolve `p-defer` correctly.

## Specific Changes

- Modify `samples/**/package-lock.json` to make sure `p-defer` are resolved as peer dependency of `p-defer-es5`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
