### PR TITLE
Support hosted webchat for different clouds

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -11,6 +11,10 @@
     "4": {
       "redirects": [
         [
+          "feature:hosted",
+          "hosted"
+        ],
+        [
           "feature:nextminor",
           "4.12"
         ],
@@ -344,6 +348,16 @@
         [
           "https://cdn.botframework.com/botframework-webchat/4.13.0/webchat-es5.js",
           "sha384-wwdw+KudAKGhnGV4ewfJL1KE1dqx8DgQ6TrY3z4hIHXc1GHjuI/HwoEx4p5VOGx1"
+        ]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
+    "hosted": {
+      "assets": [
+        [
+          "/botframework-webchat/webchat-es5.js",
+          "sha384-YT//LqZJgkEXrmVxm6RZJKs4dSZJQo5kEX0tE9dP1XaOaVsC7NEvwnlP2gW2KWcl"
         ]
       ],
       "private": true,


### PR DESCRIPTION
Support hosted webchat for different clouds

## Description

**Support hosted webchat for different clouds**

## Design

The service includes the latest stable version of webchat for clouds that do not have have access to the CDN. Versioning is not yet supported. 