### PR TITLE
Bump to 4.14.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.14.1] - 2021-09-07
+
 ### Fixed
 
 -  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#3969](https://github.com/microsoft/BotFramework-WebChat/pull/3969)

--- a/__tests__/inputHint.consecutive.js
+++ b/__tests__/inputHint.consecutive.js
@@ -54,54 +54,69 @@ describe('input hint from consecutive messages', () => {
   test('should turn on microphone for accepting then accepting', async () => {
     await sendInputHintCommand('accepting', 'accepting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
   });
 
   test('should turn on microphone for accepting then expecting', async () => {
     await sendInputHintCommand('accepting', 'expecting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
   });
 
   test('should turn on microphone for accepting then ignoring', async () => {
     await sendInputHintCommand('accepting', 'ignoring');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
   });
 
   test('should turn on microphone for expecting then accepting', async () => {
     await sendInputHintCommand('expecting', 'accepting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
   });
 
   test('should turn on microphone for expecting then expecting', async () => {
     await sendInputHintCommand('expecting', 'expecting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
   });
 
   test('should turn on microphone for expecting then ignoring', async () => {
     await sendInputHintCommand('expecting', 'ignoring');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
   });
 
   test('should turn on microphone for ignoring then accepting', async () => {
     await sendInputHintCommand('ignoring', 'accepting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
   });
 
   test('should turn on microphone for ignoring then expecting', async () => {
     await sendInputHintCommand('ignoring', 'expecting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
   });
 
   test('should turn on microphone for ignoring then ignoring', async () => {
     await sendInputHintCommand('ignoring', 'ignoring');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
   });
 });

--- a/__tests__/inputHint.js
+++ b/__tests__/inputHint.js
@@ -29,7 +29,10 @@ describe('input hint', () => {
       await pageObjects.startSpeechSynthesize();
       await pageObjects.endSpeechSynthesize();
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+      // After synthesis completed, we will dispatch START_DICTATE action.
+      // The action will trigger a re-render and the useEffect() will kickoff speech recognition.
+      // There could be a slight time delay between "end of synthesis" and "kickoff recognition".
+      await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
     });
 
     test('should not turn on microphone if initiated via typing', async () => {
@@ -45,7 +48,10 @@ describe('input hint', () => {
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
   });
 
@@ -67,7 +73,10 @@ describe('input hint', () => {
       await pageObjects.startSpeechSynthesize();
       await pageObjects.endSpeechSynthesize();
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
 
     test('should not turn on microphone if initiated via typing', async () => {
@@ -83,7 +92,10 @@ describe('input hint', () => {
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
   });
 
@@ -105,7 +117,10 @@ describe('input hint', () => {
       await pageObjects.startSpeechSynthesize();
       await pageObjects.endSpeechSynthesize();
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
 
     test('should turn off microphone if initiated via typing', async () => {
@@ -121,7 +136,10 @@ describe('input hint', () => {
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
   });
 
@@ -143,7 +161,10 @@ describe('input hint', () => {
       await pageObjects.startSpeechSynthesize();
       await pageObjects.endSpeechSynthesize();
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
 
     test('should not turn on microphone if initiated via typing', async () => {
@@ -159,7 +180,10 @@ describe('input hint', () => {
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+      // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+      await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+        'Waiting SpeechRecognition.start to be called'
+      );
     });
   });
 });

--- a/__tests__/speech.recognition.js
+++ b/__tests__/speech.recognition.js
@@ -221,6 +221,6 @@ describe('speech recognition', () => {
 
     await pageObjects.clickMicrophoneButton();
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toHaveProperty('lang', 'zh-HK');
+    await expect(driver.wait(speechRecognitionStartCalled(), timeouts.ui)).resolves.toHaveProperty('lang', 'zh-HK');
   });
 });

--- a/__tests__/speech.synthesis.js
+++ b/__tests__/speech.synthesis.js
@@ -66,14 +66,17 @@ describe('speech synthesis', () => {
 
     await pageObjects.sendMessageViaMicrophone('hint expecting');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
     await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
     await driver.wait(speechSynthesisUtterancePended(), timeouts.ui);
 
     await pageObjects.startSpeechSynthesize();
     await pageObjects.errorSpeechSynthesize();
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
   });
 
   test('should not synthesis if engine is explicitly configured off', async () => {
@@ -94,7 +97,10 @@ describe('speech synthesis', () => {
 
     await pageObjects.sendMessageViaMicrophone('Hello, World!');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
     await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
     expect(await pageObjects.getConsoleErrors()).toEqual([]);
@@ -109,7 +115,10 @@ describe('speech synthesis', () => {
 
     await pageObjects.sendMessageViaMicrophone('echo Hello, World!');
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeFalsy();
+    // TODO: [P3] #4046 Improves test reliability by identifying false positives and reduce wait time.
+    await expect(() => driver.wait(speechRecognitionStartCalled(), timeouts.ui)).rejects.toThrow(
+      'Waiting SpeechRecognition.start to be called'
+    );
     await driver.wait(minNumActivitiesShown(3), timeouts.directLine);
 
     await expect(pageObjects.startSpeechSynthesize()).resolves.toHaveProperty(
@@ -121,7 +130,7 @@ describe('speech synthesis', () => {
 
     await pageObjects.clickMicrophoneButton();
 
-    await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+    await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
     await driver.wait(negationOf(speechSynthesisUtterancePended()), timeouts.ui);
   });
 
@@ -144,7 +153,7 @@ describe('speech synthesis', () => {
 
       await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
 
-      await expect(speechRecognitionStartCalled().fn(driver)).resolves.toBeTruthy();
+      await driver.wait(speechRecognitionStartCalled(), timeouts.ui);
       await driver.wait(negationOf(speechSynthesisUtterancePended()), timeouts.ui);
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.14.1-0",
+  "version": "4.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.14.1-0",
+  "version": "4.14.1",
   "private": true,
   "files": [
     "lib/**/*"


### PR DESCRIPTION
(Related to #4044)

(Changelog includes everything to be released for 4.14.1)

## Changelog Entry

### Fixed

-  Fixes [#3968](https://github.com/microsoft/BotFramework-WebChat/issues/3968). Fix typing for `usePerformCardAction` hook, by [@compulim](https://github.com/compulim), in PR [#3969](https://github.com/microsoft/BotFramework-WebChat/pull/3969)

### Changed

-  Resolves [#4017](https://github.com/microsoft/BotFramework-WebChat/issues/4017). In samples, moved [`react-scripts`](https://npmjs.com/package/react-scripts`) to `devDependencies`, in PR [#4023](https://github.com/microsoft/BotFramework-WebChat/pull/4023)
-  Forked [`cldr-data`](https://npmjs.com/package/cldr-data) and [`cldr-data-downloader`](https://npmjs.com/package/cldr-data-downloader), in PR [#3998](https://github.com/microsoft/BotFramework-WebChat/pull/3998)
   -  Moved source code to under `./src` folder
   -  Moved to `fs.readFileSync()` from `require()` when reading JSON files
   -  Moved to `node:fs.mkdir()` and removed `mkdirp`
   -  Moved tests from `node:assert` to Jest
   -  Updated Unicode CLDR download folder to `/dist/` folder from project root
   -  Moved from Grunt/JSHint to [`eslint`](https://npmjs.com/package/eslint)
   -  Upgraded from CommonJS to ES Module
   -  Use [`read-pkg-up`](https://npmjs.com/package/read-pkg-up) to determines parent `package.json`
      -  In Web Chat, since we use `lerna` to run the `install` script, we need to relax how `cldr-data` read from parent `package.json`
-  Updated peer dependency of `react` to `>= 16.8.6`, in PR [#3996](https://github.com/microsoft/BotFramework-WebChat/pull/3996)
-  Bumped all dependencies to the latest versions and sample bumps, by [@compulim](https://github.com/compulim) in PR [#3996](https://github.com/microsoft/BotFramework-WebChat/pull/3996), PR [#3998](https://github.com/microsoft/BotFramework-WebChat/pull/3998), and PR [#4023](https://github.com/microsoft/BotFramework-WebChat/pull/4023)
   -  Production dependencies
      -  [`@babel/runtime@7.14.6`](https://npmjs.com/package/@babel/runtime)
      -  [`abort-controller-es5@2.0.0`](https://npmjs.com/package/abort-controller-es5)
      -  [`botframework-directlinejs@0.15.0`](https://npmjs.com/package/botframework-directlinejs)
      -  [`core-js@3.15.2`](https://npmjs.com/package/core-js)
      -  [`event-target-shim@6.0.2`](https://npmjs.com/package/event-target-shim)
      -  [`markdown-it-attrs-es5@2.0.0`](https://npmjs.com/package/markdown-it-attrs-es5)
      -  [`markdown-it@12.1.0`](https://npmjs.com/package/markdown-it)
      -  [`memoize-one@5.2.1`](https://npmjs.com/package/memoize-one)
      -  [`p-defer-es5@2.0.0`](https://npmjs.com/package/p-defer-es5)
      -  [`p-defer@4.0.0`](https://npmjs.com/package/p-defer)
      -  [`react-redux@7.2.4`](https://npmjs.com/package/react-redux)
      -  [`web-speech-cognitive-services@7.1.1`](https://npmjs.com/package/web-speech-cognitive-services)
   -  Development dependencies
      -  [`@babel/cli@7.14.5`](https://npmjs.com/package/@babel/cli)
      -  [`@babel/core@7.14.6`](https://npmjs.com/package/@babel/core)
      -  [`@babel/plugin-proposal-class-properties@7.14.5`](https://npmjs.com/package/@babel/plugin-proposal-class-properties)
      -  [`@babel/plugin-proposal-object-rest-spread@7.14.7`](https://npmjs.com/package/@babel/plugin-proposal-object-rest-spread)
      -  [`@babel/plugin-transform-runtime@7.14.5`](https://npmjs.com/package/@babel/plugin-transform-runtime)
      -  [`@babel/preset-env@7.14.7`](https://npmjs.com/package/@babel/preset-env)
      -  [`@babel/preset-react@7.14.5`](https://npmjs.com/package/@babel/preset-react)
      -  [`@babel/preset-typescript@7.14.5`](https://npmjs.com/package/@babel/preset-typescript)
      -  [`@babel/runtime@7.14.6`](https://npmjs.com/package/@babel/runtime)
      -  [`@emotion/react@11.4.0`](https://npmjs.com/package/@emotion/react)
      -  [`@fluentui/react@8.22.3`](https://npmjs.com/package/@fluentui/react)
      -  [`@types/node@16.3.1`](https://npmjs.com/package/@types/node)
      -  [`@types/react-dom@17.0.9`](https://npmjs.com/package/@types/react-dom)
      -  [`@types/react@17.0.14`](https://npmjs.com/package/@types/react)
      -  [`@typescript-eslint/eslint-plugin@4.28.3`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
      -  [`@typescript-eslint/parser@4.28.3`](https://npmjs.com/package/@typescript-eslint/parser)
      -  [`babel-jest@27.0.6`](https://npmjs.com/package/babel-jest)
      -  [`concurrently@6.2.0`](https://npmjs.com/package/concurrently)
      -  [`core-js@3.15.2`](https://npmjs.com/package/core-js)
      -  [`dotenv@10.0.0`](https://npmjs.com/package/dotenv)
      -  [`esbuild@0.12.15`](https://npmjs.com/package/esbuild)
      -  [`eslint-plugin-prettier@3.4.0`](https://npmjs.com/package/eslint-plugin-prettier)
      -  [`eslint-plugin-react@7.24.0`](https://npmjs.com/package/eslint-plugin-react)
      -  [`eslint@7.30.0`](https://npmjs.com/package/eslint)
      -  [`http-proxy-middleware@2.0.1`](https://npmjs.com/package/http-proxy-middleware)
      -  [`husky@7.0.1`](https://npmjs.com/package/husky)
      -  [`jest-environment-node@27.0.6`](https://npmjs.com/package/jest-environment-node)
      -  [`jest-image-snapshot@4.5.1`](https://npmjs.com/package/jest-image-snapshot)
      -  [`jest-junit@12.2.0`](https://npmjs.com/package/jest-junit)
      -  [`jest@27.0.6`](https://npmjs.com/package/jest)
      -  [`lint-staged@11.0.0`](https://npmjs.com/package/lint-staged)
      -  [`node-dev@7.0.0`](https://npmjs.com/package/node-dev)
      -  [`nodemon@2.0.12`](https://npmjs.com/package/nodemon)
      -  [`p-defer@4.0.0`](https://npmjs.com/package/p-defer)
      -  [`prettier@2.3.2`](https://npmjs.com/package/prettier)
      -  [`sanitize-html@2.4.0`](https://npmjs.com/package/sanitize-html)
      -  [`selenium-webdriver@4.0.0-beta.4`](https://npmjs.com/package/selenium-webdriver)
      -  [`serve@12.0.0`](https://npmjs.com/package/serve)
      -  [`strip-ansi@6.0.0`](https://npmjs.com/package/strip-ansi)
      -  [`typescript@4.3.5`](https://npmjs.com/package/typescript)
      -  [`webpack@5.45.1`](https://npmjs.com/package/webpack)
   -  Dependencies used by samples
      -  [`@azure/storage-blob@12.7.0`](https://npmjs.com/package/@azure/storage-blob)
      -  [`base64-arraybuffer@1.0.1`](https://npmjs.com/package/base64-arraybuffer)
      -  [`http-proxy-middleware@1.3.1`](https://npmjs.com/package/http-proxy-middleware)
      -  [`restify@8.5.1`](https://npmjs.com/package/restify)

## Description

Bumping to `4.14.1` and prepare for release.

## Design

Bumping dependencies for security fixes.

## Specific Changes

(Please refer to associated PRs)

<!-- -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] Browser and platform compatibilities reviewed
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
