### PR TITLE
Fix typing for `usePerformCardAction` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#3969](https://github.com/microsoft/BotFramework-WebChat/pull/3969)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ### Changed
 
 -  Resolves [#4017](https://github.com/microsoft/BotFramework-WebChat/issues/4017). In samples, moved [`react-scripts`](https://npmjs.com/package/react-scripts`) to `devDependencies`, in PR [#4023](https://github.com/microsoft/BotFramework-WebChat/pull/4023)

--- a/packages/api/src/hooks/middleware/createDefaultCardActionMiddleware.ts
+++ b/packages/api/src/hooks/middleware/createDefaultCardActionMiddleware.ts
@@ -6,11 +6,13 @@ export default function createDefaultCardActionMiddleware(): CardActionMiddlewar
   return ({ dispatch }) => next => (...args) => {
     const [
       {
-        cardAction: { displayText, text, type, value }
+        cardAction,
+        cardAction: { value }
       }
     ] = args;
 
-    switch (type) {
+    // We cannot use destructured "type" here because TypeScript don't recognize "messageBack" is "MessageBackCardAction".
+    switch (cardAction.type) {
       case 'imBack':
         if (typeof value === 'string') {
           // TODO: [P4] Instead of calling dispatch, we should move to dispatchers instead for completeness
@@ -22,7 +24,7 @@ export default function createDefaultCardActionMiddleware(): CardActionMiddlewar
         break;
 
       case 'messageBack':
-        dispatch(sendMessageBack(value, text, displayText));
+        dispatch(sendMessageBack(value, cardAction.text, cardAction.displayText));
 
         break;
 

--- a/packages/api/src/hooks/usePerformCardAction.ts
+++ b/packages/api/src/hooks/usePerformCardAction.ts
@@ -1,6 +1,7 @@
-import { PerformCardAction } from '../types/CardActionMiddleware';
+import { DirectLineCardAction } from 'botframework-webchat-core';
+
 import useWebChatAPIContext from './internal/useWebChatAPIContext';
 
-export default function usePerformCardAction(): PerformCardAction {
+export default function usePerformCardAction(): (cardAction: DirectLineCardAction) => void {
   return useWebChatAPIContext().onCardAction;
 }

--- a/packages/api/src/types/CardActionMiddleware.ts
+++ b/packages/api/src/types/CardActionMiddleware.ts
@@ -1,20 +1,20 @@
 import { DirectLineCardAction } from 'botframework-webchat-core';
 
-import FunctionMiddleware, { CallFunction } from './FunctionMiddleware';
+import FunctionMiddleware from './FunctionMiddleware';
 
-type PerformCardActionParameter = {
-  cardAction?: DirectLineCardAction;
-  displayText?: string;
-  getSignInUrl?: () => string;
-  target?: any;
-  text?: string;
-  type?: string;
-  value?: any;
-};
+type PerformCardAction = (cardAction: DirectLineCardAction) => void;
 
-type PerformCardAction = CallFunction<[PerformCardActionParameter], void>;
-
-type CardActionMiddleware = FunctionMiddleware<[{ dispatch: (action: any) => void }], [PerformCardActionParameter], {}>;
+type CardActionMiddleware = FunctionMiddleware<
+  [{ dispatch: (action: any) => void }],
+  [
+    {
+      cardAction: DirectLineCardAction;
+      getSignInUrl?: () => string;
+      target: any;
+    }
+  ],
+  {}
+>;
 
 export default CardActionMiddleware;
 

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardBuilder.ts
@@ -16,16 +16,16 @@ import {
   TextWeight
 } from 'adaptivecards';
 
-import { CardAction } from 'botframework-directlinejs';
+import { DirectLineCardAction } from 'botframework-webchat-core';
 import AdaptiveCardsPackage from '../../types/AdaptiveCardsPackage';
 import AdaptiveCardsStyleOptions from '../AdaptiveCardsStyleOptions';
 
 export interface BotFrameworkCardAction {
-  __isBotFrameworkCardAction: boolean;
-  cardAction: CardAction;
+  __isBotFrameworkCardAction: true;
+  cardAction: DirectLineCardAction;
 }
 
-function addCardAction(cardAction: CardAction, includesOAuthButtons?: boolean) {
+function addCardAction(cardAction: DirectLineCardAction, includesOAuthButtons?: boolean) {
   const { type } = cardAction;
   let action;
 
@@ -42,11 +42,11 @@ function addCardAction(cardAction: CardAction, includesOAuthButtons?: boolean) {
       cardAction
     };
 
-    action.title = cardAction.title;
+    action.title = (cardAction as { title: string }).title;
   } else {
     action = new OpenUrlAction();
 
-    action.title = cardAction.title;
+    action.title = (cardAction as { title: string }).title;
     action.url = cardAction.type === 'call' ? `tel:${cardAction.value}` : cardAction.value;
   }
 
@@ -71,7 +71,7 @@ export default class AdaptiveCardBuilder {
     this.card.addItem(this.container);
   }
 
-  addColumnSet(sizes: number[], container: Container = this.container, selectAction?: CardAction) {
+  addColumnSet(sizes: number[], container: Container = this.container, selectAction?: DirectLineCardAction) {
     const columnSet = new ColumnSet();
 
     columnSet.selectAction = selectAction && addCardAction(selectAction);
@@ -107,7 +107,7 @@ export default class AdaptiveCardBuilder {
     }
   }
 
-  addButtons(cardActions: CardAction[], includesOAuthButtons?: boolean) {
+  addButtons(cardActions: DirectLineCardAction[], includesOAuthButtons?: boolean) {
     cardActions &&
       cardActions.forEach(cardAction => {
         this.card.addAction(addCardAction(cardAction, includesOAuthButtons));
@@ -131,7 +131,7 @@ export default class AdaptiveCardBuilder {
     this.addButtons(content.buttons);
   }
 
-  addImage(url: string, container?: Container, selectAction?: CardAction, altText?: string) {
+  addImage(url: string, container?: Container, selectAction?: DirectLineCardAction, altText?: string) {
     container = container || this.container;
 
     const image = new Image();
@@ -146,7 +146,7 @@ export default class AdaptiveCardBuilder {
 }
 
 export interface ICommonContent {
-  buttons?: CardAction[];
+  buttons?: DirectLineCardAction[];
   subtitle?: string;
   text?: string;
   title?: string;

--- a/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.tsx
+++ b/packages/bundle/src/adaptiveCards/Attachment/AdaptiveCardRenderer.tsx
@@ -494,7 +494,7 @@ const AdaptiveCardRenderer: VFC<AdaptiveCardRendererProps> = ({
           value
         });
       } else if (actionTypeName === 'Action.Submit') {
-        const { data } = (action as SubmitAction) as {
+        const { data } = action as SubmitAction as {
           data: string | BotFrameworkCardAction;
         };
 

--- a/packages/component/src/SendBox/SuggestedActions.tsx
+++ b/packages/component/src/SendBox/SuggestedActions.tsx
@@ -209,7 +209,7 @@ SuggestedActionStackedContainer.propTypes = {
 
 type SuggestedActionsProps = {
   className?: string;
-  suggestedActions?: DirectLineCardAction;
+  suggestedActions?: DirectLineCardAction[];
 };
 
 const SuggestedActions: FC<SuggestedActionsProps> = ({ className, suggestedActions = [] }) => {
@@ -227,24 +227,36 @@ const SuggestedActions: FC<SuggestedActionsProps> = ({ className, suggestedActio
       : localize('SUGGESTED_ACTIONS_ALT_NO_CONTENT')
   );
 
-  const children = suggestedActions.map(({ displayText, image, imageAltText, text, title, type, value }, index) => (
-    <SuggestedAction
-      buttonText={suggestedActionText({ displayText, title, type, value })}
-      className="webchat__suggested-actions__button"
-      displayText={displayText}
-      image={image}
-      imageAlt={imageAltText}
-      key={index}
-      text={text}
-      textClassName={
-        suggestedActionLayout === 'stacked' && suggestedActionsStackedLayoutButtonTextWrap
-          ? 'webchat__suggested-actions__button-text-stacked-text-wrap'
-          : 'webchat__suggested-actions__button-text'
-      }
-      type={type}
-      value={value}
-    />
-  ));
+  const children = suggestedActions.map((cardAction, index) => {
+    const { displayText, image, imageAltText, text, title, type, value } = cardAction as {
+      displayText?: string;
+      image?: string;
+      imageAltText?: string;
+      text?: string;
+      title?: string;
+      type: string;
+      value?: { [key: string]: any } | string;
+    };
+
+    return (
+      <SuggestedAction
+        buttonText={suggestedActionText({ displayText, title, type, value })}
+        className="webchat__suggested-actions__button"
+        displayText={displayText}
+        image={image}
+        imageAlt={imageAltText}
+        key={index}
+        text={text}
+        textClassName={
+          suggestedActionLayout === 'stacked' && suggestedActionsStackedLayoutButtonTextWrap
+            ? 'webchat__suggested-actions__button-text-stacked-text-wrap'
+            : 'webchat__suggested-actions__button-text'
+        }
+        type={type}
+        value={value}
+      />
+    );
+  });
 
   if (suggestedActionLayout === 'flow') {
     return (
@@ -273,6 +285,10 @@ SuggestedActions.defaultProps = {
 
 SuggestedActions.propTypes = {
   className: PropTypes.string,
+
+  // TypeScript class is not mappable to PropTypes.func
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   suggestedActions: PropTypes.arrayOf(
     PropTypes.shape({
       displayText: PropTypes.string,

--- a/packages/core/src/types/external/DirectLineActivity.ts
+++ b/packages/core/src/types/external/DirectLineActivity.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineActivity = any;
 
 export default DirectLineActivity;

--- a/packages/core/src/types/external/DirectLineAnimationCard.ts
+++ b/packages/core/src/types/external/DirectLineAnimationCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineAnimationCard = any;
 
 export default DirectLineAnimationCard;

--- a/packages/core/src/types/external/DirectLineAttachment.ts
+++ b/packages/core/src/types/external/DirectLineAttachment.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineAttachment = any;
 
 export default DirectLineAttachment;

--- a/packages/core/src/types/external/DirectLineAudioCard.ts
+++ b/packages/core/src/types/external/DirectLineAudioCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineAudioCard = any;
 
 export default DirectLineAudioCard;

--- a/packages/core/src/types/external/DirectLineCardAction.ts
+++ b/packages/core/src/types/external/DirectLineCardAction.ts
@@ -1,5 +1,128 @@
-// TODO: [P1] #3953 We should fully type it out.
+type CardActionWithImageAndTitle =
+  | { image: string }
+  | { title: string }
+  | {
+      image: string;
+      title: string;
+    };
 
-type DirectLineCardAction = any;
+/**
+ * A `call` action represents a telephone number that may be called.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#call
+ */
+type CallCardAction = CardActionWithImageAndTitle & {
+  type: 'call';
+  value: string;
+};
+
+/**
+ * A `downloadFile` action represents a hyperlink to be downloaded.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#download-file-actions
+ */
+type DownloadFileCardAction = CardActionWithImageAndTitle & {
+  type: 'downloadFile';
+  value: string;
+};
+
+/**
+ * An `imBack` action represents a text response that is added to the chat feed.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#im-back
+ */
+type IMBackCardAction = CardActionWithImageAndTitle & {
+  type: 'imBack';
+  value: string;
+};
+
+/**
+ * A `messageBack` action represents a text response to be sent via the chat system.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#message-back
+ */
+type MessageBackCardAction = CardActionWithImageAndTitle & {
+  displayText?: string;
+  text?: string;
+  type: 'messageBack';
+  value?: { [key: string]: any };
+};
+
+/**
+ * An `openUrl` action represents a hyperlink to be handled by the client.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#open-url-actions
+ */
+type OpenURLCardAction = CardActionWithImageAndTitle & {
+  type: 'openUrl';
+  value: string;
+};
+
+/**
+ * A `playAudio` action represents audio media that may be played.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#play-audio
+ */
+type PlayAudioCardAction = CardActionWithImageAndTitle & {
+  type: 'playAudio';
+  value: string;
+};
+
+/**
+ * A `playVideo` action represents video media that may be played.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#play-video
+ */
+type PlayVideoCardAction = CardActionWithImageAndTitle & {
+  type: 'playVideo';
+  value: string;
+};
+
+/**
+ * A `postBack` action represents a text response that is not added to the chat feed.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#post-back
+ */
+type PostBackCardAction = CardActionWithImageAndTitle & {
+  type: 'postBack';
+  value: any; // For legacy reason, postBack support any.
+};
+
+/**
+ * A `showImage` action represents an image that may be displayed.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#show-image-file-actions
+ */
+type ShowImageCardAction = CardActionWithImageAndTitle & {
+  type: 'showImage';
+  value: string;
+};
+
+/**
+ * A `signin` action represents a hyperlink to be handled by the client's signin system.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#signin
+ */
+type SignInCardAction = CardActionWithImageAndTitle & {
+  type: 'signin';
+  value: string;
+};
+
+/**
+ * A card action represents a clickable or interactive button for use within cards or as suggested actions. They are used to solicit input from users. Despite their name, card actions are not limited to use solely on cards.
+ *
+ * https://github.com/Microsoft/botframework-sdk/blob/main/specs/botframework-activity/botframework-activity.md#card-action
+ */
+type DirectLineCardAction =
+  | CallCardAction
+  | DownloadFileCardAction
+  | IMBackCardAction
+  | MessageBackCardAction
+  | OpenURLCardAction
+  | PlayAudioCardAction
+  | PlayVideoCardAction
+  | PostBackCardAction
+  | ShowImageCardAction
+  | SignInCardAction;
 
 export default DirectLineCardAction;

--- a/packages/core/src/types/external/DirectLineHeroCard.ts
+++ b/packages/core/src/types/external/DirectLineHeroCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineHeroCard = any;
 
 export default DirectLineHeroCard;

--- a/packages/core/src/types/external/DirectLineJSBotConnection.ts
+++ b/packages/core/src/types/external/DirectLineJSBotConnection.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineJSBotConnection = any;
 
 export default DirectLineJSBotConnection;

--- a/packages/core/src/types/external/DirectLineOAuthCard.ts
+++ b/packages/core/src/types/external/DirectLineOAuthCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineOAuthCard = any;
 
 export default DirectLineOAuthCard;

--- a/packages/core/src/types/external/DirectLineReceiptCard.ts
+++ b/packages/core/src/types/external/DirectLineReceiptCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineReceiptCard = any;
 
 export default DirectLineReceiptCard;

--- a/packages/core/src/types/external/DirectLineSignInCard.ts
+++ b/packages/core/src/types/external/DirectLineSignInCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineSignInCard = any;
 
 export default DirectLineSignInCard;

--- a/packages/core/src/types/external/DirectLineSuggestedAction.ts
+++ b/packages/core/src/types/external/DirectLineSuggestedAction.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineSuggestedAction = any;
 
 export default DirectLineSuggestedAction;

--- a/packages/core/src/types/external/DirectLineThumbnailCard.ts
+++ b/packages/core/src/types/external/DirectLineThumbnailCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineThumbnailCard = any;
 
 export default DirectLineThumbnailCard;

--- a/packages/core/src/types/external/DirectLineVideoCard.ts
+++ b/packages/core/src/types/external/DirectLineVideoCard.ts
@@ -1,5 +1,6 @@
 // TODO: [P1] #3953 We should fully type it out.
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DirectLineVideoCard = any;
 
 export default DirectLineVideoCard;


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #3968

## Changelog Entry

### Fixes

-  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#3969](https://github.com/microsoft/BotFramework-WebChat/pull/3969)

## Description

The typing for `usePerformCardAction` is wrong.

We didn't catch this because we didn't not have any TypeScript code that use this hook yet. The one we have is JavaScript-in-TS, which do not type check the `usePerformCardAction` hook.

## Design

## Specific Changes

- Fix the typing of `usePerformCardAction`
- Fully type out `DirectLineCardAction.ts`
- Convert the React component in `AdaptiveCardRenderer.tsx` to TypeScript (type out the props, so `tapAction` is of type `DirectLineCardAction`)

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
