### PR TITLE
Fix bot initials being undefined in AT text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Fixes [#3489](https://github.com/microsoft/BotFramework-WebChat/issues/3489). Fix AT saying 'Bot undefined said', by [@corinagum](https://github.com/corinagum) in PR [#3524](https://github.com/microsoft/BotFramework-WebChat/pull/3524)
+
 ### Changed
 
 -  Bumped development dependency [`node-fetch@2.6.1`](https://npmjs.com/package/node-fetch) in PR [#3467](https://github.com/microsoft/BotFramework-WebChat/pull/3467) by [@dependabot](https://github.com/dependabot)

--- a/packages/component/src/ScreenReaderActivity.js
+++ b/packages/component/src/ScreenReaderActivity.js
@@ -50,7 +50,7 @@ const ScreenReaderActivity = ({ activity }) => {
 
   const greetingAlt = (fromUser
     ? localize('ACTIVITY_YOU_SAID_ALT')
-    : localize('ACTIVITY_BOT_SAID_ALT', botInitials)
+    : localize('ACTIVITY_BOT_SAID_ALT', botInitials || '')
   ).replace(/\s{2,}/gu, ' ');
   const numAttachmentsAlt =
     !!attachments.length && localizeWithPlural(ACTIVITY_NUM_ATTACHMENTS_ALT_IDS, attachments.length);


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3489

## Changelog Entry

-  Fixes [#3489](https://github.com/microsoft/BotFramework-WebChat/issues/3489). Fix AT saying 'Bot undefined said', by [@corinagum](https://github.com/corinagum) in PR [#3524](https://github.com/microsoft/BotFramework-WebChat/pull/3524)
## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes

Previously, bot initials were being said as `undefined` if initials have not been assigned. 
- Change already present for `CarouselFilmStrip` and `StackedLayout`
- Therefore, only added for `ScreenReaderActivity`
<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

- NOTE: accessibility issue; currently no test framework

~-  [ ] I have added tests and executed them locally~ 
-  [x] I have updated `CHANGELOG.md`
~-  [ ] I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
