### PR TITLE
Insert typing activity into transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3371](https://github.com/microsoft/BotFramework-WebChat/issues/3371). Add alt property for image in HeroCards, by [@corinagum](https://github.com/corinagum) in PR [#3541](https://github.com/microsoft/BotFramework-WebChat/pull/3541)
 -  Fixes [#3310](https://github.com/microsoft/BotFramework-WebChat/issues/3310). Add quantity, tap and text field to ReceiptCards, by [@corinagum](https://github.com/corinagum) in PR [#3541](https://github.com/microsoft/BotFramework-WebChat/pull/3541)
 -  Fixes [#3514](https://github.com/microsoft/BotFramework-WebChat/issues/3514). Fix PoliCheck language errors, by [@corinagum](https://github.com/corinagum) in PR [#3545](https://github.com/microsoft/BotFramework-WebChat/pull/3545)
+-  Fixes [#3431](https://github.com/microsoft/BotFramework-WebChat/issues/3431). Activities should not be delayed due to missing activity of type "typing", by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3371](https://github.com/microsoft/BotFramework-WebChat/issues/3371). Add alt property for image in HeroCards, by [@corinagum](https://github.com/corinagum) in PR [#3541](https://github.com/microsoft/BotFramework-WebChat/pull/3541)
 -  Fixes [#3310](https://github.com/microsoft/BotFramework-WebChat/issues/3310). Add quantity, tap and text field to ReceiptCards, by [@corinagum](https://github.com/corinagum) in PR [#3541](https://github.com/microsoft/BotFramework-WebChat/pull/3541)
 -  Fixes [#3514](https://github.com/microsoft/BotFramework-WebChat/issues/3514). Fix PoliCheck language errors, by [@corinagum](https://github.com/corinagum) in PR [#3545](https://github.com/microsoft/BotFramework-WebChat/pull/3545)
--  Fixes [#3431](https://github.com/microsoft/BotFramework-WebChat/issues/3431). Activities should not be delayed due to missing activity of type "typing", by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#3431](https://github.com/microsoft/BotFramework-WebChat/issues/3431). Activities should not be delayed due to missing activity of type "typing", by [@compulim](https://github.com/compulim) in PR [#3554](https://github.com/microsoft/BotFramework-WebChat/pull/3554)
 
 ### Changed
 

--- a/Dockerfile-testharness
+++ b/Dockerfile-testharness
@@ -9,6 +9,7 @@ EXPOSE 80
 RUN npm install serve@10.0.0 -g
 ENTRYPOINT ["npx", "--no-install", "serve", "-p", "80", "/web"]
 
+RUN echo {}>/web/package.json
 ADD __tests__/setup/web/ /web
 ADD packages/bundle/dist /web
 WORKDIR /web

--- a/Dockerfile-testharness
+++ b/Dockerfile-testharness
@@ -9,7 +9,7 @@ EXPOSE 80
 RUN npm install serve@10.0.0 -g
 ENTRYPOINT ["npx", "--no-install", "serve", "-p", "80", "/web"]
 
-RUN echo {}>/web/package.json
 ADD __tests__/setup/web/ /web
 ADD packages/bundle/dist /web
+RUN echo {}>/web/package.json
 WORKDIR /web

--- a/Dockerfile-testharness2
+++ b/Dockerfile-testharness2
@@ -10,8 +10,8 @@ RUN npm install serve@11.3.0 -g
 WORKDIR /web/
 ENTRYPOINT ["npx", "--no-install", "serve", "-c", "serve-test.json", "-p", "80", "/web/"]
 
-RUN echo {}>/web/package.json
 ADD serve-test.json /web/
 ADD __tests__/html/ /web/__tests__/html/
 ADD packages/bundle/dist/webchat-es5.js /web/packages/bundle/dist/
 ADD packages/testharness/dist/testharness.js /web/packages/testharness/dist/
+RUN echo {}>/web/package.json

--- a/Dockerfile-testharness2
+++ b/Dockerfile-testharness2
@@ -10,6 +10,7 @@ RUN npm install serve@11.3.0 -g
 WORKDIR /web/
 ENTRYPOINT ["npx", "--no-install", "serve", "-c", "serve-test.json", "-p", "80", "/web/"]
 
+RUN echo {}>/web/package.json
 ADD serve-test.json /web/
 ADD __tests__/html/ /web/__tests__/html/
 ADD packages/bundle/dist/webchat-es5.js /web/packages/bundle/dist/

--- a/__tests__/html/__jest__/runPageProcessor.js
+++ b/__tests__/html/__jest__/runPageProcessor.js
@@ -24,17 +24,17 @@ export default async function runPageProcessor(driver, { ignoreConsoleError = fa
   const webChatTestLoaded = await driver.executeScript(() => !!window.WebChatTest);
 
   if (!webChatLoaded) {
-    const browserConsoleErrors = await getBrowserConsoleLogs(driver);
-
-    browserConsoleErrors.length && console.log(browserConsoleErrors);
+    try {
+      console.log('Browser console logs', await getBrowserConsoleLogs(driver));
+    } catch (err) {}
 
     throw new Error('"webchat.js" did not load on the page, or the page was not found.');
   }
 
   if (!webChatTestLoaded) {
-    const browserConsoleErrors = await getBrowserConsoleLogs(driver);
-
-    browserConsoleErrors.length && console.log(browserConsoleErrors);
+    try {
+      console.log('Browser console logs', await getBrowserConsoleLogs(driver));
+    } catch (err) {}
 
     throw new Error('"testharness.js" did not load on the page.');
   }

--- a/__tests__/html/__jest__/setupRunHTMLTest.js
+++ b/__tests__/html/__jest__/setupRunHTMLTest.js
@@ -21,7 +21,7 @@ global.runHTMLTest = async (
 
   const preferences = new logging.Preferences();
 
-  preferences.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
+  preferences.setLevel(logging.Type.BROWSER, logging.Level.WARNING);
   chromeOptions.setLoggingPrefs(preferences);
 
   const driver = global.docker

--- a/__tests__/html/__jest__/setupRunHTMLTest.js
+++ b/__tests__/html/__jest__/setupRunHTMLTest.js
@@ -1,4 +1,4 @@
-import { Builder } from 'selenium-webdriver';
+import { Builder, logging } from 'selenium-webdriver';
 import { Options } from 'selenium-webdriver/chrome';
 import { URL } from 'url';
 import fetch from 'node-fetch';
@@ -18,6 +18,11 @@ global.runHTMLTest = async (
     height: height * zoom,
     width: width * zoom
   });
+
+  const preferences = new logging.Preferences();
+
+  preferences.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
+  chromeOptions.setLoggingPrefs(preferences);
 
   const driver = global.docker
     ? builder

--- a/__tests__/html/accessibility.delayActivity.typingActivity.html
+++ b/__tests__/html/accessibility.delayActivity.typingActivity.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const {
+        WebChat: { createDirectLine },
+        WebChatTest: { conditions, createStore, getConsoleHistory, host, pageObjects, timeouts, token }
+      } = window;
+
+      (async function () {
+        window.WebChat.renderWebChat(
+          {
+            directLine: createDirectLine({ token: await token.fetchDirectLineToken() }),
+            sendTypingIndicator: true,
+            store: createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+
+        await pageObjects.sendMessageViaSendBox('echo-typing', { waitForSend: true });
+        await pageObjects.wait(conditions.minNumActivitiesShown(2), timeouts.directLine);
+
+        await pageObjects.typeInSendBox('a');
+
+        await pageObjects.wait(conditions.typingIndicatorShown(), timeouts.directLine);
+
+        // The typing activity sent from the bot should not trigger timeout.
+        if (getConsoleHistory().find(({ args: [arg0] }) => arg0.includes('Timed out'))) {
+          throw new Error('Should not see timeout warning.');
+        }
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/accessibility.delayActivity.typingActivity.js
+++ b/__tests__/html/accessibility.delayActivity.typingActivity.js
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('accessibility requirement', () => {
+  test('activity should not be delayed due to user typing activity', () =>
+    runHTMLTest('accessibility.delayActivity.typingActivity.html'));
+});

--- a/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.html
+++ b/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const {
+        WebChatTest: {
+          conditions,
+          createDirectLineWithTranscript,
+          createStore,
+          getConsoleHistory,
+          host,
+          pageObjects,
+          timeouts,
+          token
+        }
+      } = window;
+
+      (async function () {
+        const clock = lolex.install();
+
+        window.WebChat.renderWebChat(
+          {
+            directLine: createDirectLineWithTranscript([
+              {
+                text: 'Hello, World!',
+                type: 'message',
+                id: 'CONVERSATION_ID-o|00000',
+                timestamp: '2000-01-23T12:34:56.12345Z',
+                channelId: 'directline',
+                from: {
+                  id: 'webchat-mockbot',
+                  name: 'webchat-mockbot'
+                },
+                conversation: {
+                  id: 'CONVERSATION_ID-o'
+                },
+                locale: 'en-US'
+              },
+              {
+                type: 'typing',
+                id: 'CONVERSATION_ID-o|00002',
+                timestamp: '2000-01-23T12:34:56.12345Z',
+                channelId: 'directline',
+                from: {
+                  id: 'webchat-mockbot',
+                  name: 'webchat-mockbot'
+                },
+                conversation: {
+                  id: 'CONVERSATION_ID-o'
+                },
+                locale: 'en-US',
+                replyToId: 'CONVERSATION_ID-o|00001'
+              }
+            ]),
+            sendTypingIndicator: true,
+            store: createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.webChatRendered(), timeouts.ui);
+
+        // Wait for "Connecting..." message to dismiss
+        clock.tick(600);
+
+        await pageObjects.wait(conditions.numActivitiesShown(1), timeouts.directLine);
+
+        clock.tick(5000);
+
+        await pageObjects.wait(conditions.typingIndicatorShown(), timeouts.directLine);
+
+        // The typing activity sent from the bot should trigger timeout because it is replying to a non-existing activity.
+        if (!getConsoleHistory().find(({ args: [arg0] }) => arg0.includes('Timed out'))) {
+          throw new Error('Should see timeout warning.');
+        }
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.js
+++ b/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.js
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('accessibility requirement', () => {
+  test('activity should be delayed due to non-existing activity', () =>
+    runHTMLTest('accessibility.delayActivity.typingActivityWithoutReplyToActivity.html'));
+});

--- a/__tests__/setup/setupTestEnvironment.js
+++ b/__tests__/setup/setupTestEnvironment.js
@@ -1,29 +1,39 @@
+import { logging } from 'selenium-webdriver';
 import { Options } from 'selenium-webdriver/chrome';
 
 export default function setupTestEnvironment(browserName, builder, { height = 640, width = 360, zoom = 1 } = {}) {
+  const preferences = new logging.Preferences();
+
+  preferences.setLevel(logging.Type.BROWSER, logging.Level.WARNING);
+
   switch (browserName) {
     case 'chrome-local':
+      const localOptions = (builder.getChromeOptions() || new Options()).windowSize({
+        height: height * zoom,
+        width: width * zoom
+      });
+
+      localOptions.setLoggingPrefs(preferences);
+
       return {
         baseURL: 'http://localhost:$PORT/index.html',
-        builder: builder
-          .forBrowser('chrome')
-          .setChromeOptions(
-            (builder.getChromeOptions() || new Options()).windowSize({ height: height * zoom, width: width * zoom })
-          )
+        builder: builder.forBrowser('chrome').setChromeOptions(localOptions)
       };
 
     case 'chrome-docker':
     default:
+      const dockerOptions = (builder.getChromeOptions() || new Options())
+        .headless()
+        .windowSize({ height: height * zoom, width: width * zoom });
+
+      dockerOptions.setLoggingPrefs(preferences);
+
       return {
         baseURL: 'http://webchat/',
         builder: builder
           .forBrowser('chrome')
           .usingServer('http://localhost:4444/wd/hub')
-          .setChromeOptions(
-            (builder.getChromeOptions() || new Options())
-              .headless()
-              .windowSize({ height: height * zoom, width: width * zoom })
-          )
+          .setChromeOptions(dockerOptions)
       };
   }
 }

--- a/__tests__/setup/setupTestFramework.js
+++ b/__tests__/setup/setupTestFramework.js
@@ -50,7 +50,7 @@ global.setupWebDriver = async options => {
               document.body.style.zoom = options.zoom;
             }
 
-            main2(options).then(
+            main(options).then(
               () => callback(),
               err => {
                 console.error(err);

--- a/__tests__/setup/setupTestFramework.js
+++ b/__tests__/setup/setupTestFramework.js
@@ -1,4 +1,4 @@
-import { Builder } from 'selenium-webdriver';
+import { Builder, logging } from 'selenium-webdriver';
 import { createServer } from 'http';
 import { join } from 'path';
 import { promisify } from 'util';
@@ -19,6 +19,10 @@ let serverPromise;
 const DEFAULT_OPTIONS = {
   pingBotOnLoad: true
 };
+
+async function getBrowserConsoleLogs(driver) {
+  return await driver.manage().logs().get(logging.Type.BROWSER);
+}
 
 global.setupWebDriver = async options => {
   options = { ...DEFAULT_OPTIONS, ...options };
@@ -46,7 +50,7 @@ global.setupWebDriver = async options => {
               document.body.style.zoom = options.zoom;
             }
 
-            main(options).then(
+            main2(options).then(
               () => callback(),
               err => {
                 console.error(err);
@@ -67,6 +71,10 @@ global.setupWebDriver = async options => {
 
         return { driver, pageObjects };
       } catch (err) {
+        try {
+          console.log('Browser console logs at exception', await getBrowserConsoleLogs(driver));
+        } catch (err) {}
+
         await driver.quit();
 
         throw err;

--- a/packages/component/src/Middleware/Activity/createCoreMiddleware.js
+++ b/packages/component/src/Middleware/Activity/createCoreMiddleware.js
@@ -12,7 +12,7 @@ export default function createCoreMiddleware() {
     const { type } = activity;
 
     // Filter out activities that should not be visible
-    if (type === 'conversationUpdate' || type === 'event' || type === 'invoke') {
+    if (type === 'conversationUpdate' || type === 'event' || type === 'invoke' || type === 'typing') {
       return false;
     } else if (type === 'message') {
       const { attachments = [], channelData, text } = activity;

--- a/packages/core/src/reducers/activities.js
+++ b/packages/core/src/reducers/activities.js
@@ -104,7 +104,7 @@ export default function activities(state = DEFAULT_STATE, { meta, payload, type 
       break;
 
     case INCOMING_ACTIVITY:
-      // TODO: [P4] Move "typing" into Constants.ActivityType
+      // TODO: [P4] #2100 Move "typing" into Constants.ActivityType
       state = upsertActivityWithSort(state, payload.activity);
       break;
 

--- a/packages/core/src/reducers/activities.js
+++ b/packages/core/src/reducers/activities.js
@@ -105,10 +105,7 @@ export default function activities(state = DEFAULT_STATE, { meta, payload, type 
 
     case INCOMING_ACTIVITY:
       // TODO: [P4] Move "typing" into Constants.ActivityType
-      if (payload.activity.type !== 'typing') {
-        state = upsertActivityWithSort(state, payload.activity);
-      }
-
+      state = upsertActivityWithSort(state, payload.activity);
       break;
 
     default:

--- a/packages/core/src/sagas/queueIncomingActivitySaga.js
+++ b/packages/core/src/sagas/queueIncomingActivitySaga.js
@@ -57,7 +57,20 @@ function* queueIncomingActivity({ userID }) {
     // Thus, the "replyToId" will always be there even it is the first activity in the conversation.
     if (replyToId && initialActivities.length) {
       // Either the activity replied to is in the transcript or after timeout.
-      yield race([waitForActivityId(replyToId, initialActivities), call(sleep, REPLY_TIMEOUT)]);
+      const result = yield race({
+        _: waitForActivityId(replyToId, initialActivities),
+        timeout: call(sleep, REPLY_TIMEOUT)
+      });
+
+      if ('timeout' in result) {
+        console.warn(
+          `botframework-webchat: Timed out while waiting for activity "${replyToId}" which activity "${activity.id}" is replying to.`,
+          {
+            activity,
+            replyToId
+          }
+        );
+      }
     }
 
     yield put(incomingActivity(activity));

--- a/packages/testharness/src/conditions/index.js
+++ b/packages/testharness/src/conditions/index.js
@@ -11,6 +11,7 @@ import scrollStabilized from './scrollStabilized';
 import scrollToBottomCompleted from './scrollToBottomCompleted';
 import suggestedActionsShown from './suggestedActionsShown';
 import toastShown from './toastShown';
+import typingIndicatorShown from './typingIndicatorShown';
 import uiConnected from './uiConnected';
 import webChatRendered from './webChatRendered';
 
@@ -28,6 +29,7 @@ export {
   scrollToBottomCompleted,
   suggestedActionsShown,
   toastShown,
+  typingIndicatorShown,
   uiConnected,
   webChatRendered
 };

--- a/packages/testharness/src/conditions/typingIndicatorShown.js
+++ b/packages/testharness/src/conditions/typingIndicatorShown.js
@@ -1,0 +1,8 @@
+import typingIndicator from '../elements/typingIndicator';
+
+export default function typingIndicatorShown() {
+  return {
+    message: 'typing indicator is shown',
+    fn: () => typingIndicator()
+  };
+}

--- a/packages/testharness/src/elements/index.js
+++ b/packages/testharness/src/elements/index.js
@@ -10,6 +10,7 @@ import transcript from './transcript';
 import transcriptList from './transcriptList';
 import transcriptScrollable from './transcriptScrollable';
 import typeFocusSink from './typeFocusSink';
+import typingIndicator from './typingIndicator';
 
 export {
   activities,
@@ -23,5 +24,6 @@ export {
   transcript,
   transcriptList,
   transcriptScrollable,
-  typeFocusSink
+  typeFocusSink,
+  typingIndicator
 };

--- a/packages/testharness/src/elements/typingIndicator.js
+++ b/packages/testharness/src/elements/typingIndicator.js
@@ -1,0 +1,3 @@
+export default function typeFocusSink() {
+  return document.querySelector('.webchat__typingIndicator');
+}


### PR DESCRIPTION
> Fixes #3431.

## Changelog Entry

### Fixed

-  Fixes [#3431](https://github.com/microsoft/BotFramework-WebChat/issues/3431). Activities should not be delayed due to missing activity of type "typing", by [@compulim](https://github.com/compulim) in PR [#3554](https://github.com/microsoft/BotFramework-WebChat/pull/3554)

## Description

Today, typing activity was not inserted into transcript. This is causing incoming activity to be delayed if they are replying to that typing activity.

Tomorrow, we are inserting the typing activity into the transcript but not displaying them. Since they are in the transcript, incoming activities will be able to infer them and not to be delayed.

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

- Updated `reducer/activities.js` not to filter out activity of type `typing`
- Added warning if an activity is being delayed because the activity it is replying to was not in the transcript

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
