### PR TITLE
Remove replyToId for Direct Line Speech adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#3773](https://github.com/microsoft/BotFramework-WebChat/issues/3773). Remove `replyToId` when using Direct Line Speech adapter, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#3773](https://github.com/microsoft/BotFramework-WebChat/issues/3773). Remove `replyToId` when using Direct Line Speech adapter, by [@compulim](https://github.com/compulim) in PR [#3776](https://github.com/microsoft/BotFramework-WebChat/pull/3776)
 
 ### Samples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Fixes [#3773](https://github.com/microsoft/BotFramework-WebChat/issues/3773). Remove `replyToId` when using Direct Line Speech adapter, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ### Samples
 
 -  Fixes [#3632](https://github.com/microsoft/BotFramework-WebChat/issues/3632). Update reaction button sample : Add replyToId to the postActivity object, by [@amal-khalaf](https://github.com/amal-khalaf) in PR [#3769](https://github.com/microsoft/BotFramework-WebChat/pull/3769)

--- a/__tests__/html/chatAdapter.directLineSpeech.html
+++ b/__tests__/html/chatAdapter.directLineSpeech.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script crossorigin="anonymous" src="/__dist__/testharness.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script type="text/babel" data-presets="env,stage-3,react">
+      const { conditions, createStore, expect, host, pageObjects, timeouts, token } = window.WebChatTest;
+
+      (async function () {
+        window.WebChat.renderWebChat(
+          {
+            ...(await window.WebChat.createDirectLineSpeechAdapters({
+              fetchCredentials: await token.fetchDirectLineSpeechCredentials()
+            })),
+            store: createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageObjects.wait(conditions.uiConnected(), timeouts.directLine);
+
+        await pageObjects.sendMessageViaSendBox('Hello, World!', { waitForSend: true });
+        await pageObjects.wait(conditions.minNumActivitiesShown(2), timeouts.directLine);
+
+        // The next message should arrive quickly as the connection has already established.
+        await pageObjects.sendMessageViaSendBox('Aloha!', { waitForSend: true });
+        await pageObjects.wait(conditions.minNumActivitiesShown(4), 2000);
+
+        await host.done();
+      })().catch(async err => {
+        console.error(err);
+
+        await host.error(err);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/chatAdapter.directLineSpeech.js
+++ b/__tests__/html/chatAdapter.directLineSpeech.js
@@ -1,0 +1,7 @@
+/**
+ * @jest-environment ./__tests__/html/__jest__/WebChatEnvironment.js
+ */
+
+describe('Direct Line Speech chat adapter', () => {
+  test('should connect to the MockBot.', () => runHTMLTest('chatAdapter.directLineSpeech.html'));
+});

--- a/docs/DIRECT_LINE_SPEECH.md
+++ b/docs/DIRECT_LINE_SPEECH.md
@@ -482,12 +482,6 @@ You can only specify speech recognition language at initialization time. You can
 
 [Proactive message](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp) is not supported when using Direct Line Speech.
 
-### Emulator is not supported
-
-> Please vote on [this bug](https://github.com/microsoft/BotFramework-WebChat/issues/2683) if this behavior is not desirable.
-
-Currently, Emulator only support Direct Line protocol. We are planning to add Direct Line Speech protocol to Emulator.
-
 ### Abort recognition is not supported
 
 > Please vote on [this bug](https://github.com/microsoft/BotFramework-WebChat/issues/2664) if this behavior is not desirable.

--- a/packages/directlinespeech/src/DirectLineSpeech.js
+++ b/packages/directlinespeech/src/DirectLineSpeech.js
@@ -56,6 +56,8 @@ export default class DirectLineSpeech {
               // Since DLSpeech service never ACK our outgoing activity, this activity must be from bot.
               role: 'bot'
             },
+            // Since DLSpeech never ACK our outgoing activity, the "replyToId" will rarely able to point to an existing activity.
+            replyToId: undefined,
             // Direct Line Speech server currently do not timestamp outgoing activities.
             // Thus, it will be easier to just re-timestamp every incoming/outgoing activities using local time.
             timestamp: new Date().toISOString()


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3773

## Changelog Entry

### Fixes

-  Fixes [#3773](https://github.com/microsoft/BotFramework-WebChat/issues/3773). Remove `replyToId` when using Direct Line Speech adapter, by [@compulim](https://github.com/compulim) in PR [#3776](https://github.com/microsoft/BotFramework-WebChat/pull/3776)

## Description

Direct Line Speech adapter does not provide send receipt or any form of ACKs. The `replyToId` will always point to an activity outside of the transcript. Thus, a delay will always be introduced (for accessibility reasons).

Since receipts or send ACKs are not supported, we could remove the `replyToId` to prevent accessibility work to introduce the delay of showing activities.

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

- Update Direct Line Speech chat adapter to remove `replyToId` for all incoming activities
- Added tests to make sure 2 consecutive messages sent are received in a timely manner.

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
