### PR TITLE
4.13.0 release bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.13.0] - 2021-03-31
+
 ### Added
 
 -  Resolves [#3087](https://github.com/microsoft/BotFramework-WebChat/issues/3087). External links in Markdown will now be appended with an "open in new window" icon and accessibility label, by [@compulim](https://github.com/compulim) in PR [#3817](https://github.com/microsoft/BotFramework-WebChat/pull/3817)
+-  Resolves [#2100](https://github.com/microsoft/BotFramework-WebChat/issues/2100). Add types declarations for Style Options in api bundle, by [@corinagum](https://github.com/corinagum), in PR [#3818](https://github.com/microsoft/BotFramework-WebChat/pull/3818)
 
 ### Changed
 
@@ -85,7 +88,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 -  Resolves [#3777](https://github.com/microsoft/BotFramework-WebChat/issues/3777). Added a new `adaptiveCardsParserMaxVersion` style options for selecting the maximum supported version when parsing an Adaptive Cards, by [@compulim](https://github.com/compulim) in PR [#3778](https://github.com/microsoft/BotFramework-WebChat/pull/3778)
--  Resolves [#2100](https://github.com/microsoft/BotFramework-WebChat/issues/2100). Add types declarations for Style Options in api bundle, by [@corinagum](https://github.com/corinagum), in PR [#3818](https://github.com/microsoft/BotFramework-WebChat/pull/3818)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.12.2-0",
+  "version": "4.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.12.2-0",
+  "version": "4.13.0",
   "private": true,
   "files": [
     "lib/**/*"


### PR DESCRIPTION
#3826
## [4.13.0] - 2021-03-31

### Added

-  Resolves [#3087](https://github.com/microsoft/BotFramework-WebChat/issues/3087). External links in Markdown will now be appended with an "open in new window" icon and accessibility label, by [@compulim](https://github.com/compulim) in PR [#3817](https://github.com/microsoft/BotFramework-WebChat/pull/3817)
-  Resolves [#2100](https://github.com/microsoft/BotFramework-WebChat/issues/2100). Add types declarations for Style Options in api bundle, by [@corinagum](https://github.com/corinagum), in PR [#3818](https://github.com/microsoft/BotFramework-WebChat/pull/3818)

### Changed

-  Bumped all dependencies to the latest versions and sample bumps, by [@corinagum](https://github.com/corinagum) in PR [#3805](https://github.com/microsoft/BotFramework-WebChat/pull/3805)
   -  Development dependencies
      -  [`@babel/cli@7.13.10`](https://npmjs.com/package/@babel/cli)
      -  [`@babel/core@7.13.10`](https://npmjs.com/package/@babel/core)
      -  [`@babel/plugin-proposal-class-properties@7.13.0`](https://npmjs.com/package/@babel/plugin-proposal-class-properties)
      -  [`@babel/plugin-proposal-object-rest-spread@7.13.8`](https://npmjs.com/package/@babel/plugin-proposal-object-rest-spread)
      -  [`@babel/plugin-transform-runtime@7.13.10`](https://npmjs.com/package/@babel/plugin-transform-runtime)
      -  [`@babel/preset-env@7.13.10`](https://npmjs.com/package/@babel/preset-env)
      -  [`@babel/preset-react@7.12.13`](https://npmjs.com/package/@babel/preset-react)
      -  [`@babel/preset-typescript@7.13.0`](https://npmjs.com/package/@babel/preset-typescript)
      -  [`@babel/runtime@7.13.10`](https://npmjs.com/package/@babel/runtime)
      -  [`@types/node@14.14.35`](https://npmjs.com/package/@types/node)
      -  [`@types/react@16.9.55`](https://npmjs.com/package/@types/react)
      -  [`@typescript-eslint/eslint-plugin@4.18.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
      -  [`@typescript-eslint/parser@4.18.0`](https://npmjs.com/package/@typescript-eslint/parser)
      -  [`babel-jest@26.6.3`](https://npmjs.com/package/babel-jest)
      -  [`eslint-plugin-prettier@3.3.1`](https://npmjs.com/package/eslint-plugin-prettier)
      -  [`eslint-plugin-react-hooks@4.2.0`](https://npmjs.com/package/eslint-plugin-react-hooks)
      -  [`eslint-plugin-react@7.22.0`](https://npmjs.com/package/eslint-plugin-react)
      -  [`eslint@7.22.0`](https://npmjs.com/package/eslint)
      -  [`husky@4.3.0`](https://npmjs.com/package/husky)
      -  [`jest-image-snapshot@4.2.0`](https://npmjs.com/package/jest-image-snapshot)
      -  [`jest-junit@12.0.0`](https://npmjs.com/package/jest-junit)
      -  [`jest-trx-results-processor@2.2.0`](https://npmjs.com/package/jest-trx-results-processor)
      -  [`jest@26.6.3`](https://npmjs.com/package/jest)
      -  [`lint-staged@10.5.1`](https://npmjs.com/package/lint-staged)
      -  [`lolex@6.0.0`](https://npmjs.com/package/lolex)
      -  [`node-dev@6.4.0`](https://npmjs.com/package/node-dev)
      -  [`node-fetch@2.6.1`](https://npmjs.com/package/node-fetch)
      -  [`prettier@2.2.1`](https://npmjs.com/package/prettier)
      -  [`source-map-loader@1.1.2`](https://npmjs.com/package/source-map-loader)
      -  [`terser-webpack-plugin@4.2.3`](https://npmjs.com/package/terser-webpack-plugin)
      -  [`typescript@4.2.3`](https://npmjs.com/package/typescript)
      -  [`webpack-cli@4.2.0`](https://npmjs.com/package/webpack-cli)
      -  [`webpack-stats-plugin@1.0.2`](https://npmjs.com/package/webpack-stats-plugin)
      -  [`webpack@4.44.2`](https://npmjs.com/package/webpack)
   -  Production dependencies
      -  [`@babel/runtime@7.13.10`](https://npmjs.com/package/@babel/runtime)
      -  [`botframework-directlinejs@0.14.1`](https://npmjs.com/package/botframework-directlinejs)
      -  [`globalize@1.6.0`](https://npmjs.com/package/globalize)
      -  [`markdown-it@12.0.4`](https://npmjs.com/package/markdown-it)
      -  [`microsoft-cognitiveservices-speech-sdk@1.15.1`](https://npmjs.com/package/microsoft-cognitiveservices-speech-sdk)
      -  [`react-redux@7.2.2`](https://npmjs.com/package/react-redux)
      -  [`redux@4.0.5`](https://npmjs.com/package/redux)
      -  [`sanitize-html@2.1.2`](https://npmjs.com/package/sanitize-html)
      -  [`web-speech-cognitive-services@7.1.0`](https://npmjs.com/package/web-speech-cognitive-services)
      -  [`whatwg-fetch@3.4.1`](https://npmjs.com/package/whatwg-fetch)

### Samples

-  Fixes [#3632](https://github.com/microsoft/BotFramework-WebChat/issues/3632). Fixed typo in reaction button sample, by [@compulim](https://github.com/compulim) in PR [#3820](https://github.com/microsoft/BotFramework-WebChat/pull/3820)

