### PR TITLE
[HIGH] Bump to 4.10.2-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.10.1",
+  "version": "4.10.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.10.1",
+  "version": "4.10.2-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -172,9 +172,22 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.10": {
+      "redirects": [
+        ["*", "4.10.1"]
+      ]
+    },
     "4.10.0": {
       "assets": [
         ["https://cdn.botframework.com/botframework-webchat/4.10.0/webchat-es5.js", "sha384-nB4tinBxptD4DwQRrhIiZL2tKeB0n2aHg2b+/RoBi801c0zU2BRRL21pKMYYhr/j"]
+      ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2022-09-10.",
+      "private": true,
+      "versionFamily": "4"
+    },
+    "4.10.1": {
+      "assets": [
+        ["https://cdn.botframework.com/botframework-webchat/4.10.1/webchat-es5.js", "sha384-ZT32ehV2SkikXkWvH8cO0OsMgQoYg+zd09eBP5oJrcrL3FJWqPSB1IGifTBYKccw"]
       ],
       "private": true,
       "versionFamily": "4"

--- a/samples/01.getting-started/j.bundle-with-content-security-policy/index.html
+++ b/samples/01.getting-started/j.bundle-with-content-security-policy/index.html
@@ -11,8 +11,11 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; base-uri 'none'; connect-src blob: https://directline.botframework.com wss://directline.botframework.com https://webchat-mockbot.azurewebsites.net; img-src blob:; script-src 'nonce-a1b2c3d' 'strict-dynamic' 'unsafe-eval'; style-src 'nonce-a1b2c3d'"
     />
-    <!-- <script crossorigin="anonymous" nonce="a1b2c3d" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script> -->
-    <script nonce="a1b2c3d" src="https://github.com/microsoft/BotFramework-WebChat/releases/download/daily/webchat.js"></script>
+    <script
+      crossorigin="anonymous"
+      nonce="a1b2c3d"
+      src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"
+    ></script>
     <style nonce="a1b2c3d">
       html,
       body {


### PR DESCRIPTION
> Related to #3469.

## Changelog Entry

(No need for CHANGELOG as this is not visible to developers: post-release version bump and update samples URL)

## Description

This is for post-release.

## Specific Changes

- Update to `4.10.2-0`
   - So next interim release will become `4.10.2-20200910-master.a1b2c3d`, which means RC build of `4.10.2`
- Update `servicingPlan.json` to add a new entry for `4.10.2`
   - Also added missing `4.10` entry
- Update samples to use CDN version, as we now rolled out to CDN

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
