### PR TITLE
Fix user-highlighting and reaction-buttons samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3561](https://github.com/microsoft/BotFramework-WebChat/issues/3561). Remove MyGet mentions from samples, by [@corinagum](https://github.com/corinagum) in PR [#3564](https://github.com/microsoft/BotFramework-WebChat/pull/3564)
 -  Fixes [#3537](https://github.com/microsoft/BotFramework-WebChat/issues/3537). Fix some carousels improperly using aria-roledescription, by [@corinagum](https://github.com/corinagum) in PR [#3599](https://github.com/microsoft/BotFramework-WebChat/pull/3599)
 
+### Samples
+
+-  Fixes [#3473](https://github.com/microsoft/BotFramework-WebChat/issues/3473). Fix samples using activityMiddleware (from 4.10.0 breaking changes), by [@corinagum](https://github.com/corinagum) in PR [#3601](https://github.com/microsoft/BotFramework-WebChat/pull/3601)
+
 ## [4.11.0] - 2020-11-04
 
 ### Added

--- a/samples/02.branding-styling-and-customization/a.branding-web-chat/README.md
+++ b/samples/02.branding-styling-and-customization/a.branding-web-chat/README.md
@@ -35,7 +35,7 @@ You may have noticed that Web Chat provides two different ways to change the app
 We provide these options to override for several reasons:
 
 -  These are commonly re-styled DOM elements that bot creators want modify in order to provide a specific brand experience
--  Although we support the modification of styling, we want it to be obvious to the user that **we do not guarantee our DOM will always stay the same**, which is why Web Chat uses CSS-in-JS (`glamor`), which generates the class names for Web Chat
+-  Although we support the modification of styling, we want it to be obvious to the user that **we do not guarantee our DOM will always stay the same**, which is why Web Chat uses CSS-in-JS (`emotion`), which generates the class names for Web Chat
 -  We encourage our users to use CSS selectors, such as `& > button > div > ul > li:nth-child`, as opposed to accessing the element by it's class name (e.g. `& > .css-1a2b3c4`) because of the high likelihood that the project will have future class and DOM changes. CSS selectors provide high specificity without the need of using `!important`, and provides implicit information of what element is being styled
 -  `styleSetOptions` is our way of preserving your modifications (without breaking changes!) but allowing the repo to continue to facilitate natural DOM changes that come with an actively updated project
 

--- a/samples/05.custom-components/c.user-highlighting/README.md
+++ b/samples/05.custom-components/c.user-highlighting/README.md
@@ -28,7 +28,7 @@ We'll start by using the [host with React sample][1] as our Web Chat React templ
 
 `activityMiddleware` can be used to add to the currently existing DOM of Web Chat by filtering the bot's content based on activity. In this instance we are going to add a containing `<div>` to the activity (with extra styling) based on the activity's `role` value.
 
-First, let's style our new containers using glamor. The container for activities from the bot will have a solid red line on the left side of the `<div>`, and activities from the user will have a green line on the right.
+First, let's style our new containers. The container for activities from the bot will have a solid red line on the left side of the `<div>`, and activities from the user will have a green line on the right.
 
 ```css
 .highlightedActivity--bot {
@@ -50,12 +50,16 @@ Next, create the `activityMiddleware` which will be passed into the bot. We will
 
 <!-- prettier-ignore-start -->
 ```js
-const activityMiddleware = () => next => card => {
-  return children => (
-    <div>
-      <!-- content here -->
-    </div>
-  );
+const activityMiddleware = () => next => (...setupArgs) => {
+   const [card] = setupArgs;
+
+   return (...renderArgs) => (
+     <div
+       className={card.activity.from.role === 'user' ? 'highlightedActivity--user' : 'highlightedActivity--bot'}
+     >
+       {next(card)(...renderArgs)}
+     </div>
+   );
 };
 ```
 <!-- prettier-ignore-end -->
@@ -168,8 +172,6 @@ Pass `activityMiddleware` into the rendering of Web Chat, and that's it.
 <!-- prettier-ignore-end -->
 
 # Further reading
-
--  CSS in JavaScript - [glamor npm](https://www.npmjs.com/package/glamor)
 
 -  [Middleware wiki](https://en.wikipedia.org/wiki/Middleware)
 

--- a/samples/05.custom-components/c.user-highlighting/index.html
+++ b/samples/05.custom-components/c.user-highlighting/index.html
@@ -59,12 +59,14 @@
         const res = await fetch('https://webchat-mockbot.azurewebsites.net/directline/token', { method: 'POST' });
         const { token } = await res.json();
         const { ReactWebChat } = window.WebChat;
-        const activityMiddleware = () => next => card => {
-          return children => (
+        const activityMiddleware = () => next => (...setupArgs) => {
+          const [card] = setupArgs;
+
+          return (...renderArgs) => (
             <div
               className={card.activity.from.role === 'user' ? 'highlightedActivity--user' : 'highlightedActivity--bot'}
             >
-              {next(card)(children)}
+              {next(card)(...renderArgs)}
             </div>
           );
         };

--- a/samples/05.custom-components/d.reaction-buttons/README.md
+++ b/samples/05.custom-components/d.reaction-buttons/README.md
@@ -159,11 +159,12 @@ Next let's build the `activityMiddleware` that will filter which activities are 
 
 <!-- prettier-ignore-start -->
 ```js
-const activityMiddleware = () => next => card => {
+const activityMiddleware = () => next => (...setupArgs) => {
+  const [card] = setupArgs
   if (card.activity.from.role === 'bot') {
-    return children => (
+    return (...renderArgs) => (
       <BotActivityDecorator activityID={card.activity.id} key={card.activity.id}>
-        {next(card)(children)}
+        {next(card)(...renderArgs)}
       </BotActivityDecorator>
     );
   } else {
@@ -290,16 +291,16 @@ Make sure `activityMiddleware` is passed into the the Web Chat component, and th
 
         const res = await fetch('https://webchat-mockbot.azurewebsites.net/directline/token', { method: 'POST' });
         const { token } = await res.json();
-        const activityMiddleware = () => next => card => {
+        const activityMiddleware = () => next => (...setupArgs) => {
+          const [card] = setupArgs
           if (card.activity.from.role === 'bot') {
-            return children => (
-              <BotActivityDecorator key={card.activity.id} activityID={card.activity.id}>
-                {next(card)(children)}
+            return (...renderArgs) => (
+              <BotActivityDecorator activityID={card.activity.id} key={card.activity.id}>
+                {next(card)(...renderArgs)}
               </BotActivityDecorator>
             );
           }
-
-          return next(card);
+          return next(...setupArgs)
         };
 
         window.ReactDOM.render(

--- a/samples/05.custom-components/d.reaction-buttons/index.html
+++ b/samples/05.custom-components/d.reaction-buttons/index.html
@@ -111,16 +111,18 @@
 
         const res = await fetch('https://webchat-mockbot.azurewebsites.net/directline/token', { method: 'POST' });
         const { token } = await res.json();
-        const activityMiddleware = () => next => card => {
+        const activityMiddleware = () => next => (...setupArgs) => {
+          const [card] = setupArgs;
+
           if (card.activity.from.role === 'bot') {
-            return children => (
+            return (...renderArgs) => (
               <BotActivityDecorator key={card.activity.id} activityID={card.activity.id}>
-                {next(card)(children)}
+                {next(...setupArgs)(...renderArgs)}
               </BotActivityDecorator>
             );
           }
 
-          return next(card);
+          return next(...setupArgs);
         };
 
         window.ReactDOM.render(


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3473

## Changelog Entry

-  Fixes [#3473](https://github.com/microsoft/BotFramework-WebChat/issues/3473). Fix samples using activityMiddleware (from 4.10.0 breaking changes), by [@corinagum](https://github.com/corinagum) in PR [#3601](https://github.com/microsoft/BotFramework-WebChat/pull/3601)

## Specific Changes
- Fix `activityMiddleware` in user-highlighting and reaction-buttons samples
- Remove references to glamor in samples

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [ ] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [ ] ~Browser and platform compatibilities reviewed~
-  [ ] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [ ] ~Internationalization reviewed (strings, unit formatting)~
-  [ ] ~`package.json` and `package-lock.json` reviewed~
-  [ ] ~Security reviewed (no data URIs, check for nonce leak)~
-  [ ] ~Tests reviewed (coverage, legitimacy)~
