### PR TITLE
Make 4.9.2 the default version for Hosted/Embed Webchat

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -8,8 +8,8 @@
     "4": {
       "redirects": [
         ["feature:nextpatch", "4.9.2"],
-        ["feature:nextminor", "4.9"],
-        ["*", "4.6"]
+        ["feature:nextminor", "4.9.2"],
+        ["*", "4.9.2"]
       ]
     },
     "4.1": {


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Description

Make 4.9.2 the default version for Hosted/Embed Webchat. This will allow us to reset the upgrade and restart rolling our 4.10.*

