### PR TITLE
Update sample to echo typing as message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4028](https://github.com/microsoft/BotFramework-WebChat/issues/4028). Added new keyboard focus indicator for send box buttons, by [@compulim](https://github.com/compulim), in PR [#4035](https://github.com/microsoft/BotFramework-WebChat/pull/4035)
    -  New style options are introduced: `sendBoxButtonXXXOnActive`, `sendBoxButtonXXXOnFocus`, `sendBoxButtonXXXOnHover`, `sendBoxButtonKeyboardFocusIndicatorXXX`
 
+### Samples
+
+-  Fixes [#4031](https://github.com/microsoft/BotFramework-WebChat/issues/4031). Updated [`05.custom-components/b.send-typing-indicator`](../../samples/05.custom-components/b.send-typing-indicator) to reply with `message` activity, instead of `typing` activity, in PR [#4063](https://github.com/microsoft/BotFramework-WebChat/pull/4063), by [@compulim](https://github.com/compulim)
+
 ## [4.14.1] - 2021-09-07
 
 ### Fixed

--- a/samples/05.custom-components/b.send-typing-indicator/README.md
+++ b/samples/05.custom-components/b.send-typing-indicator/README.md
@@ -1,6 +1,6 @@
 # Sample - Enable Typing Indicator
 
-This sample shows Web Chat users how to enable the typing indicator activity from the user, which on Mock Bot is displayed as an animated gif. This is a helpful feature in multi-user chats.
+This sample shows how to send `typing` activity when the user type. When the Mock Bot receive the `typing` activity, it will display a message with a timestamp.
 
 # Test out the hosted sample
 
@@ -15,7 +15,9 @@ This sample shows Web Chat users how to enable the typing indicator activity fro
 
 # Things to try out
 
--  Note that when you as the user type, there is a typing indicator gif in the transcript. This is activated by the `sendTypingIndicator`.
+> Note: when the sample start, it will send a message `echo-typing-as-message` to the Mock Bot. After the bot received this command, it will reply to all `typing` activities sent from the user.
+
+-  When you type, the bot will send a message indicate the time it received the `typing` activity
 
 # Code
 
@@ -72,7 +74,7 @@ Here is the finished `index.html`:
 
         const store = window.WebChat.createStore({}, ({ dispatch }) => next => action => {
           if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
-            dispatch({ type: 'WEB_CHAT/SEND_MESSAGE', payload: { text: 'echo-typing' } });
+            dispatch({ type: 'WEB_CHAT/SEND_MESSAGE', payload: { text: 'echo-typing-as-message' } });
           }
 
           return next(action);

--- a/samples/05.custom-components/b.send-typing-indicator/index.html
+++ b/samples/05.custom-components/b.send-typing-indicator/index.html
@@ -40,7 +40,7 @@
         // When "echo-typing" is enabled on MockBot, it will echo back all typing indicator send from the user.
         const store = window.WebChat.createStore({}, ({ dispatch }) => next => action => {
           if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
-            dispatch({ type: 'WEB_CHAT/SEND_MESSAGE', payload: { text: 'echo-typing' } });
+            dispatch({ type: 'WEB_CHAT/SEND_MESSAGE', payload: { text: 'echo-typing-as-message' } });
           }
 
           return next(action);


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4031.

## Changelog Entry

### Samples

-  Fixes [#4031](https://github.com/microsoft/BotFramework-WebChat/issues/4031). Updated [`05.custom-components/b.send-typing-indicator`](../../samples/05.custom-components/b.send-typing-indicator) to reply with `message` activity, instead of `typing` activity, in PR [#4063](https://github.com/microsoft/BotFramework-WebChat/pull/4063), by [@compulim](https://github.com/compulim)

## Description

To reduce confusion, the sample is updated to echo back `typing` activity as a message, instead of a `typing` activity.

## Design

Today, in this sample, when the end-user type, the bot will send a corresponding `typing` activity. As a result, a typing indicator GIF animation will be shown.

![image](https://user-images.githubusercontent.com/1622400/134882947-09931891-b19b-4178-b73a-a55967b20d67.png)

This behavior confuses accessibility audit team as the GIF animation is not desirable when the end-user type.

This PR will update the sample. The bot will send a message activity instead.

![image](https://user-images.githubusercontent.com/1622400/134882542-a9459fa7-6b7e-4268-b609-34db11200cb9.png)

## Specific Changes

- Updated sample `05.b` to send `echo-typing-as-message` command, instead of `echo-typing` command

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
