### PR TITLE
Add role="group" to transcript focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3747](https://github.com/microsoft/BotFramework-WebChat/issues/3747). `aria-pressed` and `aria-role` is not properly set on Adaptive Cards submit buttons, by [@amal-khalaf](https://github.com/amal-khalaf) in PR [#3744](https://github.com/microsoft/BotFramework-WebChat/pull/3744)
 -  Fixes [#3750](https://github.com/microsoft/BotFramework-WebChat/issues/3750). Debump Node.js engines requirements for some packages to `12.0.0`, by [@compulim](https://github.com/compulim) in PR [#3753](https://github.com/microsoft/BotFramework-WebChat/pull/3753)
 -  Fixes [#3760](https://github.com/microsoft/BotFramework-WebChat/issues/3760). Use `<ErrorBoundary>` to wrap around attachment renderer, by [@compulim](https://github.com/compulim) in PR [#3761](https://github.com/microsoft/BotFramework-WebChat/pull/3761)
+-  Fixes [#3764](https://github.com/microsoft/BotFramework-WebChat/issues/3764). Added `role="group"` to the focusable transcript to enable `aria-activedescendant`, by [@compulim](https://github.com/compulim) in PR [#3765](https://github.com/microsoft/BotFramework-WebChat/issues/3765)
 
 ### Changed
 

--- a/packages/component/src/BasicTranscript.js
+++ b/packages/component/src/BasicTranscript.js
@@ -743,6 +743,9 @@ const InternalTranscript = ({ activityElementsRef, className }) => {
       onKeyDown={handleTranscriptKeyDown}
       onKeyDownCapture={handleTranscriptKeyDownCapture}
       ref={rootElementRef}
+      // "aria-activedescendant" will only works with a number of roles and it must be explicitly set.
+      // https://www.w3.org/TR/wai-aria/#aria-activedescendant
+      role="group"
       // For up/down arrow key navigation across activities, this component must be included in the tab sequence.
       // Otherwise, "aria-activedescendant" will not be narrated when the user press up/down arrow keys.
       // https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_focus_activedescendant


### PR DESCRIPTION
> Fixes #3764.

## Changelog Entry

### Fixed

-  Fixes [#3764](https://github.com/microsoft/BotFramework-WebChat/issues/3764). Added `role="group"` to the focusable transcript to enable `aria-activedescendant`, by [@compulim](https://github.com/compulim) in PR [#3765](https://github.com/microsoft/BotFramework-WebChat/issues/3765)

## Description

Add `role="group"` to transcript focusable element, to enable `aria-activedescendant` in macOS Safari + VoiceOver.

## Design

[According to WAI-ARIA](https://www.w3.org/TR/wai-aria/#aria-activedescendant), `aria-activedescendant` will only work with one of the following `role`:

- `application`
- `composite` with subclass of
  - `grid`
  - `select`
  - `spinbutton`
  - `tablist`
- `group`
- `textbox`
- `combobox`
- `grid`
- `listbox`
- `menu`
- `menubar`
- `radiogroup`
- `row`
- `searchbox`
- `select`
- `spinbutton`
- `tablist`
- `toolbar`
- `tree`
- `treegrid`

## Specific Changes

- Add `role="group"` to the focusable of `<BasicTranscript>`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
