### PR TITLE
Add typing indicator to live region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,11 +111,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  [`webpack-cli@4.9.2`](https://npmjs.com/package/webpack-cli)
       -  [`webpack@5.70.0`](https://npmjs.com/package/webpack)
 
+### Added
+
+-  Resolves [#4099](https://github.com/microsoft/BotFramework-WebChat/issues/4099), added typing indicator to live region for screen reader, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ## [4.15.1] - 2022-03-04
 
 ### Fixed
 
--  Fixes [#4196](https://github.com/microsoft/BotFramework-WebChat/issues/4196). Should render/mount to a detached DOM node without errors, by [@compulim](https://github.com/compulim), in PR [#4197](https://github.com/microsoft/BotFramework-WebChat/issues/4197)
+-  Fixes [#4196](https://github.com/microsoft/BotFramework-WebChat/issues/4196). Should render/mount to a detached DOM node without errors, by [@compulim](https://github.com/compulim), in PR [#4197](https://github.com/microsoft/BotFramework-WebChat/pull/4197)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Resolves [#4099](https://github.com/microsoft/BotFramework-WebChat/issues/4099), added typing indicator to live region for screen reader, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Resolves [#4099](https://github.com/microsoft/BotFramework-WebChat/issues/4099), added typing indicator to live region for screen reader, by [@compulim](https://github.com/compulim), in PR [#4210](https://github.com/microsoft/BotFramework-WebChat/pull/4210)
 
 ## [4.15.1] - 2022-03-04
 

--- a/__tests__/hooks/useActiveTyping.js
+++ b/__tests__/hooks/useActiveTyping.js
@@ -50,7 +50,7 @@ test('getter should represent bot and user typing respectively', async () => {
     {
       at: 0,
       expireAt: 5000,
-      name: 'bot',
+      name: 'Bot',
       role: 'bot'
     }
   ]);
@@ -63,7 +63,7 @@ test('getter should represent bot and user typing respectively', async () => {
     {
       at: 0,
       expireAt: 5000,
-      name: 'bot',
+      name: 'Bot',
       role: 'bot'
     },
     {

--- a/__tests__/html/assets/accessibility.liveRegionAttachment.css
+++ b/__tests__/html/assets/accessibility.liveRegionAttachment.css
@@ -1,4 +1,4 @@
-.webchat__screen-reader-activity, .webchat__live-region-transcript__interactive_note {
+.webchat__screen-reader-activity, .webchat__live-region-transcript__interactive-note, .webchat__live-region-transcript__text-element {
   color: initial !important;
   height: initial !important;
   opacity: initial !important;

--- a/__tests__/html/typingIndicator.liveRegion.fromName.html
+++ b/__tests__/html/typingIndicator.liveRegion.fromName.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const directLine = testHelpers.createDirectLineWithTranscript();
+
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store: testHelpers.createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+
+        const liveRegionElement = pageElements.transcriptLiveRegion();
+
+        // WHEN: A typing activity is sent by a participant with a name.
+        //       Currently, Web Chat only support "bot" role for other participants.
+        directLine.activityDeferredObservable.next({
+          channelId: 'directline',
+          from: {
+            id: 'u00001',
+            name: 'John',
+            role: 'bot'
+          },
+          id: 'a00001',
+          timestamp: new Date().toISOString(),
+          type: 'typing'
+        });
+
+        // THEN: It should read "John is typing."
+        await pageConditions.became(
+          'typing indicator to appear in live region',
+          async () =>
+            [].map.call(liveRegionElement.childNodes, ({ innerText }) => innerText).join('\n') === 'John is typing.',
+          5000
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/typingIndicator.liveRegion.fromName.js
+++ b/__tests__/html/typingIndicator.liveRegion.fromName.js
@@ -1,0 +1,5 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('typing indicator in live region', () => {
+  test('should display from.name', () => runHTML('typingIndicator.liveRegion.fromName.html'));
+});

--- a/__tests__/html/typingIndicator.liveRegion.multiple.html
+++ b/__tests__/html/typingIndicator.liveRegion.multiple.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const clock = lolex.install();
+        const directLine = testHelpers.createDirectLineWithTranscript();
+
+        let nextActivityId = 1;
+        const sendTyping = who => {
+          directLine.activityDeferredObservable.next({
+            channelId: 'directline',
+            from:
+              who === 'John'
+                ? {
+                    id: 'u00001',
+                    name: 'John',
+                    role: 'bot'
+                  }
+                : {
+                    id: 'u00002',
+                    name: 'Mary',
+                    role: 'bot'
+                  },
+            id: `a${nextActivityId++}`,
+            timestamp: new Date().toISOString(),
+            type: 'typing'
+          });
+        };
+
+        const liveRegionTypingIndicatorBecame = expected =>
+          pageConditions.became(
+            'typing indicator to appear in live region',
+            () => liveRegionInnerTexts.join('\n') === expected.join('\n'),
+            2000
+          );
+
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store: testHelpers.createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.webChatRendered();
+
+        clock.tick(600);
+
+        await pageConditions.uiConnected();
+
+        const liveRegionElement = pageElements.transcriptLiveRegion();
+        const liveRegionInnerTexts = [];
+
+        const mutationObserver = new MutationObserver(records => {
+          liveRegionInnerTexts.push(
+            ...[].reduce.call(
+              records,
+              (addedInnerTexts, record) =>
+                [].reduce.call(
+                  record.addedNodes,
+                  (addedInnerTexts, { innerText }) => [...addedInnerTexts, innerText],
+                  addedInnerTexts
+                ),
+              []
+            )
+          );
+        });
+
+        mutationObserver.observe(liveRegionElement, { childList: true });
+
+        // WHEN: At t = 0, John send a typing activity, which should expires at t >= 5.
+        sendTyping('John');
+
+        // THEN: It should read "John is typing."
+        await liveRegionTypingIndicatorBecame(['John is typing.']);
+
+        // THEN: The typing indicator should be shown.
+        await pageConditions.typingIndicatorShown();
+
+        // WHEN: At t = 0.5, Mary send a typing activity, which should expires at t >= 5.5.
+        clock.tick(500);
+        sendTyping('Mary');
+
+        // THEN: It should read "John and others are typing."
+        await liveRegionTypingIndicatorBecame(['John is typing.', 'John and others are typing.']);
+
+        // WHEN: At t = 1, John send another typing activity, which should expires at t >= 6.
+        clock.tick(500);
+        sendTyping('John');
+
+        // THEN: It should not add any live region elements.
+        await liveRegionTypingIndicatorBecame(['John is typing.', 'John and others are typing.']);
+
+        // WHEN: At t = 1.5, Mary send another typing activity, which should expires at t >= 6.5.
+        clock.tick(500);
+        sendTyping('Mary');
+
+        // THEN: It should not add any live region elements.
+        await liveRegionTypingIndicatorBecame(['John is typing.', 'John and others are typing.']);
+
+        // THEN: At t = 6, it should read "Mary is typing."
+        clock.tick(4500);
+        await liveRegionTypingIndicatorBecame(['John is typing.', 'John and others are typing.', 'Mary is typing.']);
+
+        // THEN: The typing indicator should be shown, because Mary is typing.
+        await pageConditions.typingIndicatorShown();
+
+        // THEN: At t = 6.5, it should not add any live region elements.
+        clock.tick(500);
+        await liveRegionTypingIndicatorBecame(['John is typing.', 'John and others are typing.', 'Mary is typing.']);
+
+        // THEN: Tthe typing indicator should be hidden, because all typing indicators are expired.
+        await pageConditions.typingIndicatorHidden();
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/typingIndicator.liveRegion.multiple.js
+++ b/__tests__/html/typingIndicator.liveRegion.multiple.js
@@ -1,0 +1,5 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('typing indicator in live region', () => {
+  test('with multiple participants should display properly', () => runHTML('typingIndicator.liveRegion.multiple.html'));
+});

--- a/__tests__/html/typingIndicator.liveRegion.simple.html
+++ b/__tests__/html/typingIndicator.liveRegion.simple.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const clock = lolex.install();
+        const directLine = testHelpers.createDirectLineWithTranscript();
+
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store: testHelpers.createStore()
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.webChatRendered();
+
+        clock.tick(600);
+
+        await pageConditions.uiConnected();
+
+        const liveRegionElement = pageElements.transcriptLiveRegion();
+        const liveRegionInnerTexts = [];
+
+        const mutationObserver = new MutationObserver(records => {
+          liveRegionInnerTexts.push(
+            ...[].reduce.call(
+              records,
+              (addedInnerTexts, record) =>
+                [].reduce.call(
+                  record.addedNodes,
+                  (addedInnerTexts, { innerText }) => [...addedInnerTexts, innerText],
+                  addedInnerTexts
+                ),
+              []
+            )
+          );
+        });
+
+        mutationObserver.observe(liveRegionElement, { childList: true });
+
+        // WHEN: At t = 0, a typing activity is sent by the bot.
+        directLine.activityDeferredObservable.next({
+          channelId: 'directline',
+          from: {
+            id: 'bot-id',
+            name: 'bot-id',
+            role: 'bot'
+          },
+          id: 'a00001',
+          timestamp: new Date().toISOString(),
+          type: 'typing'
+        });
+
+        // THEN: It should read "Bot is typing."
+        await pageConditions.became(
+          'typing indicator to appear in live region',
+          async () => () => liveRegionInnerTexts.join('\n') === 'Bot is typing.',
+          5000
+        );
+
+        // THEN: The typing indicator should be shown.
+        await pageConditions.typingIndicatorShown();
+
+        // WHEN: At t = 1, another typing activity is sent by the bot.
+        clock.tick(1000);
+        directLine.activityDeferredObservable.next({
+          channelId: 'directline',
+          from: {
+            id: 'bot-id',
+            name: 'bot-id',
+            role: 'bot'
+          },
+          id: 'a00002',
+          timestamp: new Date().toISOString(),
+          type: 'typing'
+        });
+
+        // THEN: It should not add any live region elements.
+        await pageConditions.became(
+          'typing indicator should not add to the live region',
+          async () => () => liveRegionInnerTexts.join('\n') === 'Bot is typing.',
+          5000
+        );
+
+        // THEN: The typing indicator should be shown.
+        await pageConditions.typingIndicatorShown();
+
+        // WHEN: At t = 6.
+        clock.tick(5000);
+
+        // THEN: It should not add any live region elements.
+        await pageConditions.became(
+          'typing indicator should not add to the live region',
+          async () => () => liveRegionInnerTexts.join('\n') === 'Bot is typing.',
+          5000
+        );
+
+        // THEN: The typing indicator should be hidden.
+        await pageConditions.typingIndicatorHidden();
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/typingIndicator.liveRegion.simple.js
+++ b/__tests__/html/typingIndicator.liveRegion.simple.js
@@ -1,0 +1,5 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('typing indicator in live region', () => {
+  test('should display properly', () => runHTML('typingIndicator.liveRegion.simple.html'));
+});

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -143,7 +143,9 @@ useActiveTyping(expireAfter?: number): [{ [id: string]: Typing }]
 ```
 <!-- prettier-ignore-end -->
 
-This hook will return a list of participants who are actively typing, including the start typing time (`at`) and expiration time (`expireAt`), the name and the role of the participant.
+> On or before 4.15.1, there is [an issue](https://github.com/microsoft/BotFramework-WebChat/issues/4209) which the `at` field is not accurately reflecting the time when the participant start typing.
+
+This hook will return a list of participants who are actively typing, including the start typing time (`at`) and expiration time (`expireAt`), the name and the role of the participant. Both time values are based on local clock.
 
 If the participant sends a message after the typing activity, the participant will be explicitly removed from the list. If no messages or typing activities are received, the participant is considered inactive and not listed in the result. To keep the typing indicator active, participants should continuously send the typing activity.
 

--- a/packages/api/src/hooks/useActiveTyping.ts
+++ b/packages/api/src/hooks/useActiveTyping.ts
@@ -10,15 +10,17 @@ function useActiveTyping(expireAfter?: number): [{ [userId: string]: Typing }] {
 
   const [{ typingAnimationDuration }] = useStyleOptions();
   const forceRender = useForceRender();
-  const typing: { [userId: string]: { at: number; name: string; role: string } } = useSelector(({ typing }) => typing);
+  const typing: { [userId: string]: { at: number; last: number; name: string; role: string } } = useSelector(
+    ({ typing }) => typing
+  );
 
   if (typeof expireAfter !== 'number') {
     expireAfter = typingAnimationDuration;
   }
 
   const activeTyping: { [userId: string]: Typing } = Object.entries(typing).reduce(
-    (activeTyping, [id, { at, name, role }]) => {
-      const until = at + expireAfter;
+    (activeTyping, [id, { at, last, name, role }]) => {
+      const until = last + expireAfter;
 
       if (until > now) {
         return { ...activeTyping, [id]: { at, expireAt: until, name, role } };

--- a/packages/api/src/localization/en-US.json
+++ b/packages/api/src/localization/en-US.json
@@ -18,7 +18,7 @@
   "ACTIVITY_YOU_ATTACHED_ALT": "You attached:",
   "_ACTIVITY_YOU_ATTACHED_ALT.comment": "This is for screen reader and is narrated before each attachments sent by the user.",
   "ACTIVITY_NUM_ATTACHMENTS_ONE_ALT": "1 attachment.",
-  "_ACTIVITY_NUM_ATTACHMENTS_OONE_ALT.comment": "This is for screen reader and only narrated when the message arrive. The narration when the message arrive, could be \"Bot WC said: Hello, World! 1 attachment. Sent at 2020-01-02 12:34 PM.\". This is for plural rule of \"one\".",
+  "_ACTIVITY_NUM_ATTACHMENTS_ONE_ALT.comment": "This is for screen reader and only narrated when the message arrive. The narration when the message arrive, could be \"Bot WC said: Hello, World! 1 attachment. Sent at 2020-01-02 12:34 PM.\". This is for plural rule of \"one\".",
   "ACTIVITY_NUM_ATTACHMENTS_FEW_ALT": "$1 attachments.",
   "_ACTIVITY_NUM_ATTACHMENTS_FEW_ALT.comment": "$1 is the number of attachments. This is for plural rule of \"few\".",
   "ACTIVITY_NUM_ATTACHMENTS_MANY_ALT": "$1 attachments.",
@@ -137,5 +137,8 @@
   "TRANSCRIPT_NEW_MESSAGES": "New messages",
   "TRANSCRIPT_TERMINATOR_TEXT": "End of chat history",
   "TYPING_INDICATOR_ALT": "Showing typing indicator",
-  "_TYPING_INDICATOR_ALT.comment": "This is for screen reader for the label that will be narrated when the other party is typing a message."
+  "_TYPING_INDICATOR_SINGLE_TEXT.comment": "This shows when a single user is typing.",
+  "TYPING_INDICATOR_SINGLE_TEXT": "$1 is typing.",
+  "_TYPING_INDICATOR_MULTIPLE_TEXT.comment": "This shows when two or more users are typing simultaneously.",
+  "TYPING_INDICATOR_MULTIPLE_TEXT": "$1 and others are typing."
 }

--- a/packages/component/src/Transcript/LiveRegionTranscript.tsx
+++ b/packages/component/src/Transcript/LiveRegionTranscript.tsx
@@ -12,13 +12,15 @@ import tabbableElements from '../Utils/tabbableElements';
 import useActivityTreeWithRenderer from '../providers/ActivityTree/useActivityTreeWithRenderer';
 import useQueueStaticElement from '../providers/LiveRegionTwin/useQueueStaticElement';
 import useStyleToEmotionObject from '../hooks/internal/useStyleToEmotionObject';
+import useTypistNames from './useTypistNames';
+
 import type { ActivityElementMap } from './types';
 
 const { useGetKeyByActivity, useLocalizer, useStyleOptions } = hooks;
 
 const ROOT_STYLE = {
   '&.webchat__live-region-transcript': {
-    '& .webchat__live-region-transcript__interactive_note': {
+    '& .webchat__live-region-transcript__interactive-note, & .webchat__live-region-transcript__text-element': {
       color: 'transparent',
       height: 1,
       overflow: 'hidden',
@@ -62,12 +64,19 @@ type LiveRegionTranscriptCoreProps = {
 
 const LiveRegionTranscriptCore: FC<LiveRegionTranscriptCoreProps> = ({ activityElementMapRef }) => {
   const [flattenedActivityTree] = useActivityTreeWithRenderer({ flat: true });
+  const [typistNames] = useTypistNames();
   const getKeyByActivity = useGetKeyByActivity();
   const localize = useLocalizer();
   const queueStaticElement = useQueueStaticElement();
 
   const liveRegionInteractiveLabelAlt = localize('TRANSCRIPT_LIVE_REGION_INTERACTIVE_LABEL_ALT');
   const liveRegionInteractiveWithLinkLabelAlt = localize('TRANSCRIPT_LIVE_REGION_INTERACTIVE_WITH_LINKS_LABEL_ALT');
+  const typingIndicator =
+    !!typistNames.length &&
+    localize(
+      typistNames.length > 1 ? 'TYPING_INDICATOR_MULTIPLE_TEXT' : 'TYPING_INDICATOR_SINGLE_TEXT',
+      typistNames[0]
+    );
 
   const renderingActivities = useMemo<Readonly<RenderingActivities>>(
     () =>
@@ -110,7 +119,7 @@ const LiveRegionTranscriptCore: FC<LiveRegionTranscriptCoreProps> = ({ activityE
 
     if (hasNewLink || hasNewWidget) {
       // eslint-disable-next-line no-magic-numbers
-      const labelId = `webchat__live-region-transcript__interactive_note--${random().toString(36).substr(2, 5)}`;
+      const labelId = `webchat__live-region-transcript__interactive-note--${random().toString(36).substr(2, 5)}`;
 
       queueStaticElement(
         // Inside ARIA live region:
@@ -124,7 +133,7 @@ const LiveRegionTranscriptCore: FC<LiveRegionTranscriptCoreProps> = ({ activityE
         <div
           aria-atomic="true"
           aria-labelledby={labelId}
-          className="webchat__live-region-transcript__interactive_note"
+          className="webchat__live-region-transcript__interactive-note"
           role="note"
         >
           {/* "id" is required for "aria-activedescendant" */}
@@ -144,6 +153,10 @@ const LiveRegionTranscriptCore: FC<LiveRegionTranscriptCoreProps> = ({ activityE
     queueStaticElement,
     renderingActivities
   ]);
+
+  useEffect(() => {
+    typingIndicator && queueStaticElement(typingIndicator);
+  }, [queueStaticElement, typingIndicator]);
 
   return null;
 };
@@ -165,6 +178,7 @@ const LiveRegionTranscript: VFC<LiveRegionTranscriptProps> = ({ activityElementM
       className={classNames('webchat__live-region-transcript', rootClassName)}
       fadeAfter={internalLiveRegionFadeAfter}
       role="log"
+      textElementClassName="webchat__live-region-transcript__text-element"
     >
       <LiveRegionTranscriptCore activityElementMapRef={activityElementMapRef} />
     </LiveRegionTwinComposer>

--- a/packages/component/src/Transcript/useTypistNames.ts
+++ b/packages/component/src/Transcript/useTypistNames.ts
@@ -1,0 +1,37 @@
+import { hooks } from 'botframework-webchat-api';
+import { useEffect, useRef } from 'react';
+
+const { useActiveTyping } = hooks;
+
+function arrayEquals<T>(x: readonly T[], y: readonly T[]): boolean {
+  return x.length === y.length && x.every((value, index) => y[+index] === value);
+}
+
+/** Gets names of users who are actively typing, sorted by the time they started typing. */
+export default function useTypistNames(): readonly [readonly string[]] {
+  const [activeTyping] = useActiveTyping();
+  const prevTypistNamesStateRef = useRef<readonly [readonly string[]]>(
+    Object.freeze([Object.freeze([] as string[])]) as [readonly string[]]
+  );
+
+  const activeTypingFromOthersValues = Object.values(activeTyping).filter(({ role }) => role !== 'user');
+
+  // Sort the list by the first typist.
+  const sortedActiveTypingFromOthersValues = activeTypingFromOthersValues.sort(({ at: x }, { at: y }) => x - y);
+
+  const typistNamesState: readonly [readonly string[]] = Object.freeze([
+    Object.freeze(sortedActiveTypingFromOthersValues.map(({ name }) => name))
+  ]) as readonly [readonly string[]];
+
+  const { current: prevTypistNamesState } = prevTypistNamesStateRef;
+
+  const nextTypistNamesState = arrayEquals(typistNamesState[0], prevTypistNamesState[0])
+    ? prevTypistNamesState
+    : typistNamesState;
+
+  useEffect(() => {
+    prevTypistNamesStateRef.current = nextTypistNamesState;
+  }, [prevTypistNamesStateRef, nextTypistNamesState]);
+
+  return nextTypistNamesState;
+}

--- a/packages/component/src/providers/LiveRegionTwin/LiveRegionTwinComposer.tsx
+++ b/packages/component/src/providers/LiveRegionTwin/LiveRegionTwinComposer.tsx
@@ -36,6 +36,9 @@ type LiveRegionTwinComposerProps = PropsWithChildren<{
 
   /** Optional "role" attribute for the live region twin container. */
   role?: string;
+
+  /** Optional "className" attribute for static text element. */
+  textElementClassName?: string;
 }>;
 
 /**
@@ -56,7 +59,8 @@ const LiveRegionTwinComposer: FC<LiveRegionTwinComposerProps> = ({
   children,
   className,
   fadeAfter = DEFAULT_FADE_AFTER,
-  role
+  role,
+  textElementClassName
 }) => {
   const [staticElementEntries, setStaticElementEntries] = useState<StaticElementEntry[]>([]);
   const fadeAfterRef = useValueRef(fadeAfter);
@@ -125,6 +129,7 @@ const LiveRegionTwinComposer: FC<LiveRegionTwinComposerProps> = ({
         aria-roledescription={ariaRoleDescription}
         className={className}
         role={role}
+        textElementClassName={textElementClassName}
       />
       {children}
     </LiveRegionTwinContext.Provider>
@@ -138,7 +143,8 @@ LiveRegionTwinComposer.defaultProps = {
   children: undefined,
   className: undefined,
   fadeAfter: DEFAULT_FADE_AFTER,
-  role: undefined
+  role: undefined,
+  textElementClassName: undefined
 };
 
 LiveRegionTwinComposer.propTypes = {
@@ -148,7 +154,8 @@ LiveRegionTwinComposer.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
   fadeAfter: PropTypes.number,
-  role: PropTypes.string
+  role: PropTypes.string,
+  textElementClassName: PropTypes.string
 };
 
 export default LiveRegionTwinComposer;

--- a/packages/component/src/providers/LiveRegionTwin/private/LiveRegionTwinContainer.tsx
+++ b/packages/component/src/providers/LiveRegionTwin/private/LiveRegionTwinContainer.tsx
@@ -12,6 +12,7 @@ type LiveRegionTwinContainerProps = {
   'aria-roledescription'?: string;
   className?: string;
   role?: string;
+  textElementClassName?: string;
 };
 
 // This container is marked as private because we assume there is only one instance under the <LiveRegionTwinContext>.
@@ -20,7 +21,8 @@ const LiveRegionTwinContainer: VFC<LiveRegionTwinContainerProps> = ({
   'aria-live': ariaLive,
   'aria-roledescription': ariaRoleDescription,
   className,
-  role
+  role,
+  textElementClassName
 }) => {
   const [staticElementEntries] = useStaticElementEntries();
 
@@ -37,9 +39,21 @@ const LiveRegionTwinContainer: VFC<LiveRegionTwinContainerProps> = ({
       className={className}
       role={role}
     >
-      {staticElementEntries.map(({ element, key }) =>
-        typeof element === 'string' ? <div key={key}>{element}</div> : <Fragment key={key}>{element}</Fragment>
-      )}
+      {staticElementEntries.map(({ element, key }) => {
+        if (typeof element === 'string') {
+          const id = `webchat__live-region-twin__text-element-${key}`;
+
+          return (
+            <div aria-atomic={true} aria-labelledby={id} className={textElementClassName} key={key}>
+              {/* "aria-labelledby" requires the use of "id" attribute. */}
+              {/* eslint-disable-next-line react/forbid-dom-props */}
+              <p id={id}>{element}</p>
+            </div>
+          );
+        }
+
+        return <Fragment key={key}>{element}</Fragment>;
+      })}
     </div>
   );
 };
@@ -48,7 +62,8 @@ LiveRegionTwinContainer.defaultProps = {
   'aria-label': undefined,
   'aria-roledescription': undefined,
   className: undefined,
-  role: undefined
+  role: undefined,
+  textElementClassName: undefined
 };
 
 LiveRegionTwinContainer.propTypes = {
@@ -58,7 +73,8 @@ LiveRegionTwinContainer.propTypes = {
   'aria-live': PropTypes.oneOf(['assertive', 'polite']).isRequired,
   'aria-roledescription': PropTypes.string,
   className: PropTypes.string,
-  role: PropTypes.string
+  role: PropTypes.string,
+  textElementClassName: PropTypes.string
 };
 
 export default LiveRegionTwinContainer;

--- a/packages/core/src/reducers/typing.js
+++ b/packages/core/src/reducers/typing.js
@@ -18,11 +18,12 @@ export default function lastTyping(state = DEFAULT_STATE, { payload, type }) {
     } = payload;
 
     if (activityType === 'typing') {
-      state = updateIn(state, [id], () => ({
-        at: Date.now(),
-        name,
-        role
-      }));
+      const now = Date.now();
+
+      state = updateIn(state, [id, 'at'], at => at || now);
+      state = updateIn(state, [id, 'last'], () => now);
+      state = updateIn(state, [id, 'name'], () => name);
+      state = updateIn(state, [id, 'role'], () => role);
     } else if (activityType === 'message') {
       state = updateIn(state, [id]);
     }

--- a/packages/test/page-object/src/globals/pageConditions/index.js
+++ b/packages/test/page-object/src/globals/pageConditions/index.js
@@ -15,6 +15,7 @@ import scrollToEndButtonShown from './scrollToEndButtonShown';
 import stabilized from './stabilized';
 import suggestedActionsShown from './suggestedActionsShown';
 import toastShown from './toastShown';
+import typingIndicatorHidden from './typingIndicatorHidden';
 import typingIndicatorShown from './typingIndicatorShown';
 import uiConnected from './uiConnected';
 import webChatRendered from './webChatRendered';
@@ -37,6 +38,7 @@ export {
   stabilized,
   suggestedActionsShown,
   toastShown,
+  typingIndicatorHidden,
   typingIndicatorShown,
   uiConnected,
   webChatRendered

--- a/packages/test/page-object/src/globals/pageConditions/typingIndicatorHidden.js
+++ b/packages/test/page-object/src/globals/pageConditions/typingIndicatorHidden.js
@@ -1,0 +1,6 @@
+import became from './became';
+import typingIndicator from '../pageElements/typingIndicator';
+
+export default function typingIndicatorHidden() {
+  return became('typing indicator is hidden', () => !typingIndicator(), 5000);
+}

--- a/packages/test/page-object/src/globals/pageConditions/typingIndicatorShown.js
+++ b/packages/test/page-object/src/globals/pageConditions/typingIndicatorShown.js
@@ -2,5 +2,5 @@ import became from './became';
 import typingIndicator from '../pageElements/typingIndicator';
 
 export default function typingIndicatorShown() {
-  return became('typing indicator is shown', () => typingIndicator(), 15000);
+  return became('typing indicator is shown', () => typingIndicator(), 5000);
 }


### PR DESCRIPTION
> Fixes #4099.

## Changelog Entry

### Added

-  Resolves [#4099](https://github.com/microsoft/BotFramework-WebChat/issues/4099), added typing indicator to live region for screen reader, by [@compulim](https://github.com/compulim), in PR [#4210](https://github.com/microsoft/BotFramework-WebChat/pull/4210)

## Description

When receiving a typing activity, screen reader should narrate "Bot is typing."

## Design

### Who is typing

Depends on which participant send the typing activity, it could be "Bot is typing" or "John is typing".

Direct Line activity do have a field `from.name` to indicate the name of the sender. However, Direct Line does not return a friendly bot name and we need to patch it.

If all of the condition is true, we will change the `activity.from.name` to `"Bot"`:
- `activity.channelData` is `"directline"` or `"webchat"`, and;
- `activity.from.role` is `"bot"`, and;
- `activity.from.id` is the same as `activity.from.name`.

When more than one participant is typing, the typing indicator will be read as "John and others are typing."

### Incorrect `at` field returned by `useActiveTyping()`

Previously, in our `HOOKS.md`, we stated:

> This hook will return a list of participants who are actively typing, including the start typing time (`at`) and expiration time (`expireAt`), the name and the role of the participant.

However, when we revisit the code, the `at` field actually indicate the timestamp of *most recent* typing activity, instead of the *starting time*.

We fixed this by correcting the `at` field.

## Specific Changes

- Updated `core/src/reducers/typing.js` for correcting the `at` field, it should be based on 
- Updated `HOOKS.md` to indicate the issue `<= 4.15.1`
- Updated `<LiveRegionTwin>` to narrate static text properly (`aria-labelledby` is required by some browsers)
- Added sender name patch logic for `"directline"` and `"webchat"` channel
- Added new string "$1 is typing" and "$1 and others are typing" to `en-US.json`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] Internationalization reviewed (strings, unit formatting)
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
