### PR TITLE
Add CD for daily release

### DIFF
--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: tarball
+          name: tarballs
 
       - id: compute_hash
         name: Compute build metadata

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -1,0 +1,77 @@
+name: Daily build
+
+on:
+  push:
+    paths:
+      - .github/workflows/daily-release.yaml
+  schedule:
+    - cron: 00 03 * * *
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out for ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - run: npm ci --no-production
+
+      - name: Propagate versions
+        run: node_modules/.bin/lerna version --exact --force-publish --no-git-tag-version --no-push --yes `cat package.json | jq -r .version`
+
+      - run: npm run bootstrap
+      - run: npm run build
+
+      - name: Run npm pack api
+        run: |
+          cd packages/api
+          npm pack
+
+      - name: Run npm pack bundle
+        run: |
+          cd packages/bundle
+          npm pack
+
+      - name: Run npm pack component
+        run: |
+          cd packages/component
+          npm pack
+
+      - name: Run npm pack core
+        run: |
+          cd packages/core
+          npm pack
+
+      - name: Run npm pack directlinespeech
+        run: |
+          cd packages/directlinespeech
+          npm pack
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: tarball
+          path: |
+            packages/api/*.tgz
+            packages/bundle/*.tgz
+            packages/component/*.tgz
+            packages/core/*.tgz
+            packages/directlinespeech/*.tgz
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bundle
+          path: packages/bundle/dist/**/*
+
+      # - id: deploy
+      #   uses: azure/webapps-deploy@v2.1.2
+      #   with:
+      #     app-name: webchat-playground
+      #     slot-name: production
+      #     publish-profile: ${{ secrets.PLAYGROUND_PUBLISH_PROFILE }}
+      #     package: packages/playground/build.zip
+
+      # - name: Ping deployment
+      #   run: |
+      #     sleep 15
+      #     curl -s ${{ steps.deploy.outputs.webapp-url }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -10,8 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NODE_ENV: production
 
     steps:
       - name: Checking out for ${{ github.ref }}
@@ -24,6 +22,8 @@ jobs:
 
       - run: npm run bootstrap
       - run: npm run build
+        env:
+          NODE_ENV: production
 
       - name: Run npm pack api
         run: |
@@ -65,30 +65,59 @@ jobs:
           name: bundle
           path: packages/bundle/dist/**/*
 
-      # - id: deploy
-      #   uses: azure/webapps-deploy@v2.1.2
-      #   with:
-      #     app-name: webchat-playground
-      #     slot-name: production
-      #     publish-profile: ${{ secrets.PLAYGROUND_PUBLISH_PROFILE }}
-      #     package: packages/playground/build.zip
-
-      # - name: Ping deployment
-      #   run: |
-      #     sleep 15
-      #     curl -s ${{ steps.deploy.outputs.webapp-url }}
-
       - id: compute-hash
         name: Compute build metadata
         run: |
+          echo "::set-output name=build-date::`date \"+%Y-%m-%d %R:%S\"`"
+          echo "::set-output name=package-version::`tar -xOzf packages/bundle/webchat-*.tgz package/package.json | jq -r '.version'`"
+          echo "::set-output name=release-tag-name::daily"
           echo "::set-output name=sha384-es5::`cat packages/bundle/dist/webchat-es5.js | openssl dgst -sha384 -binary | openssl base64 -A`"
           echo "::set-output name=sha384-full::`cat packages/bundle/dist/webchat.js | openssl dgst -sha384 -binary | openssl base64 -A`"
           echo "::set-output name=sha384-minimal::`cat packages/bundle/dist/webchat-minimal.js | openssl dgst -sha384 -binary | openssl base64 -A`"
-          echo "::set-output name=package-version::`tar -xOzf packages/bundle/webchat-*.tgz package/package.json | jq -r '.version'`"
 
       - name: Display build metadata
         run: |
+          echo build-date=${{ steps.compute-hash.outputs.build-date }}
+          echo release-tag-name=${{ steps.compute-hash.outputs.release-tag-name }}
+          echo package-version=${{ steps.compute-hash.outputs.package-version }}
           echo sha384-es5=${{ steps.compute-hash.outputs.sha384-es5 }}
           echo sha384-full=${{ steps.compute-hash.outputs.sha384-full }}
           echo sha384-minimal=${{ steps.compute-hash.outputs.sha384-minimal }}
-          echo package-version=${{ steps.compute-hash.outputs.package-version }}
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+        with:
+          tag_name: ${{ steps.compute-hash.outputs.release-tag-name }}
+          release_name: Daily build $GITHUB_REF
+          body: |
+            This build will be updated daily. **Please do not use this build in production environment.**
+
+            | Build time | Run ID | Source version | Git ref | Package version |
+            | - | - | - | - | - |
+            | ${{ steps.compute-hash.outputs.build-date }} | [`$GITHUB_RUN_ID`](${{ $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID }}) | [$GITHUB_SHA]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA) | `$GITHUB_REF` | `${{ steps.compute-hash.outputs.package-version }}` |
+
+            ```html
+            <script
+              crossorigin="anonymous"
+              integrity="sha384-${{ steps.compute-hash.outputs.sha384-full }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat.js"
+            ></script>
+
+            <script
+              crossorigin="anonymous"
+              integrity="sha384-${{ steps.compute-hash.outputs.sha384-es5 }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat-es5.js"
+            ></script>
+
+            <script
+              crossorigin="anonymous"
+              integrity="sha384-${{ steps.compute-hash.outputs.sha384-minimal }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat-minimal.js"
+            ></script>
+            ```
+
+            > Note: the SHA384 hash may change daily.
+          draft: false
+          prerelease: true

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -111,7 +111,7 @@ jobs:
         run: gh release delete ${{ steps.compute_hash.outputs.release_tag_name }} --repo ${{ github.repository }} --yes
 
       - name: Create release
-        id: create-release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -149,7 +149,47 @@ jobs:
           draft: false
           prerelease: true
 
-      - name: Upload release assets
+      - name: Upload tarballs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.json *.tgz --repo ${{ github.repository }}
+        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.tgz --repo ${{ github.repository }}
+
+      - name: Upload stats.json
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./stats.json
+          asset_name: stats.json
+          asset_content_type: application/json
+
+      - name: Upload webchat.js
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./webchat.js
+          asset_name: webchat.js
+          asset_content_type: text/javascript
+
+      - name: Upload webchat-es5.js
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./webchat-es5.js
+          asset_name: webchat-es5.js
+          asset_content_type: text/javascript
+
+      - name: Upload webchat-minimal.js
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./webchat-minimal.js
+          asset_name: webchat-minimal.js
+          asset_content_type: text/javascript

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -149,47 +149,7 @@ jobs:
           draft: false
           prerelease: true
 
-      - name: Upload tarballs
+      - name: Upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.tgz --repo ${{ github.repository }}
-
-      - name: Upload stats.json
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./stats.json
-          asset_name: stats.json
-          asset_content_type: application/json
-
-      - name: Upload webchat.js
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./webchat.js
-          asset_name: webchat.js
-          asset_content_type: text/javascript
-
-      - name: Upload webchat-es5.js
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./webchat-es5.js
-          asset_name: webchat-es5.js
-          asset_content_type: text/javascript
-
-      - name: Upload webchat-minimal.js
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./webchat-minimal.js
-          asset_name: webchat-minimal.js
-          asset_content_type: text/javascript
+        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.json *.tgz --repo ${{ github.repository }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -59,10 +59,10 @@ jobs:
           npm pack
           cp *.tgz ../../artifacts/tarballs
 
-      - name: Upload bundle
+      - name: Upload bundles
         uses: actions/upload-artifact@v2
         with:
-          name: bundle
+          name: bundles
           path: packages/bundle/dist/**/*
 
       - name: Upload tarballs
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: bundle
+          name: bundles
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -22,102 +22,158 @@ jobs:
 
       - run: npm run bootstrap
       - run: npm run build
-        env:
-          NODE_ENV: production
+        # env:
+        #   NODE_ENV: production
+
+      - run: mkdir -p artifacts/tarballs
 
       - name: Run npm pack api
         run: |
           cd packages/api
           npm pack
+          cp *.tgz ../../artifacts/tarballs
 
       - name: Run npm pack bundle
         run: |
           cd packages/bundle
           npm pack
+          cp *.tgz ../../artifacts/tarballs
 
       - name: Run npm pack component
         run: |
           cd packages/component
           npm pack
+          cp *.tgz ../../artifacts/tarballs
 
       - name: Run npm pack core
         run: |
           cd packages/core
           npm pack
+          cp *.tgz ../../artifacts/tarballs
 
       - name: Run npm pack directlinespeech
         run: |
           cd packages/directlinespeech
           npm pack
+          cp *.tgz ../../artifacts/tarballs
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: tarball
-          path: |
-            packages/api/*.tgz
-            packages/bundle/*.tgz
-            packages/component/*.tgz
-            packages/core/*.tgz
-            packages/directlinespeech/*.tgz
-
-      - uses: actions/upload-artifact@v2
+      - name: Upload bundle
+        uses: actions/upload-artifact@v2
         with:
           name: bundle
           path: packages/bundle/dist/**/*
 
-      - id: compute-hash
+      - name: Upload tarballs
+        uses: actions/upload-artifact@v2
+        with:
+          name: tarballs
+          path: artifacts/tarballs/**/*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: bundle
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: tarball
+
+      - id: compute_hash
         name: Compute build metadata
         run: |
-          echo "::set-output name=build-date::`date \"+%Y-%m-%d %R:%S\"`"
-          echo "::set-output name=package-version::`tar -xOzf packages/bundle/webchat-*.tgz package/package.json | jq -r '.version'`"
-          echo "::set-output name=release-tag-name::daily"
-          echo "::set-output name=sha384-es5::`cat packages/bundle/dist/webchat-es5.js | openssl dgst -sha384 -binary | openssl base64 -A`"
-          echo "::set-output name=sha384-full::`cat packages/bundle/dist/webchat.js | openssl dgst -sha384 -binary | openssl base64 -A`"
-          echo "::set-output name=sha384-minimal::`cat packages/bundle/dist/webchat-minimal.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=git_short_ref::`echo ${{ github.ref }} | cut -c 1-7`"
+          echo "::set-output name=package_version::`tar -xOzf botframework-webchat-4*.tgz package/package.json | jq -r '.version'`"
+          echo "::set-output name=release_date::`date \"+%Y-%m-%d %R:%S\"`"
+          echo "::set-output name=release_tag_name::daily"
+          echo "::set-output name=sha384_es5::`cat webchat-es5.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=sha384_full::`cat webchat.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=sha384_minimal::`cat webchat-minimal.js | openssl dgst -sha384 -binary | openssl base64 -A`"
 
       - name: Display build metadata
         run: |
-          echo build-date=${{ steps.compute-hash.outputs.build-date }}
-          echo release-tag-name=${{ steps.compute-hash.outputs.release-tag-name }}
-          echo package-version=${{ steps.compute-hash.outputs.package-version }}
-          echo sha384-es5=${{ steps.compute-hash.outputs.sha384-es5 }}
-          echo sha384-full=${{ steps.compute-hash.outputs.sha384-full }}
-          echo sha384-minimal=${{ steps.compute-hash.outputs.sha384-minimal }}
+          echo git_short_ref=${{ steps.compute_hash.outputs.git_short_ref }}
+          echo package_version=${{ steps.compute_hash.outputs.package_version }}
+          echo release_date=${{ steps.compute_hash.outputs.release_date }}
+          echo release_tag_name=${{ steps.compute_hash.outputs.release_tag_name }}
+          echo sha384_es5=${{ steps.compute_hash.outputs.sha384_es5 }}
+          echo sha384_full=${{ steps.compute_hash.outputs.sha384_full }}
+          echo sha384_minimal=${{ steps.compute_hash.outputs.sha384_minimal }}
 
       - name: Create release
+        id: create-release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.compute-hash.outputs.release-tag-name }}
+          tag_name: ${{ steps.compute_hash.outputs.release_tag_name }}
           release_name: Daily build ${{ github.ref }}
           body: |
             This build will be updated daily. **Please do not use this build in production environment.**
 
             | Build time | Run ID | Source version | Git ref | Package version |
             | - | - | - | - | - |
-            | ${{ steps.compute-hash.outputs.build-date }} | [`${{ github.run_id }}`](${{ env.GITHUB_SERVER_URL }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ github.sha }}](${{ env.GITHUB_SERVER_URL }}/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute-hash.outputs.package-version }}` |
+            | ${{ steps.compute_hash.outputs.release_date }} | [`${{ github.run_id }}`]($GITHUB_SERVER_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ steps.compute_hash.outputs.git_short_ref }}]($GITHUB_SERVER_URL/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute_hash.outputs.package_version }}` |
 
             ```html
             <script
               crossorigin="anonymous"
-              integrity="sha384-${{ steps.compute-hash.outputs.sha384-full }}"
-              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat.js"
+              integrity="sha384-${{ steps.compute_hash.outputs.sha384_full }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute_hash.outputs.release_tag_name }}/webchat.js"
             ></script>
 
             <script
               crossorigin="anonymous"
-              integrity="sha384-${{ steps.compute-hash.outputs.sha384-es5 }}"
-              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat-es5.js"
+              integrity="sha384-${{ steps.compute_hash.outputs.sha384_es5 }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute_hash.outputs.release_tag_name }}/webchat-es5.js"
             ></script>
 
             <script
               crossorigin="anonymous"
-              integrity="sha384-${{ steps.compute-hash.outputs.sha384-minimal }}"
-              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute-hash.outputs.release-tag-name }}/webchat-minimal.js"
+              integrity="sha384-${{ steps.compute_hash.outputs.sha384_minimal }}"
+              src="https://github.com/microsoft/BotFramework-WebChat/releases/download/${{ steps.compute_hash.outputs.release_tag_name }}/webchat-minimal.js"
             ></script>
             ```
 
             > Note: the SHA384 hash may change daily.
           draft: false
           prerelease: true
+
+      - name: Upload release assets
+        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz
+
+      # - name: Upload webchat.js
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     asset_content_type: text/javascript
+      #     asset_name: webchat.js
+      #     asset_path: ./webchat.js
+      #     upload_url: ${{ steps.create-release.outputs.upload_url }}
+
+      # - name: Upload webchat-es5.js
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     asset_content_type: text/javascript
+      #     asset_name: webchat-es5.js
+      #     asset_path: ./webchat-es5.js
+      #     upload_url: ${{ steps.create-release.outputs.upload_url }}
+
+      # - name: Upload webchat-minimal.js
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     asset_content_type: text/javascript
+      #     asset_name: webchat-minimal.js
+      #     asset_path: ./webchat-minimal.js
+      #     upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -104,6 +104,8 @@ jobs:
           echo sha384_minimal=${{ steps.compute_hash.outputs.sha384_minimal }}
 
       - name: Delete existing release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release delete ${{ steps.compute_hash.outputs.release_tag_name }} --yes
 
       - name: Create release
@@ -146,4 +148,6 @@ jobs:
           prerelease: true
 
       - name: Upload release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - run: npm run bootstrap
       - run: npm run build
-        # env:
-        #   NODE_ENV: production
+        env:
+          NODE_ENV: production
 
       - run: mkdir -p artifacts/tarballs
 
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.compute_hash.outputs.release_tag_name }}
-          release_name: Daily build ${{ github.ref }}
+          release_name: Daily build (${{ github.ref }})
           body: |
             This build will be updated daily. **Please do not use this build in production environment.**
 

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -15,6 +15,8 @@ jobs:
       - name: Checking out for ${{ github.ref }}
         uses: actions/checkout@v2
 
+      - run: npx version-from-git --no-git-tag-version
+
       - run: npm ci --no-production
 
       - name: Propagate versions

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -4,8 +4,8 @@ on:
   push:
     paths:
       - .github/workflows/daily-release.yaml
-  schedule:
-    - cron: 00 03 * * *
+  # schedule:
+  #   - cron: 00 03 * * *
 
 jobs:
   build:
@@ -87,16 +87,16 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.compute-hash.outputs.release-tag-name }}
-          release_name: Daily build $GITHUB_REF
+          release_name: Daily build ${{ github.ref }}
           body: |
             This build will be updated daily. **Please do not use this build in production environment.**
 
             | Build time | Run ID | Source version | Git ref | Package version |
             | - | - | - | - | - |
-            | ${{ steps.compute-hash.outputs.build-date }} | [`$GITHUB_RUN_ID`](${{ $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID }}) | [$GITHUB_SHA]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA) | `$GITHUB_REF` | `${{ steps.compute-hash.outputs.package-version }}` |
+            | ${{ steps.compute-hash.outputs.build-date }} | [`${{ github.run_id }}`](${{ env.GITHUB_SERVER_URL }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ github.sha }}](${{ env.GITHUB_SERVER_URL }}/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute-hash.outputs.package-version }}` |
 
             ```html
             <script

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -123,7 +123,7 @@ jobs:
 
             | Build time | Run ID | Source version | Git ref | Package version |
             | - | - | - | - | - |
-            | ${{ steps.compute_hash.outputs.release_date }} | [`${{ github.run_id }}`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ steps.compute_hash.outputs.git_short_sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute_hash.outputs.package_version }}` |
+            | ${{ steps.compute_hash.outputs.release_date }}Z | [`${{ github.run_id }}`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [`${{ steps.compute_hash.outputs.git_short_sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute_hash.outputs.package_version }}` |
 
             ```html
             <script
@@ -152,4 +152,4 @@ jobs:
       - name: Upload release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz --repo ${{ github.repository }}
+        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.json *.tgz --repo ${{ github.repository }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -103,6 +103,9 @@ jobs:
           echo sha384_full=${{ steps.compute_hash.outputs.sha384_full }}
           echo sha384_minimal=${{ steps.compute_hash.outputs.sha384_minimal }}
 
+      - name: Delete existing release
+        run: gh release delete ${{ steps.compute_hash.outputs.release_tag_name }} --yes
+
       - name: Create release
         id: create-release
         uses: actions/create-release@v1
@@ -144,36 +147,3 @@ jobs:
 
       - name: Upload release assets
         run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz
-
-      # - name: Upload webchat.js
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     asset_content_type: text/javascript
-      #     asset_name: webchat.js
-      #     asset_path: ./webchat.js
-      #     upload_url: ${{ steps.create-release.outputs.upload_url }}
-
-      # - name: Upload webchat-es5.js
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     asset_content_type: text/javascript
-      #     asset_name: webchat-es5.js
-      #     asset_path: ./webchat-es5.js
-      #     upload_url: ${{ steps.create-release.outputs.upload_url }}
-
-      # - name: Upload webchat-minimal.js
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     asset_content_type: text/javascript
-      #     asset_name: webchat-minimal.js
-      #     asset_path: ./webchat-minimal.js
-      #     upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
 
     steps:
       - name: Checking out for ${{ github.ref }}
@@ -75,3 +77,18 @@ jobs:
       #   run: |
       #     sleep 15
       #     curl -s ${{ steps.deploy.outputs.webapp-url }}
+
+      - id: compute-hash
+        name: Compute build metadata
+        run: |
+          echo "::set-output name=sha384-es5::`cat packages/bundle/dist/webchat-es5.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=sha384-full::`cat packages/bundle/dist/webchat.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=sha384-minimal::`cat packages/bundle/dist/webchat-minimal.js | openssl dgst -sha384 -binary | openssl base64 -A`"
+          echo "::set-output name=package-version::`tar -xOzf packages/bundle/webchat-*.tgz package/package.json | jq -r '.version'`"
+
+      - name: Display build metadata
+        run: |
+          echo sha384-es5=${{ steps.compute-hash.outputs.sha384-es5 }}
+          echo sha384-full=${{ steps.compute-hash.outputs.sha384-full }}
+          echo sha384-minimal=${{ steps.compute-hash.outputs.sha384-minimal }}
+          echo package-version=${{ steps.compute-hash.outputs.package-version }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -87,7 +87,7 @@ jobs:
       - id: compute_hash
         name: Compute build metadata
         run: |
-          echo "::set-output name=git_short_ref::`echo ${{ github.ref }} | cut -c 1-7`"
+          echo "::set-output name=git_short_sha::`echo ${{ github.sha }} | cut -c 1-7`"
           echo "::set-output name=package_version::`tar -xOzf botframework-webchat-4*.tgz package/package.json | jq -r '.version'`"
           echo "::set-output name=release_date::`date \"+%Y-%m-%d %R:%S\"`"
           echo "::set-output name=release_tag_name::daily"
@@ -97,7 +97,7 @@ jobs:
 
       - name: Display build metadata
         run: |
-          echo git_short_ref=${{ steps.compute_hash.outputs.git_short_ref }}
+          echo git_short_sha=${{ steps.compute_hash.outputs.git_short_sha }}
           echo package_version=${{ steps.compute_hash.outputs.package_version }}
           echo release_date=${{ steps.compute_hash.outputs.release_date }}
           echo release_tag_name=${{ steps.compute_hash.outputs.release_tag_name }}
@@ -123,7 +123,7 @@ jobs:
 
             | Build time | Run ID | Source version | Git ref | Package version |
             | - | - | - | - | - |
-            | ${{ steps.compute_hash.outputs.release_date }} | [`${{ github.run_id }}`]($GITHUB_SERVER_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ steps.compute_hash.outputs.git_short_ref }}]($GITHUB_SERVER_URL/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute_hash.outputs.package_version }}` |
+            | ${{ steps.compute_hash.outputs.release_date }} | [`${{ github.run_id }}`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) | [${{ steps.compute_hash.outputs.git_short_sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) | `${{ github.ref }}` | `${{ steps.compute_hash.outputs.package_version }}` |
 
             ```html
             <script

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -4,8 +4,8 @@ on:
   push:
     paths:
       - .github/workflows/daily-release.yaml
-  # schedule:
-  #   - cron: 00 03 * * *
+  schedule:
+    - cron: 00 03 * * *
 
 jobs:
   build:
@@ -117,9 +117,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.compute_hash.outputs.release_tag_name }}
-          release_name: Daily build (${{ github.ref }})
+          release_name: Daily (${{ github.ref }})
           body: |
-            This build will be updated daily. **Please do not use this build in production environment.**
+            This release will be updated daily. **Please do not use this build in production environment.**
 
             | Build time | Run ID | Source version | Git ref | Package version |
             | - | - | - | - | - |

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -1,4 +1,4 @@
-name: Daily build
+name: Daily release
 
 on:
   push:

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Delete existing release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete ${{ steps.compute_hash.outputs.release_tag_name }} --yes
+        run: gh release delete ${{ steps.compute_hash.outputs.release_tag_name }} --repo ${{ github.repository }} --yes
 
       - name: Create release
         id: create-release
@@ -150,4 +150,4 @@ jobs:
       - name: Upload release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz
+        run: gh release upload ${{ steps.compute_hash.outputs.release_tag_name }} *.js *.tgz --repo ${{ github.repository }}


### PR DESCRIPTION
## Changelog Entry

(No changelog for CI change)

## Description

This will add a new workflow for GitHub Actions to build and release a new daily release.

This is a replacement to our existing CI pipeline in Azure DevOps.

## Design

It triggers when the YAML file changed, or every day at 3 AM.

```yaml
on:
  push:
    paths:
      - .github/workflows/daily-release.yaml
  schedule:
    - cron: 00 03 * * *
```

## Specific Changes

- Added a new workflow that will run every day at 3 AM

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
