### PR TITLE
IE11 anchors fixed to open securely without 'noreferrer' or 'noopener'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3534](https://github.com/microsoft/BotFramework-WebChat/issues/3534). Remove 2020 deprecations, by [@corinagum](https://github.com/corinagum) in PR [#3564](https://github.com/microsoft/BotFramework-WebChat/pull/3564)
 -  Fixes [#3561](https://github.com/microsoft/BotFramework-WebChat/issues/3561). Remove MyGet mentions from samples, by [@corinagum](https://github.com/corinagum) in PR [#3564](https://github.com/microsoft/BotFramework-WebChat/pull/3564)
 -  Fixes [#3537](https://github.com/microsoft/BotFramework-WebChat/issues/3537). Fix some carousels improperly using aria-roledescription, by [@corinagum](https://github.com/corinagum) in PR [#3599](https://github.com/microsoft/BotFramework-WebChat/pull/3599)
+-  Fixes [#3483](https://github.com/microsoft/BotFramework-WebChat/issues/3483). IE11 anchors fixed to open securely without 'noreferrer' or 'noopener', by [@corinagum](https://github.com/corinagum) in PR [#3607](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Samples
 

--- a/packages/component/src/Middleware/CardAction/createCoreMiddleware.js
+++ b/packages/component/src/Middleware/CardAction/createCoreMiddleware.js
@@ -1,3 +1,5 @@
+import { ie11 } from '../../Utils/detectBrowser';
+
 // This code is adopted from sanitize-html/naughtyScheme.
 // sanitize-html is a dependency of Web Chat but the naughtScheme function is neither exposed nor reusable.
 // https://github.com/apostrophecms/sanitize-html/blob/master/src/index.js#L526
@@ -45,7 +47,13 @@ export default function createDefaultCardActionMiddleware() {
         case 'playVideo':
         case 'showImage':
           if (ALLOWED_SCHEMES.includes(getScheme(value))) {
-            window.open(value, '_blank', 'noopener noreferrer');
+            if (ie11) {
+              const newWindow = window.open();
+              newWindow.opener = null;
+              newWindow.location = value;
+            } else {
+              window.open(value, '_blank', 'noopener noreferrer');
+            }
           } else {
             console.warn('botframework-webchat: Cannot open URL with disallowed schemes.', value);
           }


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3483

## Changelog Entry

-  Fixes [#3483](https://github.com/microsoft/BotFramework-WebChat/issues/3483). IE11 anchors fixed to open securely without 'noreferrer' or 'noopener', by [@corinagum](https://github.com/corinagum) in PR [#3607](https://github.com/microsoft/BotFramework-WebChat/pull/3607)

Reference previous PR: https://github.com/microsoft/BotFramework-WebChat/pull/3224

## Description

Due to `'noopener'` not being available in IE11 ([caniuse.com noopener](https://caniuse.com/rel-noopener)), anchors opened in Internet Explorer were opening without scrolling and in a separate window. This fix securely opens links in Internet Explorer 11 without using 'noopener', with information used from https://mathiasbynens.github.io/rel-noopener/

This does not affect behavior in other browsers.

![ezgif-ie11-windowOpen](https://user-images.githubusercontent.com/14900841/99327547-078a2500-282f-11eb-9acc-410971738f9b.gif)


<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] ~I have added tests and executed them locally~
   - **We don't have IE11 tests**
-  [x] I have updated `CHANGELOG.md`
-  [ ] ~I have updated documentation~

