### PR TITLE
Use webchat-es5.js SHA for Embed 4.10.1.

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -187,7 +187,7 @@
     },
     "4.10.1": {
       "assets": [
-        ["https://cdn.botframework.com/botframework-webchat/4.10.1/webchat-es5.js", "sha384-ZT32ehV2SkikXkWvH8cO0OsMgQoYg+zd09eBP5oJrcrL3FJWqPSB1IGifTBYKccw"]
+        ["https://cdn.botframework.com/botframework-webchat/4.10.1/webchat-es5.js", "sha384-FT3pdxVxoyBtfEc83Xt1uxb8vm/KVuyBicVG6gM41mgXeGw/S3Q2/CThAtFXhxcN"]
       ],
       "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2022-11-05.",
       "private": true,


### PR DESCRIPTION
## Description

Use webchat-es5.js SHA for Embed 4.10.1. The servicingPlan.json incorrectly uses the SHA for non-es5 webchat.js

