### PR TITLE
Disable SRI for webchat.js hosted with DirectLine (vs CDN)

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -356,8 +356,7 @@
     "hosted": {
       "assets": [
         [
-          "/botframework-webchat/webchat-es5.js",
-          "sha384-YT//LqZJgkEXrmVxm6RZJKs4dSZJQo5kEX0tE9dP1XaOaVsC7NEvwnlP2gW2KWcl"
+          "/botframework-webchat/webchat-es5.js"          
         ]
       ],
       "private": true,


### PR DESCRIPTION
Disable SRI for webchat.js hosted with DirectLine (vs CDN)

## Description

Disable SRI for webchat.js hosted with DirectLine (vs **CDN)**. The hosted webchat gets signed differently during the service builds. 
