### PR TITLE
Fix obsolete Web Chat API of Avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ Here is how how you can add Web Chat control to your website:
           }),
           userID: 'YOUR_USER_ID',
           username: 'Web Chat User',
-          locale: 'en-US',
-          botAvatarInitials: 'WC',
-          userAvatarInitials: 'WW'
+          locale: 'en-US'
         },
         document.getElementById('webchat')
       );
@@ -119,7 +117,7 @@ Here is how how you can add Web Chat control to your website:
 ```
 <!-- prettier-ignore-end -->
 
-> `userID`, `username`, `locale`, `botAvatarInitials`, and `userAvatarInitials` are all optional parameters to pass into the `renderWebChat` method. To learn more about Web Chat props, look at the [Web Chat API Reference](https://github.com/microsoft/BotFramework-WebChat/tree/master/docs/API.md) documentation.
+> `userID`, `username`, and `locale` are all optional parameters to pass into the `renderWebChat` method. To learn more about Web Chat props, look at the [Web Chat API Reference](https://github.com/microsoft/BotFramework-WebChat/tree/master/docs/API.md) documentation.
 
 > Assigning `userID` as a static value is not recommended since this will cause all users to share state. Please see the [`API userID entry`](https://github.com/microsoft/BotFramework-WebChat/blob/master/docs/API.md#userID) for more information.
 


### PR DESCRIPTION
##  Description
I found botAvatarInitials and userAvatarInitials on [README](https://github.com/microsoft/BotFramework-WebChat/blob/master/README.md#integrate-with-javascript) document.
However, it doesn't work.

Also, I found there is no longer the two parameters on [Web Chat API Reference](https://github.com/microsoft/BotFramework-WebChat/blob/master/docs/API.md).

Meanwhile, it works correctly if I set botAvatarInitials and userAvatarInitials on [styleOptions](https://github.com/microsoft/BotFramework-WebChat/tree/master/samples/02.branding-styling-and-customization/a.branding-web-chat#getting-started).

## Specific Changes
I remove botAvatarInitials and userAvatarInitials from Web Chat API parameters on README document.

#### before
```
window.WebChat.renderWebChat(
        {
          directLine: window.WebChat.createDirectLine({
            token: 'YOUR_DIRECT_LINE_TOKEN'
          }),
          userID: 'YOUR_USER_ID',
          username: 'Web Chat User',
          locale: 'en-US',
          botAvatarInitials: 'WC',
          userAvatarInitials: 'WW'
        },
        document.getElementById('webchat')
      );
```

#### after
```
window.WebChat.renderWebChat(
        {
          directLine: window.WebChat.createDirectLine({
            token: 'YOUR_DIRECT_LINE_TOKEN'
          }),
          userID: 'YOUR_USER_ID',
          username: 'Web Chat User',
          locale: 'en-US'
        },
        document.getElementById('webchat')
      );
```

Previously it could be set in the Web Chat API Reference, but I'm guessing it's obsolete now.
I believe it is appropriate to set them in styleOptions now.