### PR TITLE
Remove "u" flag intentionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    -  Fixed overlapping hit zone causing clicking on bottom edge of message bubble may focus on the next activity instead
    -  Fixed typings of `useFocus` and `useLocalizer`
 -  Fixes [#3165](https://github.com/microsoft/BotFramework-WebChat/issues/3165) and [#4094](https://github.com/microsoft/BotFramework-WebChat/issues/4094). Allowlist `aria-label` for links in Markdown and skip unrecognized attributes or invalid curly brackets, by [@compulim](https://github.com/compulim), in PR [#4095](https://github.com/microsoft/BotFramework-WebChat/pull/4095)
+-  Fixes [#4190](https://github.com/microsoft/BotFramework-WebChat/issues/4190). Recent Markdown curly bracket fix should not break IE11 due to unsupported "u" flag in `RegExp`, by [@compulim](https://github.com/compulim), in PR [#4191](https://github.com/microsoft/BotFramework-WebChat/pull/4191)
 
 ### Changed
 

--- a/packages/bundle/src/renderMarkdown.ts
+++ b/packages/bundle/src/renderMarkdown.ts
@@ -59,13 +59,15 @@ const internalMarkdownIt = new MarkdownIt();
 
 const MARKDOWN_ATTRS_LEFT_DELIMITER = '⟬';
 // Make sure the delimiter is free from any RegExp characters, such as *, ?, etc.
-// eslint-disable-next-line security/detect-non-literal-regexp
-const MARKDOWN_ATTRS_LEFT_DELIMITER_PATTERN = new RegExp(MARKDOWN_ATTRS_LEFT_DELIMITER, 'gu');
+// IE11 does not support "u" flag and Babel could not remove it. We intentionally omitting the "u" flag here.
+// eslint-disable-next-line security/detect-non-literal-regexp, require-unicode-regexp
+const MARKDOWN_ATTRS_LEFT_DELIMITER_PATTERN = new RegExp(MARKDOWN_ATTRS_LEFT_DELIMITER, 'g');
 
 const MARKDOWN_ATTRS_RIGHT_DELIMITER = '⟭';
 // Make sure the delimiter is free from any RegExp characters, such as *, ?, etc.
-// eslint-disable-next-line security/detect-non-literal-regexp
-const MARKDOWN_ATTRS_RIGHT_DELIMITER_PATTERN = new RegExp(MARKDOWN_ATTRS_RIGHT_DELIMITER, 'gu');
+// IE11 does not support "u" flag and Babel could not remove it. We intentionally omitting the "u" flag here.
+// eslint-disable-next-line security/detect-non-literal-regexp, require-unicode-regexp
+const MARKDOWN_ATTRS_RIGHT_DELIMITER_PATTERN = new RegExp(MARKDOWN_ATTRS_RIGHT_DELIMITER, 'g');
 
 export default function render(
   markdown: string,


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4190.

## Changelog Entry

### Fixed

-  Fixes [#4190](https://github.com/microsoft/BotFramework-WebChat/issues/4190). Recent Markdown curly bracket fix should not break IE11 due to unsupported "u" flag in `RegExp`, by [@compulim](https://github.com/compulim), in PR [#4191](https://github.com/microsoft/BotFramework-WebChat/pull/4191)

## Description

Remove "u" flag used in `new RegExp`. We can keep "u" flag used in `/abc/` constructs as they will be removed by Babel.

## Design

"u" flag is required in this case:

```js
/^[😀]$/.test('😀'); // return false
/^[😀]$/u.test('😀'); // return true
```

## Specific Changes

- Modify `packages/bundle/renderMarkdown.html` to remove "u" flag in `new RegExp`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
