### PR TITLE
Bump to 4.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.10.1] - 2020-09-09
+
 ### Breaking changes
 
 -  To support Content Security Policy, [`glamor`](https://npmjs.com/package/glamor) is being replaced by [`create-emotion`](https://npmjs.com/package/create-emotion). The CSS hash and rule name is being prefixed with `webchat--css` with a random value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+-  Bumped [`botframework-directlinejs@0.13.1`](https://npmjs.com/package/botframework-directlinejs), by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 -  Support Content Security Policy, in PR [#3443](https://github.com/microsoft/BotFramework-WebChat/pull/3443) by [@compulim](https://github.com/compulim)
    -  Moved from [`glamor@2.20.40`](https://npmjs.com/package/glamor) to [`create-emotion@10.0.27`](https://npmjs.com/package/create-emotion)
    -  Inlined assets are now using `blob:` scheme, instead of `data:` scheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--  Bumped [`botframework-directlinejs@0.13.1`](https://npmjs.com/package/botframework-directlinejs), by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Bumped [`botframework-directlinejs@0.13.1`](https://npmjs.com/package/botframework-directlinejs), by [@compulim](https://github.com/compulim) in PR [#3461](https://github.com/microsoft/BotFramework-WebChat/pull/3461)
 -  Support Content Security Policy, in PR [#3443](https://github.com/microsoft/BotFramework-WebChat/pull/3443) by [@compulim](https://github.com/compulim)
    -  Moved from [`glamor@2.20.40`](https://npmjs.com/package/glamor) to [`create-emotion@10.0.27`](https://npmjs.com/package/create-emotion)
    -  Inlined assets are now using `blob:` scheme, instead of `data:` scheme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.10.1-0",
+  "version": "4.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.10.1-0",
+  "version": "4.10.1",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -3650,12 +3650,12 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"botframework-directlinejs": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.13.0.tgz",
-			"integrity": "sha512-OJR5Ov+Dd/S5wEb0kWfpey1PerZFeRalWQ+WJfX5xEVQsQN/cDLpz0JjLiAIcPZcuTlUC9oEYfWSvTnlQLfCFw==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.13.1.tgz",
+			"integrity": "sha512-fE2uDcct7xPSTipuUQzpohy2VPIcM2LU2P/6G+TmDHPBLiXm47TU89/y4jZzh7eHNyR+8oPOtfMPkJ7YUU7nbg==",
 			"requires": {
 				"@babel/runtime": "7.6.0",
-				"botframework-streaming": "4.9.2",
+				"botframework-streaming": "4.10.3",
 				"core-js": "3.6.4",
 				"cross-fetch": "3.0.4",
 				"rxjs": "5.5.10",
@@ -3683,12 +3683,12 @@
 			}
 		},
 		"botframework-streaming": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.9.2.tgz",
-			"integrity": "sha512-Vl94e6SnKUp94R1akKpFAUK5kinaKLAAmSBrol/fV8xghtfsZNLMWyVLDYPmstWdemuH5Jccpahb3mgPuEqV8A==",
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.3.tgz",
+			"integrity": "sha512-9g6942ejQQ6S72OT5uzN5HaKBYQrsDTXQ0d3Z9+7Q1Rj7gpJJEI0JzsSkX+80k746TQJEk3V7PRnV+HXNOqduA==",
 			"requires": {
 				"@types/ws": "^6.0.3",
-				"uuid": "^3.3.2",
+				"uuid": "^3.4.0",
 				"ws": "^7.1.2"
 			}
 		},

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "7.11.2",
     "adaptivecards": "1.2.6",
-    "botframework-directlinejs": "0.13.0",
+    "botframework-directlinejs": "0.13.1",
     "botframework-directlinespeech-sdk": "0.0.0-0",
     "botframework-webchat-component": "0.0.0-0",
     "botframework-webchat-core": "0.0.0-0",


### PR DESCRIPTION
## Changelog Entry

## [4.10.1] - 2020-09-09

### Changed

-  Bumped [`botframework-directlinejs@0.13.1`](https://npmjs.com/package/botframework-directlinejs), by [@compulim](https://github.com/compulim) in PR [#3461](https://github.com/microsoft/BotFramework-WebChat/pull/3461)

## Description

Bump `botframework-directlinejs@0.13.1` and prepare to release 4.10.1.

## Specific Changes

- Bump `botframework-directlinejs@0.13.1`
- Bump Web Chat to `4.10.1`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
