### PR TITLE
Acknowledge all activities when scroll to bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3483](https://github.com/microsoft/BotFramework-WebChat/issues/3483). IE11 anchors fixed to open securely without 'noreferrer' or 'noopener', by [@corinagum](https://github.com/corinagum) in PR [#3607](https://github.com/microsoft/BotFramework-WebChat/pull/3607)
 -  Fixes [#3565](https://github.com/microsoft/BotFramework-WebChat/issues/3565). Allow strikethrough `<s>` on sanitize markdown, by [@corinagum](https://github.com/corinagum) in PR [#3646](https://github.com/microsoft/BotFramework-WebChat/pull/3646)
 -  Fixes [#3672](https://github.com/microsoft/BotFramework-WebChat/issues/3672). Center the icon of send box buttons vertically and horizontally, by [@compulim](https://github.com/compulim) in PR [#3673](https://github.com/microsoft/BotFramework-WebChat/pull/3673)
--  Fixes [#3683](https://github.com/microsoft/BotFramework-WebChat/issues/3683). Activities should be acknowledged when user scroll to bottom, by [@compulim](https://github.com/compulim) in PR [#3684](https://github.com/microsoft/BotFramework-WebChat/pull/3684)
+-  Fixes [#3683](https://github.com/microsoft/BotFramework-WebChat/issues/3683). Activities should be acknowledged when user scrolls to bottom, by [@compulim](https://github.com/compulim) in PR [#3684](https://github.com/microsoft/BotFramework-WebChat/pull/3684)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3483](https://github.com/microsoft/BotFramework-WebChat/issues/3483). IE11 anchors fixed to open securely without 'noreferrer' or 'noopener', by [@corinagum](https://github.com/corinagum) in PR [#3607](https://github.com/microsoft/BotFramework-WebChat/pull/3607)
 -  Fixes [#3565](https://github.com/microsoft/BotFramework-WebChat/issues/3565). Allow strikethrough `<s>` on sanitize markdown, by [@corinagum](https://github.com/corinagum) in PR [#3646](https://github.com/microsoft/BotFramework-WebChat/pull/3646)
 -  Fixes [#3672](https://github.com/microsoft/BotFramework-WebChat/issues/3672). Center the icon of send box buttons vertically and horizontally, by [@compulim](https://github.com/compulim) in PR [#3673](https://github.com/microsoft/BotFramework-WebChat/pull/3673)
+-  Fixes [#3683](https://github.com/microsoft/BotFramework-WebChat/issues/3683). Activities should be acknowledged when user scroll to bottom, by [@compulim](https://github.com/compulim) in PR [#3684](https://github.com/microsoft/BotFramework-WebChat/pull/3684)
 
 ### Changed
 

--- a/__tests__/html/autoScroll.acknowledgement.html
+++ b/__tests__/html/autoScroll.acknowledgement.html
@@ -160,6 +160,28 @@
         expect(scrollable.scrollTop).toBe(0);
         expect(numActivitiesByAcknowledgement()).toEqual({ acknowledged: 8, unacknowledged: 1 });
 
+        await pageObjects.clickNewMessageButton();
+        await pageObjects.wait(conditions.scrollToBottomCompleted(), timeouts.scrollToBottom);
+
+        addDummyActivitiesToDirectLine(10);
+        addDummyActivitiesToDirectLine(10);
+        addDummyActivitiesToDirectLine(10);
+
+        await pageObjects.wait(conditions.scrollStabilized(), timeouts.scrollToBottom);
+
+        expect(numActivitiesByAcknowledgement()).toEqual({ acknowledged: 9, unacknowledged: 3 });
+
+        expect(scrollable.scrollTop).toBe(
+          document.querySelectorAll('.webchat__basic-transcript__activity')[9].offsetTop
+        );
+
+        // Scroll to bottom
+        scrollable.scrollTop = scrollable.scrollHeight;
+
+        // Wait for scroll-to-bottom to detect it is at the bottom.
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        expect(numActivitiesByAcknowledgement()).toEqual({ acknowledged: 12, unacknowledged: 0 });
+
         await host.done();
       })().catch(async err => {
         console.error(err);

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -635,18 +635,17 @@ InternalTranscriptScrollable.propTypes = {
   children: PropTypes.arrayOf(PropTypes.element).isRequired
 };
 
-const BasicTranscript = ({ className }) => {
+const SetScroller = ({ activityElementsRef, scrollerRef }) => {
   const [
     { autoScrollSnapOnActivity, autoScrollSnapOnActivityOffset, autoScrollSnapOnPage, autoScrollSnapOnPageOffset }
   ] = useStyleOptions();
   const [lastAcknowledgedActivity] = useAcknowledgedActivity();
-  const activityElementsRef = useRef([]);
 
   const lastAcknowledgedActivityRef = useRef(lastAcknowledgedActivity);
 
   lastAcknowledgedActivityRef.current = lastAcknowledgedActivity;
 
-  const scroller = useCallback(
+  scrollerRef.current = useCallback(
     ({ offsetHeight, scrollTop }) => {
       const patchedAutoScrollSnapOnActivity =
         typeof autoScrollSnapOnActivity === 'number'
@@ -719,8 +718,18 @@ const BasicTranscript = ({ className }) => {
     ]
   );
 
+  return false;
+};
+
+const BasicTranscript = ({ className }) => {
+  const activityElementsRef = useRef([]);
+  const scrollerRef = useRef(() => Infinity);
+
+  const scroller = useCallback((...args) => scrollerRef.current(...args), [scrollerRef]);
+
   return (
     <ReactScrollToBottomComposer scroller={scroller}>
+      <SetScroller activityElementsRef={activityElementsRef} scrollerRef={scrollerRef} />
       <InternalTranscript activityElementsRef={activityElementsRef} className={className} />
     </ReactScrollToBottomComposer>
   );

--- a/packages/component/src/hooks/internal/useAcknowledgedActivity.js
+++ b/packages/component/src/hooks/internal/useAcknowledgedActivity.js
@@ -42,6 +42,8 @@ export default function useAcknowledgedActivity() {
     if (stickyChangedToSticky) {
       lastStickyActivityIDRef.current = getActivityUniqueId(activities[activities.length - 1] || {});
     }
+
+    return lastStickyActivityIDRef.current;
   }, [activities, lastStickyActivityIDRef, stickyChangedToSticky]);
 
   return useMemo(() => {


### PR DESCRIPTION
> Fixes #3683.

## Changelog Entry

### Fixed

-  Fixes [#3683](https://github.com/microsoft/BotFramework-WebChat/issues/3683). Activities should be acknowledged when user scroll to bottom, by [@compulim](https://github.com/compulim) in PR [#3684](https://github.com/microsoft/BotFramework-WebChat/pull/3684)

## Description

Web Chat should acknowledge all activities when the user scroll to bottom.

## Design

In the code:

```js
const [sticky] = useReactScrollToBottomSticky(); // The actual code call `useAcknowledgedActivity()`, which call `useSticky()`

return (
  <ReactScrollToBottomComposer scroller={scroller}>
    ...
  </ReactScrollToBottomComposer>
);
```

We wrongly used the `useSticky` hook outside of the `<ReactScrollToBottomComposer>` surface.

## Specific Changes

- Adds a new internal component under the composer surface for calling `useSticky`
- Proxy the `scroller` function out
- Update test

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
