### PR TITLE
Add typings for Adaptive Cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  `"any"` will show when there are any offscreen messages;
       -  `false` will always hide the button.
    -  Added new [`scrollToEndButtonMiddleware`](https://github.com/microsoft/BotFramework-WebChat/blob/main/packages/api/src/types/scrollToEndButtonMiddleware.ts) to customize the appearance of the scroll to end button.
--  Resolves [#3752](https://github.com/microsoft/BotFramework-WebChat/issues/3752). Added typings (`*.d.ts`) for all public interfaces, by [@compulim](https://github.com), in PR [#3931](https://github.com/microsoft/BotFramework-WebChat/pull/3931)
+-  Resolves [#3752](https://github.com/microsoft/BotFramework-WebChat/issues/3752). Added typings (`*.d.ts`) for all public interfaces, by [@compulim](https://github.com), in PR [#3931](https://github.com/microsoft/BotFramework-WebChat/pull/3931) and [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  `"any"` will show when there are any offscreen messages;
       -  `false` will always hide the button.
    -  Added new [`scrollToEndButtonMiddleware`](https://github.com/microsoft/BotFramework-WebChat/blob/main/packages/api/src/types/scrollToEndButtonMiddleware.ts) to customize the appearance of the scroll to end button.
--  Resolves [#3752](https://github.com/microsoft/BotFramework-WebChat/issues/3752). Added typings (`*.d.ts`) for all public interfaces, by [@compulim](https://github.com), in PR [#3931](https://github.com/microsoft/BotFramework-WebChat/pull/3931) and [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Resolves [#3752](https://github.com/microsoft/BotFramework-WebChat/issues/3752). Added typings (`*.d.ts`) for all public interfaces, by [@compulim](https://github.com), in PR [#3931](https://github.com/microsoft/BotFramework-WebChat/pull/3931) and [#3946](https://github.com/microsoft/BotFramework-WebChat/pull/3946)
 
 ### Fixed
 

--- a/__tests__/types/__typescript__/fail-once/invalid-type-for-use-style-options.tsx
+++ b/__tests__/types/__typescript__/fail-once/invalid-type-for-use-style-options.tsx
@@ -1,0 +1,5 @@
+import { hooks } from '../../../../packages/bundle';
+
+const [styleOptions] = hooks.useStyleOptions();
+
+styleOptions.cardEmphasisBackgroundColor = 123;

--- a/__tests__/types/__typescript__/fail-once/no-full-bundle-style-options-in-minimal-for-hooks.ts
+++ b/__tests__/types/__typescript__/fail-once/no-full-bundle-style-options-in-minimal-for-hooks.ts
@@ -1,0 +1,5 @@
+import { hooks } from '../../../../packages/bundle/lib/index-minimal';
+
+const [styleOptions] = hooks.useStyleOptions();
+
+styleOptions.cardEmphasisBackgroundColor = 'black';

--- a/__tests__/types/__typescript__/pass/use-style-options-with-full-bundle.ts
+++ b/__tests__/types/__typescript__/pass/use-style-options-with-full-bundle.ts
@@ -1,0 +1,5 @@
+import { hooks } from '../../../../packages/bundle';
+
+const [styleOptions] = hooks.useStyleOptions();
+
+styleOptions.cardEmphasisBackgroundColor = 'black';

--- a/packages/bundle/src/adaptiveCards/AdaptiveCardsStyleOptions.ts
+++ b/packages/bundle/src/adaptiveCards/AdaptiveCardsStyleOptions.ts
@@ -1,7 +1,9 @@
+/**
+ * Adaptive Cards styling
+ */
 type AdaptiveCardsStyleOptions = {
-  /**
-   * Adaptive Cards styling
-   */
+  /** Adaptive Cards: Specify the maximum schema version supported by the Adaptive Card serializer. */
+  adaptiveCardsParserMaxVersion?: string;
 
   /**
    * Adaptive Cards styling for 'emphasis' container style

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
@@ -17,6 +17,8 @@ import {
 } from 'adaptivecards';
 
 import { CardAction } from 'botframework-directlinejs';
+import AdaptiveCardsPackage from '../../types/AdaptiveCardsPackage';
+import AdaptiveCardsStyleOptions from '../AdaptiveCardsStyleOptions';
 
 export interface BotFrameworkCardAction {
   __isBotFrameworkCardAction: boolean;
@@ -54,9 +56,13 @@ function addCardAction(cardAction: CardAction, includesOAuthButtons?: boolean) {
 export default class AdaptiveCardBuilder {
   card: AdaptiveCard;
   container: Container;
-  styleOptions: any;
+  styleOptions: AdaptiveCardsStyleOptions;
 
-  constructor(adaptiveCards, styleOptions, direction = 'ltr') {
+  constructor(
+    adaptiveCards: AdaptiveCardsPackage,
+    styleOptions: AdaptiveCardsStyleOptions,
+    direction: 'ltr' | 'rtl' | 'auto' = 'ltr'
+  ) {
     this.card = new adaptiveCards.AdaptiveCard();
     this.container = new Container();
     this.container.rtl = direction === 'rtl';

--- a/packages/bundle/src/adaptiveCards/Attachment/AnimationCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/AnimationCardContent.tsx
@@ -1,5 +1,6 @@
 /* eslint react/no-array-index-key: "off" */
 
+import { DirectLineAnimationCard } from 'botframework-webchat-core';
 import { Components, hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC } from 'react';
@@ -11,7 +12,7 @@ const { useStyleSet } = hooks;
 
 type AnimationCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineAnimationCard;
   disabled?: boolean;
 };
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AudioCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/AudioCardContent.tsx
@@ -1,5 +1,6 @@
 /* eslint react/no-array-index-key: "off" */
 
+import { DirectLineAudioCard } from 'botframework-webchat-core';
 import { Components, hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC } from 'react';
@@ -11,7 +12,7 @@ const { useStyleSet } = hooks;
 
 type AudioCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineAudioCard;
   disabled?: boolean;
 };
 

--- a/packages/bundle/src/adaptiveCards/Attachment/CommonCard.js
+++ b/packages/bundle/src/adaptiveCards/Attachment/CommonCard.js
@@ -6,8 +6,9 @@ import { hooks } from 'botframework-webchat-component';
 import AdaptiveCardBuilder from './AdaptiveCardBuilder';
 import AdaptiveCardRenderer from './AdaptiveCardRenderer';
 import useAdaptiveCardsPackage from '../hooks/useAdaptiveCardsPackage';
+import useStyleOptions from '../../hooks/useStyleOptions';
 
-const { useDirection, useStyleOptions } = hooks;
+const { useDirection } = hooks;
 
 const CommonCard = ({ actionPerformedClassName, content, disabled }) => {
   const [adaptiveCardsPackage] = useAdaptiveCardsPackage();

--- a/packages/bundle/src/adaptiveCards/Attachment/HeroCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/HeroCardContent.tsx
@@ -1,3 +1,4 @@
+import { DirectLineHeroCard } from 'botframework-webchat-core';
 import { hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC, useMemo } from 'react';
@@ -5,12 +6,13 @@ import React, { FC, useMemo } from 'react';
 import AdaptiveCardBuilder from './AdaptiveCardBuilder';
 import AdaptiveCardRenderer from './AdaptiveCardRenderer';
 import useAdaptiveCardsPackage from '../hooks/useAdaptiveCardsPackage';
+import useStyleOptions from '../../hooks/useStyleOptions';
 
-const { useDirection, useStyleOptions } = hooks;
+const { useDirection } = hooks;
 
 type HeroCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineHeroCard;
   disabled?: boolean;
 };
 
@@ -18,6 +20,7 @@ const HeroCardContent: FC<HeroCardContentProps> = ({ actionPerformedClassName, c
   const [adaptiveCardsPackage] = useAdaptiveCardsPackage();
   const [styleOptions] = useStyleOptions();
   const [direction] = useDirection();
+
   const builtCard = useMemo(() => {
     const builder = new AdaptiveCardBuilder(adaptiveCardsPackage, styleOptions, direction);
 

--- a/packages/bundle/src/adaptiveCards/Attachment/OAuthCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/OAuthCardContent.tsx
@@ -1,3 +1,4 @@
+import { DirectLineOAuthCard } from 'botframework-webchat-core';
 import { hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC, useMemo } from 'react';
@@ -5,12 +6,13 @@ import React, { FC, useMemo } from 'react';
 import AdaptiveCardBuilder from './AdaptiveCardBuilder';
 import AdaptiveCardRenderer from './AdaptiveCardRenderer';
 import useAdaptiveCardsPackage from '../hooks/useAdaptiveCardsPackage';
+import useStyleOptions from '../../hooks/useStyleOptions';
 
-const { useDirection, useStyleOptions } = hooks;
+const { useDirection } = hooks;
 
 type OAuthCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineOAuthCard;
   disabled?: boolean;
 };
 

--- a/packages/bundle/src/adaptiveCards/Attachment/ReceiptCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/ReceiptCardContent.tsx
@@ -1,15 +1,16 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [0, 1, 10, 15, 25, 50, 75] }] */
 
+import { DirectLineReceiptCard } from 'botframework-webchat-core';
 import { hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC, useMemo } from 'react';
 
-import { StrictFullBundleStyleOptions } from '../../types/FullBundleStyleOptions';
 import AdaptiveCardBuilder from './AdaptiveCardBuilder';
 import AdaptiveCardRenderer from './AdaptiveCardRenderer';
 import useAdaptiveCardsPackage from '../hooks/useAdaptiveCardsPackage';
+import useStyleOptions from '../../hooks/useStyleOptions';
 
-const { useDirection, useLocalizer, useStyleOptions } = hooks;
+const { useDirection, useLocalizer } = hooks;
 
 function nullOrUndefined(obj) {
   return obj === null || typeof obj === 'undefined';
@@ -17,16 +18,14 @@ function nullOrUndefined(obj) {
 
 type ReceiptCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineReceiptCard;
   disabled?: boolean;
 };
 
 const ReceiptCardContent: FC<ReceiptCardContentProps> = ({ actionPerformedClassName, content, disabled }) => {
   const [adaptiveCardsPackage] = useAdaptiveCardsPackage();
   const [direction] = useDirection();
-
-  // TODO: Create another useStyleOptions that natively export the correct type.
-  const [styleOptions] = useStyleOptions() as [StrictFullBundleStyleOptions];
+  const [styleOptions] = useStyleOptions();
   const localize = useLocalizer();
 
   const taxText = localize('RECEIPT_CARD_TAX');

--- a/packages/bundle/src/adaptiveCards/Attachment/SignInCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/SignInCardContent.tsx
@@ -1,3 +1,4 @@
+import { DirectLineSignInCard } from 'botframework-webchat-core';
 import { hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC } from 'react';
@@ -8,7 +9,7 @@ const { useStyleSet } = hooks;
 
 type SignInCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineSignInCard;
   disabled?: boolean;
 };
 

--- a/packages/bundle/src/adaptiveCards/Attachment/ThumbnailCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/ThumbnailCardContent.tsx
@@ -1,28 +1,27 @@
 /* eslint no-magic-numbers: ["error", { "ignore": [25, 75] }] */
 
+import { DirectLineThumbnailCard } from 'botframework-webchat-core';
 import { hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC, useMemo } from 'react';
 
-import { StrictFullBundleStyleOptions } from '../../types/FullBundleStyleOptions';
 import AdaptiveCardBuilder from './AdaptiveCardBuilder';
 import AdaptiveCardRenderer from './AdaptiveCardRenderer';
 import useAdaptiveCardsPackage from '../hooks/useAdaptiveCardsPackage';
+import useStyleOptions from '../../hooks/useStyleOptions';
 
-const { useDirection, useStyleOptions } = hooks;
+const { useDirection } = hooks;
 
 type ThumbnailCardContentProps = {
   actionPerformedClassName?: string;
-  content: any;
+  content: DirectLineThumbnailCard;
   disabled?: boolean;
 };
 
 const ThumbnailCardContent: FC<ThumbnailCardContentProps> = ({ actionPerformedClassName, content, disabled }) => {
   const [adaptiveCardsPackage] = useAdaptiveCardsPackage();
   const [direction] = useDirection();
-
-  // TODO: Create another useStyleOptions that natively export the correct type.
-  const [styleOptions] = useStyleOptions() as [StrictFullBundleStyleOptions];
+  const [styleOptions] = useStyleOptions();
 
   const builtCard = useMemo(() => {
     if (content) {

--- a/packages/bundle/src/adaptiveCards/Attachment/VideoCardContent.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/VideoCardContent.tsx
@@ -1,5 +1,6 @@
 /* eslint react/no-array-index-key: "off" */
 
+import { DirectLineVideoCard } from 'botframework-webchat-core';
 import { Components, hooks } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
 import React, { FC } from 'react';
@@ -11,7 +12,7 @@ const { VideoContent } = Components;
 
 type VideoCardContentProps = {
   actionPerformedClassName?: string;
-  content: {
+  content: DirectLineVideoCard & {
     autoloop?: boolean;
     autostart?: boolean;
     image?: { url?: string };
@@ -21,7 +22,7 @@ type VideoCardContentProps = {
 };
 
 const VideoCardContent: FC<VideoCardContentProps> = ({ actionPerformedClassName, content, disabled }) => {
-  const { autoloop, autostart, image: { url: imageURL } = {}, media } = content;
+  const { autoloop, autostart, image: { url: imageURL } = { url: undefined }, media } = content;
   const [{ audioCardAttachment: audioCardAttachmentStyleSet }] = useStyleSet();
 
   return (

--- a/packages/bundle/src/adaptiveCards/defaultStyleOptions.ts
+++ b/packages/bundle/src/adaptiveCards/defaultStyleOptions.ts
@@ -1,6 +1,7 @@
 import AdaptiveCardsStyleOptions from './AdaptiveCardsStyleOptions';
 
 const ADAPTIVE_CARDS_DEFAULT_STYLE_OPTIONS: Required<AdaptiveCardsStyleOptions> = {
+  adaptiveCardsParserMaxVersion: undefined,
   cardEmphasisBackgroundColor: '#F0F0F0',
   cardPushButtonBackgroundColor: '#0063B1',
   cardPushButtonTextColor: 'White',

--- a/packages/bundle/src/adaptiveCards/hooks/internal/useAdaptiveCardsContext.ts
+++ b/packages/bundle/src/adaptiveCards/hooks/internal/useAdaptiveCardsContext.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import AdaptiveCardsContext from '../../AdaptiveCardsContext';
 
-export default function useAdaptiveCardsContext() {
+export default function useAdaptiveCardsContext(): AdaptiveCardsContext {
   const context = useContext(AdaptiveCardsContext);
 
   if (!context) {

--- a/packages/bundle/src/adaptiveCards/hooks/internal/useParseAdaptiveCardJSON.ts
+++ b/packages/bundle/src/adaptiveCards/hooks/internal/useParseAdaptiveCardJSON.ts
@@ -2,8 +2,9 @@ import { hooks } from 'botframework-webchat-component';
 import { useCallback, useMemo } from 'react';
 
 import useAdaptiveCardsPackage from '../useAdaptiveCardsPackage';
+import useStyleOptions from '../../../hooks/useStyleOptions';
 
-const { useDirection, useStyleOptions } = hooks;
+const { useDirection } = hooks;
 
 function updateRTLInline(element, rtl, adaptiveCardsPackage) {
   if (element instanceof adaptiveCardsPackage.Container) {
@@ -33,7 +34,9 @@ export default function useParseAdaptiveCardJSON() {
     const maxVersion = Version.parse(adaptiveCardsParserMaxVersion, new SerializationContext());
 
     if (maxVersion && !maxVersion.isValid) {
-      return console.warn('botframework-webchat: "adaptiveCardsParserMaxVersion" specified is not a valid version.');
+      console.warn('botframework-webchat: "adaptiveCardsParserMaxVersion" specified is not a valid version.');
+
+      return;
     }
 
     return maxVersion;

--- a/packages/bundle/src/adaptiveCards/hooks/internal/useUniqueId.ts
+++ b/packages/bundle/src/adaptiveCards/hooks/internal/useUniqueId.ts
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import random from 'math-random';
 
-export default function useUniqueId(prefix) {
+export default function useUniqueId(prefix?: string): string {
   const id = useMemo(() => random().toString(36).substr(2, 5), []);
 
   prefix = prefix ? `${prefix}--` : '';

--- a/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsHostConfig.ts
+++ b/packages/bundle/src/adaptiveCards/hooks/useAdaptiveCardsHostConfig.ts
@@ -1,10 +1,8 @@
-import { hooks } from 'botframework-webchat-component';
 import { useMemo } from 'react';
 
 import createDefaultAdaptiveCardHostConfig from '../Styles/adaptiveCardHostConfig';
 import useAdaptiveCardsContext from './internal/useAdaptiveCardsContext';
-
-const { useStyleOptions } = hooks;
+import useStyleOptions from '../../hooks/useStyleOptions';
 
 export default function useAdaptiveCardsHostConfig(): [any] {
   const { hostConfigFromProps } = useAdaptiveCardsContext();

--- a/packages/bundle/src/hooks/useStyleOptions.ts
+++ b/packages/bundle/src/hooks/useStyleOptions.ts
@@ -1,0 +1,9 @@
+import { hooks } from 'botframework-webchat-component';
+
+import { StrictFullBundleStyleOptions } from '../types/FullBundleStyleOptions';
+
+export default function useStyleOptions(): [StrictFullBundleStyleOptions] {
+  const [styleOptions] = hooks.useStyleOptions();
+
+  return [styleOptions as StrictFullBundleStyleOptions];
+}

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -27,6 +27,7 @@ import SignInCardContent from './adaptiveCards/Attachment/SignInCardContent';
 import ThumbnailCardContent from './adaptiveCards/Attachment/ThumbnailCardContent';
 import useAdaptiveCardsHostConfig from './adaptiveCards/hooks/useAdaptiveCardsHostConfig';
 import useAdaptiveCardsPackage from './adaptiveCards/hooks/useAdaptiveCardsPackage';
+import useStyleOptions from './hooks/useStyleOptions';
 import VideoCardContent from './adaptiveCards/Attachment/VideoCardContent';
 
 const renderWebChat = coreRenderWebChat.bind(null, ReactWebChat);
@@ -54,7 +55,8 @@ export const createDirectLineAppServiceExtension = (
 const patchedHooks = {
   ...hooks,
   useAdaptiveCardsHostConfig,
-  useAdaptiveCardsPackage
+  useAdaptiveCardsPackage,
+  useStyleOptions
 };
 
 const AdditionalComponents = {

--- a/packages/bundle/src/types/AdaptiveCardsPackage.ts
+++ b/packages/bundle/src/types/AdaptiveCardsPackage.ts
@@ -1,10 +1,12 @@
-class AdaptiveCard {}
+import { AdaptiveCard, HorizontalAlignment, TextSize, TextWeight, SerializationContext, Version } from 'adaptivecards';
 
 type AdaptiveCardsPackage = {
-  AdaptiveCard: AdaptiveCard;
-  HorizontalAlignment: any;
-  TextSize: any;
-  TextWeight: any;
+  AdaptiveCard: typeof AdaptiveCard;
+  HorizontalAlignment: typeof HorizontalAlignment;
+  TextSize: typeof TextSize;
+  TextWeight: typeof TextWeight;
+  SerializationContext: typeof SerializationContext;
+  Version: typeof Version;
 };
 
 export default AdaptiveCardsPackage;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,10 +4,18 @@ import clearSuggestedActions from './actions/clearSuggestedActions';
 import connect from './actions/connect';
 import createStore, { withDevTools as createStoreWithDevTools } from './createStore';
 import DirectLineActivity from './types/external/DirectLineActivity';
+import DirectLineAnimationCard from './types/external/DirectLineAnimationCard';
 import DirectLineAttachment from './types/external/DirectLineAttachment';
+import DirectLineAudioCard from './types/external/DirectLineAudioCard';
 import DirectLineCardAction from './types/external/DirectLineCardAction';
+import DirectLineHeroCard from './types/external/DirectLineHeroCard';
 import DirectLineJSBotConnection from './types/external/DirectLineJSBotConnection';
+import DirectLineOAuthCard from './types/external/DirectLineOAuthCard';
+import DirectLineReceiptCard from './types/external/DirectLineReceiptCard';
+import DirectLineSignInCard from './types/external/DirectLineSignInCard';
 import DirectLineSuggestedAction from './types/external/DirectLineSuggestedAction';
+import DirectLineThumbnailCard from './types/external/DirectLineThumbnailCard';
+import DirectLineVideoCard from './types/external/DirectLineVideoCard';
 import disconnect from './actions/disconnect';
 import dismissNotification from './actions/dismissNotification';
 import emitTypingIndicator from './actions/emitTypingIndicator';
@@ -72,9 +80,17 @@ export {
 
 export type {
   DirectLineActivity,
+  DirectLineAnimationCard,
   DirectLineAttachment,
+  DirectLineAudioCard,
   DirectLineCardAction,
+  DirectLineHeroCard,
+  DirectLineOAuthCard,
   DirectLineJSBotConnection,
+  DirectLineReceiptCard,
+  DirectLineSignInCard,
   DirectLineSuggestedAction,
+  DirectLineThumbnailCard,
+  DirectLineVideoCard,
   OneOrMany
 };

--- a/packages/core/src/types/external/DirectLineActivity.ts
+++ b/packages/core/src/types/external/DirectLineActivity.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineActivity = any;
 

--- a/packages/core/src/types/external/DirectLineAnimationCard.ts
+++ b/packages/core/src/types/external/DirectLineAnimationCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineAnimationCard = any;
 

--- a/packages/core/src/types/external/DirectLineAnimationCard.ts
+++ b/packages/core/src/types/external/DirectLineAnimationCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineAnimationCard = any;
+
+export default DirectLineAnimationCard;

--- a/packages/core/src/types/external/DirectLineAttachment.ts
+++ b/packages/core/src/types/external/DirectLineAttachment.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineAttachment = any;
 

--- a/packages/core/src/types/external/DirectLineAudioCard.ts
+++ b/packages/core/src/types/external/DirectLineAudioCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineAudioCard = any;
 

--- a/packages/core/src/types/external/DirectLineAudioCard.ts
+++ b/packages/core/src/types/external/DirectLineAudioCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineAudioCard = any;
+
+export default DirectLineAudioCard;

--- a/packages/core/src/types/external/DirectLineCardAction.ts
+++ b/packages/core/src/types/external/DirectLineCardAction.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineCardAction = any;
 

--- a/packages/core/src/types/external/DirectLineHeroCard.ts
+++ b/packages/core/src/types/external/DirectLineHeroCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineHeroCard = any;
+
+export default DirectLineHeroCard;

--- a/packages/core/src/types/external/DirectLineHeroCard.ts
+++ b/packages/core/src/types/external/DirectLineHeroCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineHeroCard = any;
 

--- a/packages/core/src/types/external/DirectLineJSBotConnection.ts
+++ b/packages/core/src/types/external/DirectLineJSBotConnection.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineJSBotConnection = any;
 

--- a/packages/core/src/types/external/DirectLineOAuthCard.ts
+++ b/packages/core/src/types/external/DirectLineOAuthCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineOAuthCard = any;
 

--- a/packages/core/src/types/external/DirectLineOAuthCard.ts
+++ b/packages/core/src/types/external/DirectLineOAuthCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineOAuthCard = any;
+
+export default DirectLineOAuthCard;

--- a/packages/core/src/types/external/DirectLineReceiptCard.ts
+++ b/packages/core/src/types/external/DirectLineReceiptCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineReceiptCard = any;
 

--- a/packages/core/src/types/external/DirectLineReceiptCard.ts
+++ b/packages/core/src/types/external/DirectLineReceiptCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineReceiptCard = any;
+
+export default DirectLineReceiptCard;

--- a/packages/core/src/types/external/DirectLineSignInCard.ts
+++ b/packages/core/src/types/external/DirectLineSignInCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineSignInCard = any;
 

--- a/packages/core/src/types/external/DirectLineSignInCard.ts
+++ b/packages/core/src/types/external/DirectLineSignInCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineSignInCard = any;
+
+export default DirectLineSignInCard;

--- a/packages/core/src/types/external/DirectLineSuggestedAction.ts
+++ b/packages/core/src/types/external/DirectLineSuggestedAction.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineSuggestedAction = any;
 

--- a/packages/core/src/types/external/DirectLineThumbnailCard.ts
+++ b/packages/core/src/types/external/DirectLineThumbnailCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineThumbnailCard = any;
 

--- a/packages/core/src/types/external/DirectLineThumbnailCard.ts
+++ b/packages/core/src/types/external/DirectLineThumbnailCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineThumbnailCard = any;
+
+export default DirectLineThumbnailCard;

--- a/packages/core/src/types/external/DirectLineVideoCard.ts
+++ b/packages/core/src/types/external/DirectLineVideoCard.ts
@@ -1,4 +1,4 @@
-// TODO: [P1] We should fully type it out.
+// TODO: [P1] #3953 We should fully type it out.
 
 type DirectLineVideoCard = any;
 

--- a/packages/core/src/types/external/DirectLineVideoCard.ts
+++ b/packages/core/src/types/external/DirectLineVideoCard.ts
@@ -1,0 +1,5 @@
+// TODO: [P1] We should fully type it out.
+
+type DirectLineVideoCard = any;
+
+export default DirectLineVideoCard;


### PR DESCRIPTION
## Changelog Entry

### Added

-  Resolves [#3752](https://github.com/microsoft/BotFramework-WebChat/issues/3752). Added typings (`*.d.ts`) for all public interfaces, by [@compulim](https://github.com), in PR [#3931](https://github.com/microsoft/BotFramework-WebChat/pull/3931) and [#3946](https://github.com/microsoft/BotFramework-WebChat/pull/3946)

## Description

Add typings for Adaptive Cards style options.

This will catch missing style options, such as `adaptiveCardsParserMaxVersion`.

## Design

Expose another version of `useStyleOptions` when using full bundle.

## Specific Changes

- Adds and use a full bundle version of `useStyleOptions`
- Adds (generic) types for Direct Line rich cards

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
