### PR TITLE
Fix anchors being disabled in obsolete Adaptive Cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,11 +89,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  [`sanitize-html@2.1.2`](https://npmjs.com/package/sanitize-html)
       -  [`whatwg-fetch@3.4.1`](https://npmjs.com/package/whatwg-fetch)
 -  [#3392](https://github.com/microsoft/BotFramework-WebChat/issues/3392) Bumped Adaptive Cards to the 2.5.0, by [@corinagum](https://github.com/corinagum) in PR [#3630](https://github.com/microsoft/BotFramework-WebChat/pull/3630)
+-  Fixes [#3618](https://github.com/microsoft/BotFramework-WebChat/issues/3618). Fix AC anchors being disabled when AC is obsolete, by [@corinagum](https://github.com/johndoe) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Samples
 
 -  Fixes [#3473](https://github.com/microsoft/BotFramework-WebChat/issues/3473). Fix samples using activityMiddleware (from 4.10.0 breaking changes), by [@corinagum](https://github.com/corinagum) in PR [#3601](https://github.com/microsoft/BotFramework-WebChat/pull/3601)
 - Fixes [#3434](https://github.com/microsoft/BotFramework-WebChat/issues/3434). Dispatched event, postBack, or messageBack + activityMiddleware causes fatal error, by [@amal-khalaf](https://github.com/amal-khalaf) in PR [#3671](https://github.com/microsoft/BotFramework-WebChat/pull/3671)
+-  Fixes [#3582](https://github.com/microsoft/BotFramework-WebChat/issues/3582). Fix Disable Adaptive Cards sample, by [@corinagum](https://github.com/corinagum) in PR [#xxx](https://github.com/microsoft/BotFramework-WebChat/pull/xxx)
 
 ## [4.11.0] - 2020-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,13 +89,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  [`sanitize-html@2.1.2`](https://npmjs.com/package/sanitize-html)
       -  [`whatwg-fetch@3.4.1`](https://npmjs.com/package/whatwg-fetch)
 -  [#3392](https://github.com/microsoft/BotFramework-WebChat/issues/3392) Bumped Adaptive Cards to the 2.5.0, by [@corinagum](https://github.com/corinagum) in PR [#3630](https://github.com/microsoft/BotFramework-WebChat/pull/3630)
--  Fixes [#3618](https://github.com/microsoft/BotFramework-WebChat/issues/3618). Fix AC anchors being disabled when AC is obsolete, by [@corinagum](https://github.com/johndoe) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#3618](https://github.com/microsoft/BotFramework-WebChat/issues/3618). Fix AC anchors being disabled when AC is obsolete, by [@corinagum](https://github.com/johndoe) in PR [#3687](https://github.com/microsoft/BotFramework-WebChat/pull/3687)
 
 ### Samples
 
 -  Fixes [#3473](https://github.com/microsoft/BotFramework-WebChat/issues/3473). Fix samples using activityMiddleware (from 4.10.0 breaking changes), by [@corinagum](https://github.com/corinagum) in PR [#3601](https://github.com/microsoft/BotFramework-WebChat/pull/3601)
-- Fixes [#3434](https://github.com/microsoft/BotFramework-WebChat/issues/3434). Dispatched event, postBack, or messageBack + activityMiddleware causes fatal error, by [@amal-khalaf](https://github.com/amal-khalaf) in PR [#3671](https://github.com/microsoft/BotFramework-WebChat/pull/3671)
--  Fixes [#3582](https://github.com/microsoft/BotFramework-WebChat/issues/3582). Fix Disable Adaptive Cards sample, by [@corinagum](https://github.com/corinagum) in PR [#xxx](https://github.com/microsoft/BotFramework-WebChat/pull/xxx)
+-  Fixes [#3434](https://github.com/microsoft/BotFramework-WebChat/issues/3434). Dispatched event, postBack, or messageBack + activityMiddleware causes fatal error, by [@amal-khalaf](https://github.com/amal-khalaf) in PR [#3671](https://github.com/microsoft/BotFramework-WebChat/pull/3671)
+-  Fixes [#3582](https://github.com/microsoft/BotFramework-WebChat/issues/3582). Fix Disable Adaptive Cards sample, by [@corinagum](https://github.com/corinagum) in PR [#3687](https://github.com/microsoft/BotFramework-WebChat/pull/3687)
 
 ## [4.11.0] - 2020-11-04
 

--- a/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.html
+++ b/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const { conditions, createStore, elements, expect, host, pageObjects, timeouts, token } = window.WebChatTest;
+
+      (async function () {
+        const attachmentMiddleware = () => next => card => {
+          const { activity, attachment } = card;
+          const { activities } = store.getState();
+
+          const messages = activities.filter(activity => activity.type === 'message');
+          const mostRecent = messages.pop() === activity;
+
+          if (attachment.contentType === 'application/vnd.microsoft.card.adaptive') {
+            return React.createElement(window.WebChat.Components.AdaptiveCardContent, {
+              content: attachment.content,
+              disabled: !mostRecent
+            });
+          }
+          return next(card);
+        };
+        const directLine = window.WebChat.createDirectLine({ token: await token.fetchDirectLineToken() });
+        const store = createStore();
+
+        window.WebChat.renderWebChat(
+          {
+            attachmentMiddleware,
+            directLine,
+            store
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+        await pageObjects.sendMessageViaSendBox('card markdown');
+        await pageObjects.sendMessageViaSendBox('stop');
+        await pageObjects.wait(conditions.minNumActivitiesShown(4));
+
+        const externalLink = elements.transcript().querySelector('.ac-adaptiveCard a');
+        const relationships = (externalLink.getAttribute('rel') || '').split(new RegExp('\\s+', 'gu')).sort();
+        const ariaDisabled = externalLink.getAttribute('aria-disabled');
+
+        expect(relationships).toEqual(['noopener', 'noreferrer']);
+
+        expect(ariaDisabled).toBeFalsy();
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.js
+++ b/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.js
@@ -1,0 +1,7 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('middleware to disable obsolete Adaptive Cards', () => {
+  test('should NOT disable anchors', () => runHTMLTest('middleware.obsoleteAdaptiveCard.anchor.html'));
+});

--- a/packages/api/src/hooks/middleware/applyMiddleware.js
+++ b/packages/api/src/hooks/middleware/applyMiddleware.js
@@ -35,25 +35,24 @@ export function forRenderer(type, { strict = false } = {}, ...middleware) {
           }
 
           return <UserlandBoundary type={`render of ${type}`}>{render}</UserlandBoundary>;
-        } else {
-          return (...renderTimeArgs) => (
-            <UserlandBoundary type={`render of ${type}`}>
-              {() => {
-                try {
-                  const element = render(...renderTimeArgs);
-
-                  if (strict && !isValidElement(element)) {
-                    console.error(`botframework-webchat: ${type} should return React element only.`);
-                  }
-
-                  return element;
-                } catch (err) {
-                  return <ErrorBox error={err} type={type} />;
-                }
-              }}
-            </UserlandBoundary>
-          );
         }
+        return (...renderTimeArgs) => (
+          <UserlandBoundary type={`render of ${type}`}>
+            {() => {
+              try {
+                const element = render(...renderTimeArgs);
+
+                if (strict && !isValidElement(element)) {
+                  console.error(`botframework-webchat: ${type} should return React element only.`);
+                }
+
+                return element;
+              } catch (err) {
+                return <ErrorBox error={err} type={type} />;
+              }
+            }}
+          </UserlandBoundary>
+        );
       } catch (err) {
         return <ErrorBox error={err} type={type} />;
       }

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
@@ -131,7 +131,7 @@ function disableElementWithUndo(element) {
 }
 
 function disableInputElementsWithUndo(element, observeSubtree = true) {
-  const undoStack = [].map.call(element.querySelectorAll('a, button, input, select, textarea'), element =>
+  const undoStack = [].map.call(element.querySelectorAll('button, input, select, textarea'), element =>
     disableElementWithUndo(element)
   );
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.js
@@ -84,6 +84,12 @@ function addEventListenerOnceWithUndo(element, name, handler) {
   return detach;
 }
 
+function addEventListenerWithUndo(element, name, handler) {
+  element.addEventListener(name, handler);
+
+  return () => element.removeEventListener(name, handler);
+}
+
 function disableElementWithUndo(element) {
   const undoStack = [];
   const isActive = element === document.activeElement;
@@ -91,12 +97,6 @@ function disableElementWithUndo(element) {
 
   /* eslint-disable-next-line default-case */
   switch (tag) {
-    // Should we not disable <a>? Will some of the <a> are styled as button?
-    case 'a':
-      undoStack.push(addEventListenerOnceWithUndo(element, 'click', disabledHandler));
-
-      break;
-
     case 'button':
     case 'input':
     case 'select':
@@ -114,7 +114,7 @@ function disableElementWithUndo(element) {
       }
 
       if (tag === 'input' || tag === 'textarea') {
-        undoStack.push(addEventListenerOnceWithUndo(element, 'click', disabledHandler));
+        undoStack.push(addEventListenerWithUndo(element, 'click', disabledHandler));
         undoStack.push(setAttributeWithUndo(element, 'readonly', 'readonly'));
       } else if (tag === 'select') {
         undoStack.push(

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -69,7 +69,7 @@ function App() {
   const [messageActivityWordBreak, setMessageActivityWordBreak] = useState('break-word');
 
   // 'middlewareDisableObsoleteAC': Middleware that renders inputs disabled on an Adaptive Card that is no longer the latest activity.
-  const [middlewareDisableObsoleteAC, setMiddlewareDisableObsoleteAC] = useState(
+  const [disableObsoleteAC, setDisableObsoleteAC] = useState(
     () => window.sessionStorage.getItem('PLAYGROUND_MIDDLEWARE_DISABLE_OBSOLETE_AC') === 'true'
   );
 
@@ -123,7 +123,7 @@ function App() {
     const { activity, attachment } = card;
     const { activities } = store.getState();
 
-    if (middlewareDisableObsoleteAC) {
+    if (disableObsoleteAC) {
       const messages = activities.filter(activity => activity.type === 'message');
       const mostRecent = messages.pop() === activity;
 
@@ -202,10 +202,10 @@ function App() {
 
   const handleDisableObsoleteACMiddlewareChange = useCallback(
     (e, checked) => {
-      setMiddlewareDisableObsoleteAC(checked);
+      setDisableObsoleteAC(checked);
       window.sessionStorage.setItem('PLAYGROUND_MIDDLEWARE_DISABLE_OBSOLETE_AC', checked.toString());
     },
-    [setMiddlewareDisableObsoleteAC]
+    [setDisableObsoleteAC]
   );
 
   /// END MIDDLEWARE
@@ -447,7 +447,7 @@ function App() {
                 <IconButton aria-label="info" iconProps={{ iconName: 'infoSolid' }} />
               </TooltipHost>
               <Toggle
-                checked={middlewareDisableObsoleteAC}
+                checked={disableObsoleteAC}
                 label="Disable obsolete Adaptive Cards"
                 onChange={handleDisableObsoleteACMiddlewareChange}
                 onText="On"

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-magic-numbers */
 
 import { Global } from '@emotion/core';
-import { Dropdown, Label, SearchBox, Stack, TextField, Toggle } from '@fluentui/react';
+import { Dropdown, IconButton, Label, SearchBox, Stack, TextField, Toggle, TooltipHost } from '@fluentui/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   dirOptions,
@@ -21,8 +21,19 @@ function App() {
   const REDUX_STORE_KEY = 'REDUX_STORE';
 
   // fluentui settings
-  const stackTokens = { childrenGap: 10 };
+  const stackTokens = { childrenGap: 0 };
 
+  // TODO: Add action buttons in tooltip later
+  const wordBreakTooltipProps = {
+    onRenderContent: () => (
+      <ol style={{ margin: 10, padding: 10 }}>
+        <li>
+          Send 'https://subdomain.domain.com/pathname0/pathname1/pathname2/pathname3/pathname4/' to test 'break-all{' '}
+        </li>
+        <li>Send '箸より重いものを持ったことがない箸より重いものを持ったことがない' to test 'keep-all </li>
+      </ol>
+    )
+  };
   /*
   /// STATE
   */
@@ -57,6 +68,11 @@ function App() {
 
   const [messageActivityWordBreak, setMessageActivityWordBreak] = useState('break-word');
 
+  // 'middlewareDisableObsoleteAC': Middleware that renders inputs disabled on an Adaptive Card that is no longer the latest activity.
+  const [middlewareDisableObsoleteAC, setMiddlewareDisableObsoleteAC] = useState(
+    () => window.sessionStorage.getItem('PLAYGROUND_MIDDLEWARE_DISABLE_OBSOLETE_AC') === 'true'
+  );
+
   const [richCardWrapTitle, setRichCardWrapTitle] = useState(false);
 
   const [sendTimeout, setSendTimeout] = useState(
@@ -77,7 +93,6 @@ function App() {
   });
 
   useEffect(() => {
-    document.querySelector('html').setAttribute('lang', locale);
     document.querySelector('html').setAttribute('lang', locale);
   }, [locale]);
 
@@ -103,6 +118,25 @@ function App() {
   store.subscribe(() => {
     sessionStorage.setItem(REDUX_STORE_KEY, JSON.stringify(store.getState()));
   });
+
+  const attachmentMiddleware = () => next => card => {
+    const { activity, attachment } = card;
+    const { activities } = store.getState();
+
+    if (middlewareDisableObsoleteAC) {
+      const messages = activities.filter(activity => activity.type === 'message');
+      const mostRecent = messages.pop() === activity;
+
+      if (attachment.contentType === 'application/vnd.microsoft.card.adaptive') {
+        return React.createElement(window.WebChat.Components.AdaptiveCardContent, {
+          actionPerformedClassName: 'card__action--performed',
+          content: attachment.content,
+          disabled: !mostRecent
+        });
+      }
+    }
+    return next(card);
+  };
 
   const [token, setToken] = useState();
 
@@ -163,6 +197,20 @@ function App() {
   /// END CONNECTIVITY
 
   /*
+  /// MIDDLEWARE
+  */
+
+  const handleDisableObsoleteACMiddlewareChange = useCallback(
+    (e, checked) => {
+      setMiddlewareDisableObsoleteAC(checked);
+      window.sessionStorage.setItem('PLAYGROUND_MIDDLEWARE_DISABLE_OBSOLETE_AC', checked.toString());
+    },
+    [setMiddlewareDisableObsoleteAC]
+  );
+
+  /// END MIDDLEWARE
+
+  /*
   /// Web Chat props
   */
 
@@ -185,14 +233,14 @@ function App() {
 
   const handleSendTypingIndicatorChange = useCallback(
     (e, checked) => {
-      setSendTypingIndicator(!!checked);
+      setSendTypingIndicator(checked);
     },
     [setSendTypingIndicator]
   );
 
   const handleUIDisabledChange = useCallback(
     (e, checked) => {
-      setDisabledUI(!!checked);
+      setDisabledUI(checked);
     },
     [setDisabledUI]
   );
@@ -216,14 +264,14 @@ function App() {
 
   const handleBubbleNubChange = useCallback(
     (e, checked) => {
-      setBubbleNub(!!checked);
+      setBubbleNub(checked);
     },
     [setBubbleNub]
   );
 
   const handleBubbleBorderChange = useCallback(
     (e, checked) => {
-      setBubbleBorders(!!checked);
+      setBubbleBorders(checked);
     },
     [setBubbleBorders]
   );
@@ -238,14 +286,14 @@ function App() {
 
   const handleHideSendBoxChange = useCallback(
     (e, checked) => {
-      setHideSendBox(!!checked);
+      setHideSendBox(checked);
     },
     [setHideSendBox]
   );
 
   const handleRichCardWrapTitleChange = useCallback(
     (e, checked) => {
-      setRichCardWrapTitle(!!checked);
+      setRichCardWrapTitle(checked);
     },
     [setRichCardWrapTitle]
   );
@@ -304,6 +352,7 @@ function App() {
     <div id="app-container" ref={mainRef}>
       <Global styles={PlaygroundStyles} />
       <ReactWebChat
+        attachmentMiddleware={attachmentMiddleware}
         className="webchat"
         dir={dir}
         directLine={directLine}
@@ -315,13 +364,15 @@ function App() {
       />
       <div className="button-bar">
         {/* TODO: (#3515) enable search */}
-        {/* eslint-disable-next-line no-console */}
         <Label>
           Search Web Chat props
           <SearchBox
             aria-label="Search Web Chat properties"
             placeholder="Search"
-            onSearch={newValue => console.log('value is ' + newValue)}
+            onSearch={newValue => {
+              /* eslint-disable-next-line no-console */
+              console.log('value is ' + newValue);
+            }}
           />
         </Label>
         <fieldset>
@@ -346,95 +397,142 @@ function App() {
           <legend>Web Chat props</legend>
           <Stack tokens={stackTokens}>
             <Dropdown label="Direction" onChange={handleDirChange} options={dirOptions} selectedKey={dir} />
-            <Toggle
-              label="Disable UI"
-              checked={uiDisabled}
-              onChange={handleUIDisabledChange}
-              onText="On"
-              offText="Off"
-            />
+            <Label className="info-container">
+              <TooltipHost
+                calloutProps={{ gapSpace: 0 }}
+                content="Disable the SendBox and inputs in the transcript"
+                id="disableUI tooltip"
+              >
+                <IconButton aria-label="info" iconProps={{ iconName: 'infoSolid' }} />
+              </TooltipHost>
+              <Toggle
+                label="Disable UI"
+                checked={uiDisabled}
+                onChange={handleUIDisabledChange}
+                onText="On"
+                offText="Off"
+              />
+            </Label>
             <Dropdown label="Locale" onChange={handleLocaleChange} options={localeOptions} selectedKey={locale} />
+            <Label className="info-container">
+              <TooltipHost
+                calloutProps={{ gapSpace: 0 }}
+                content="Shows a typing indicator when the user is typing. Send 'echo-typing' to the bot to turn this feature on and off and test"
+                id="sendTyping tooltip"
+              >
+                <IconButton aria-label="info" iconProps={{ iconName: 'infoSolid' }} />
+              </TooltipHost>
 
-            {/* TODO: (#3515) info icon: Send 'echo-typing' to the bot to turn this feature on and off */}
-            <Toggle
-              label="Send typing indicator"
-              checked={sendTypingIndicator}
-              onChange={handleSendTypingIndicatorChange}
-              onText="On"
-              offText="Off"
-            />
-          </Stack>
-        </fieldset>
-        <fieldset>
-          <legend>Style Options</legend>
-          <Stack tokens={stackTokens}>
-            <Label>
-              Avatar Initials
-              <TextField
-                label="Bot avatar initials"
-                onChange={handleBotAvatarInitialsChange}
-                value={botAvatarInitials || ''}
-              />
-              <TextField
-                label="User avatar initials"
-                onChange={handleUserAvatarInitialsChange}
-                value={userAvatarInitials || ''}
-              />
-            </Label>
-            <Label>
-              Bubble style options
               <Toggle
-                label="Show bubble nub"
-                checked={bubbleNub}
-                onChange={handleBubbleNubChange}
-                onText="On"
-                offText="Off"
-              />
-              <Toggle
-                label="Customize bubble borders"
-                checked={bubbleStyle}
-                onChange={handleBubbleBorderChange}
+                label="Send typing indicator"
+                checked={sendTypingIndicator}
+                onChange={handleSendTypingIndicatorChange}
                 onText="On"
                 offText="Off"
               />
             </Label>
-            <Toggle
-              label="Hide SendBox"
-              checked={hideSendBox}
-              onChange={handleHideSendBoxChange}
-              onText="On"
-              offText="Off"
-            />
-            <Dropdown
-              label="Group timestamp"
-              onChange={handleGroupTimestampChange}
-              options={groupTimestampOptions}
-              selectedKey={groupTimestamp}
-            />
-            {/* TODO: (#3515) info icon: Send 'herocard long title' to the bot to turn this feature on and off */}
-            <Toggle
-              label="Rich card wrap title"
-              checked={richCardWrapTitle}
-              onChange={handleRichCardWrapTitleChange}
-              onText="On"
-              offText="Off"
-            />
-            {/*  (#3515) info icon: Turn on airplane mode to test this feature */}
-            <Dropdown
-              label="Send timeout"
-              onChange={handleSendTimeoutChange}
-              options={sendTimeoutOptions}
-              selectedKey={sendTimeout}
-            />
-            {/* TODO: (#3515) info: Send 'https://subdomain.domain.com/pathname0/pathname1/pathname2/pathname3/pathname4/' test 'break-all */}
-            {/* TODO: (#3515) info: Send '箸より重いものを持ったことがない箸より重いものを持ったことがない' test 'keep-all */}
-            <Dropdown
-              label="Word break"
-              onChange={handleWordBreakChange}
-              options={messageActivityWordBreakOptions}
-              selectedKey={messageActivityWordBreak}
-            />
           </Stack>
+          {/* Empty for now; plan is to add more middleware eventually, so I'm keeping this commented out */}
+          {/* <fieldset>
+            <legend>Activity middleware</legend>
+          </fieldset> */}
+          <fieldset>
+            <legend>Attachment middleware</legend>
+            <Label className="info-container">
+              <TooltipHost
+                calloutProps={{ gapSpace: 0 }}
+                content="This feature disables inputs (e.g. buttons) on Adaptive Cards that are not the latest activity"
+                id="disableObsolete AC tooltip"
+              >
+                <IconButton aria-label="info" iconProps={{ iconName: 'infoSolid' }} />
+              </TooltipHost>
+              <Toggle
+                checked={middlewareDisableObsoleteAC}
+                label="Disable obsolete Adaptive Cards"
+                onChange={handleDisableObsoleteACMiddlewareChange}
+                onText="On"
+                offText="Off"
+              ></Toggle>
+            </Label>
+          </fieldset>
+          <fieldset>
+            <legend>Style Options</legend>
+            <Stack tokens={stackTokens}>
+              <Label>
+                <h3>Avatar Initials</h3>
+                <TextField
+                  label="Bot avatar initials"
+                  onChange={handleBotAvatarInitialsChange}
+                  value={botAvatarInitials || ''}
+                />
+                <TextField
+                  label="User avatar initials"
+                  onChange={handleUserAvatarInitialsChange}
+                  value={userAvatarInitials || ''}
+                />
+              </Label>
+              <Label>
+                <h3>Bubble style options</h3>
+                <Toggle
+                  label="Show bubble nub"
+                  checked={bubbleNub}
+                  onChange={handleBubbleNubChange}
+                  onText="On"
+                  offText="Off"
+                />
+                <Toggle
+                  label="Customize bubble borders"
+                  checked={bubbleStyle}
+                  onChange={handleBubbleBorderChange}
+                  onText="On"
+                  offText="Off"
+                />
+              </Label>
+              <Toggle
+                label="Hide SendBox"
+                checked={hideSendBox}
+                onChange={handleHideSendBoxChange}
+                onText="On"
+                offText="Off"
+              />
+              <Dropdown
+                label="Group timestamp"
+                onChange={handleGroupTimestampChange}
+                options={groupTimestampOptions}
+                selectedKey={groupTimestamp}
+              />
+              {/* TODO: (#3515) info icon: Send 'herocard long title' to test this feature */}
+              <Toggle
+                label="Rich card wrap title"
+                checked={richCardWrapTitle}
+                onChange={handleRichCardWrapTitleChange}
+                onText="On"
+                offText="Off"
+              />
+              {/*  (#3515) info icon: Turn on airplane mode to test this feature */}
+              <Dropdown
+                label="Send timeout"
+                onChange={handleSendTimeoutChange}
+                options={sendTimeoutOptions}
+                selectedKey={sendTimeout}
+              />
+              <Label className="info-container">
+                <TooltipHost
+                  calloutProps={{ gapSpace: 0 }}
+                  tooltipProps={wordBreakTooltipProps}
+                  id="Word break tooltip"
+                >
+                  <IconButton aria-label="info" iconProps={{ iconName: 'infoSolid' }} />
+                </TooltipHost>
+                <Dropdown
+                  label="Word break"
+                  onChange={handleWordBreakChange}
+                  options={messageActivityWordBreakOptions}
+                  selectedKey={messageActivityWordBreak}
+                />
+              </Label>
+            </Stack>
+          </fieldset>
         </fieldset>
       </div>
     </div>

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -24,6 +24,7 @@ function App() {
   const stackTokens = { childrenGap: 0 };
 
   // TODO: Add action buttons in tooltip later
+  // wordBreak styleOption is in regards to css feature word-break: 'break-all' (as an example) within the activity bubble
   const wordBreakTooltipProps = {
     onRenderContent: () => (
       <ol style={{ margin: 10, padding: 10 }}>

--- a/packages/playground/src/css.js
+++ b/packages/playground/src/css.js
@@ -1,6 +1,7 @@
 // TODO: (#3515) make into proper emotion objects
 const PlaygroundStyles = `html,
 body {
+  font-family: "Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   height: 100%;
 }
 
@@ -38,8 +39,7 @@ fieldset {
   flex-direction: column;
 }
 
-fieldset > button {
-
+fieldset button {
   background-color: rgba(128, 128, 128, .2);
   border: 0;
   height: 25px;
@@ -49,14 +49,47 @@ fieldset > button {
   width: 100%;
 }
 
-fieldset > button:hover {
+fieldset button:hover {
   background-color: rgba(0, 0, 0, .2);
   color: 'White'
 }
 
+.info-container {
+  display: flex;
+  flex-flow: row-reverse;
+  justify-content: flex-end;
+}
+
+h3 {
+  margin: 10px 0px 0px 0px;
+}
+
+legend {
+  font-weight: bold;
+  font-size: 1.5em;
+}
+
+fieldset fieldset legend {
+  font-size: 1.25em;
+}
 .webchat {
   height: 100%;
   margin: 0;
   max-width: 500px
+}
+
+:disabled:focus,
+[aria-disabled='true']:focus {
+  outline-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.webchat .card__action--performed {
+  background-color: #0063b1 !important;
+  border-color: #0063b1 !important;
+  color: White !important;
+}
+
+.webchat .card__action--performed:focus {
+  outline-color: rgba(255, 255, 255, 0.6) !important;
 }`;
 export default PlaygroundStyles;

--- a/samples/05.custom-components/l.disable-adaptive-cards/index.html
+++ b/samples/05.custom-components/l.disable-adaptive-cards/index.html
@@ -197,14 +197,7 @@
         const App = () => {
           const directLine = useMemo(() => window.WebChat.createDirectLine({ token }), []);
 
-          return (
-            <ReactWebChat
-              attachmentMiddleware={attachmentMiddleware}
-              directLine={directLine}
-              disabled={disabled}
-              store={store}
-            />
-          );
+          return <ReactWebChat attachmentMiddleware={attachmentMiddleware} directLine={directLine} store={store} />;
         };
 
         window.ReactDOM.render(<App />, document.getElementById('webchat'));


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3618 
> Fixes #3582

## Changelog Entry

## Description

Previously, Adaptive Cards that have been marked as obsolete in the DOM were disabling anchors, which is invalid behavior. This change makes it so that while other inputs are disabled, anchors remain enabled and can be clicked/navigated to when in an older message in the transcript.

This also fixes the Disable Adaptive Cards sample, which had an error in it.


<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  ~[ ] I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
