### PR TITLE
Skip custom MicrophoneAudioConfig for unsupported hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3947](https://github.com/microsoft/BotFramework-WebChat/issues/3947). Adaptive Cards: all action sets (which has `role="menubar"`) must have at least 1 or more `role="menuitem"`, by [@compulim](https://github.com/compulim), in PR [#3950](https://github.com/microsoft/BotFramework-WebChat/pull/3950)
 -  Fixes [#3823](https://github.com/microsoft/BotFramework-WebChat/issues/3823) and [#3899](https://github.com/microsoft/BotFramework-WebChat/issues/3899). Fix speech recognition and synthesis on Safari, by [@compulim](https://github.com/compulim), in PR [#3974](https://github.com/microsoft/BotFramework-WebChat/pull/3974)
 -  Fixes [#3977](https://github.com/microsoft/BotFramework-WebChat/issues/3977). Fix bundle not work in Internet Explorer 11 due to `p-defer`, by [@compulim](https://github.com/compulim), in PR [#3978](https://github.com/microsoft/BotFramework-WebChat/pull/3978)
+-  Fixes [#3979](https://github.com/microsoft/BotFramework-WebChat/issues/3979). Fix Direct Line Speech in environments without Web Audio support, by [@compulim](https://github.com/compulim), in PR [#3980](https://github.com/microsoft/BotFramework-WebChat/pull/3980)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#3947](https://github.com/microsoft/BotFramework-WebChat/issues/3947). Adaptive Cards: all action sets (which has `role="menubar"`) must have at least 1 or more `role="menuitem"`, by [@compulim](https://github.com/compulim), in PR [#3950](https://github.com/microsoft/BotFramework-WebChat/pull/3950)
 -  Fixes [#3823](https://github.com/microsoft/BotFramework-WebChat/issues/3823) and [#3899](https://github.com/microsoft/BotFramework-WebChat/issues/3899). Fix speech recognition and synthesis on Safari, by [@compulim](https://github.com/compulim), in PR [#3974](https://github.com/microsoft/BotFramework-WebChat/pull/3974)
 -  Fixes [#3977](https://github.com/microsoft/BotFramework-WebChat/issues/3977). Fix bundle not work in Internet Explorer 11 due to `p-defer`, by [@compulim](https://github.com/compulim), in PR [#3978](https://github.com/microsoft/BotFramework-WebChat/pull/3978)
--  Fixes [#3979](https://github.com/microsoft/BotFramework-WebChat/issues/3979). Fix Direct Line Speech in environments without Web Audio support, by [@compulim](https://github.com/compulim), in PR [#3980](https://github.com/microsoft/BotFramework-WebChat/pull/3980)
+-  Fixes [#3979](https://github.com/microsoft/BotFramework-WebChat/issues/3979). Fix Direct Line Speech should work in environments without microphone access, by [@compulim](https://github.com/compulim), in PR [#3980](https://github.com/microsoft/BotFramework-WebChat/pull/3980)
 
 ### Changed
 

--- a/packages/bundle/src/createDirectLineSpeechAdapters.ts
+++ b/packages/bundle/src/createDirectLineSpeechAdapters.ts
@@ -54,10 +54,10 @@ export default function createDirectLineSpeechAdapters({
         'botframework-webchat: "audioConfig" and "audioContext" cannot be set at the same time; ignoring "audioContext" for speech recognition.'
       );
   } else if (!window.navigator.mediaDevices) {
-    // If the browser does not support Direct Line Speech, we will continue to create Direct Line Speech adapter without custom "audioConfig" and "audioContext".
-    // In Direct Line Speech, it will disable speech functionality, only leaving text chat available via the protocol.
+    // If the browser does not support or allow microphone access, we will continue to create Direct Line Speech adapter without custom "audioConfig" and "audioContext".
+    // In Direct Line Speech SDK, it will disable speech functionality, only leaving text chat available via the protocol.
     console.warn(
-      'botframework-webchat: Your browser does not support Web Audio or the page is not loaded via HTTPS or localhost. Speech is disabled for Direct Line Speech. However, you may pass a custom "audioConfig" to enable speech in this environment.'
+      'botframework-webchat: Your browser does not support or allow microphone access or the page is not loaded via HTTPS or localhost. Speech is disabled for Direct Line Speech. However, you may pass a custom "audioConfig" to enable speech in this environment.'
     );
   } else {
     ({ audioConfig, audioContext } = createMicrophoneAudioConfigAndAudioContext({

--- a/packages/bundle/src/createDirectLineSpeechAdapters.ts
+++ b/packages/bundle/src/createDirectLineSpeechAdapters.ts
@@ -53,6 +53,12 @@ export default function createDirectLineSpeechAdapters({
       console.warn(
         'botframework-webchat: "audioConfig" and "audioContext" cannot be set at the same time; ignoring "audioContext" for speech recognition.'
       );
+  } else if (!window.navigator.mediaDevices) {
+    // If the browser does not support Direct Line Speech, we will continue to create Direct Line Speech adapter without custom "audioConfig" and "audioContext".
+    // In Direct Line Speech, it will disable speech functionality, only leaving text chat available via the protocol.
+    console.warn(
+      'botframework-webchat: Your browser does not support Web Audio or the page is not loaded via HTTPS or localhost. Speech is disabled for Direct Line Speech. However, you may pass a custom "audioConfig" to enable speech in this environment.'
+    );
   } else {
     ({ audioConfig, audioContext } = createMicrophoneAudioConfigAndAudioContext({
       audioContext,


### PR DESCRIPTION
> Fixes #3979.

## Changelog Entry

### Fixed

-  Fixes [#3979](https://github.com/microsoft/BotFramework-WebChat/issues/3979). Fix Direct Line Speech should work in environments without microphone access, by [@compulim](https://github.com/compulim), in PR [#3980](https://github.com/microsoft/BotFramework-WebChat/pull/3980)

## Description

In IE11, WebView, or insecure environment, `window.navigator.mediaDevices` and `window.navigator.getUserMedia` are unavailable because lack of microphone access.

In our recent PR #3974, we modified DLSpeech initialization code in a way that it requires both `mediaDevices` and `getUserMedia`. In the old days, there is no such requirement.

This PR is to remove that requirement, to enable DLSpeech in environment without microphone access.

## Design

- Modify `packages/bundle/src/createDirectLineSpeechAdapters.ts` to give out warnings, instead of creating custom audio input source, which would result in exceptions

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] Browser and platform compatibilities reviewed
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
