### PR TITLE
Fix path on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Fixes [#4102](https://github.com/microsoft/BotFramework-WebChat/issues/4102). Fixed `cldr-data-downloader` package not working properly on Windows, by [@compulim](https://github.com/compulim) in PR [#4223](https://github.com/microsoft/BotFramework-WebChat/pull/4223)
+
 ### Changed
 
 -  Bumped all dependencies to the latest versions, by [@compulim](https://github.com/compulim) in PR [#4195](https://github.com/microsoft/BotFramework-WebChat/pull/4195)

--- a/packages/support/cldr-data-downloader/package.json
+++ b/packages/support/cldr-data-downloader/package.json
@@ -44,7 +44,7 @@
     "bump:prod": "npm install $(cat package.json | jq -r '(.dependencies | keys) - .skipBump | .[]' | awk '{print $1 \"@latest\"}')",
     "eslint": "npm run precommit",
     "precommit": "npm run precommit:eslint -- src",
-    "precommit:eslint": "../../../node_modules/.bin/eslint --report-unused-disable-directives --max-warnings 0"
+    "precommit:eslint": "node ../../../node_modules/eslint/bin/eslint.js --report-unused-disable-directives --max-warnings 0"
   },
   "skipBump": [],
   "dependencies": {

--- a/packages/support/cldr-data-downloader/src/index.js
+++ b/packages/support/cldr-data-downloader/src/index.js
@@ -9,7 +9,9 @@
 
 'use strict';
 
+import { fileURLToPath } from 'url';
 import { mkdirSync } from 'fs';
+import { resolve } from 'path';
 import assert from 'assert';
 
 import { isUrl, readJSON } from './util.js';
@@ -37,17 +39,20 @@ export default function (srcUrl, destPath, options, callback) {
     options = {};
   }
 
-  assert(typeof srcUrl === 'string', 'must include srcUrl (e.g., "http://www.unicode.org/Public/cldr/26/json.zip")');
+  assert(typeof srcUrl === 'string', 'must include srcUrl (e.g., "https://www.unicode.org/Public/cldr/26/json.zip")');
 
   assert(typeof destPath === 'string', 'must include destPath (e.g., "./cldr")');
   assert(!/\.\./u.test(destPath), '"destPath" must not contains "..".');
+  assert(!/^file:/u.test(destPath), '"destPath" must not be URL.');
 
   assert(typeof options === 'object', 'invalid options');
 
   assert(typeof callback === 'function', 'must include callback function');
 
+  destPath = resolve(fileURLToPath(import.meta.url), destPath);
+
   try {
-    mkdirSync(new URL(destPath, import.meta.url), { recursive: true });
+    mkdirSync(destPath, { recursive: true });
   } catch (err) {
     if (err.code !== 'EEXIST') {
       throw err;

--- a/packages/support/cldr-data-downloader/src/util.js
+++ b/packages/support/cldr-data-downloader/src/util.js
@@ -28,10 +28,9 @@ function deepEqual(a, b) {
 
 function isUrl(urlOrPath) {
   try {
-    // eslint-disable-next-line no-new
-    new URL(urlOrPath);
+    const url = new URL(urlOrPath);
 
-    return true;
+    return ['file:', 'http:', 'https:'].some(protocol => url.protocol === protocol);
   } catch (err) {
     return false;
   }

--- a/packages/support/cldr-data/package.json
+++ b/packages/support/cldr-data/package.json
@@ -44,7 +44,7 @@
     "eslint": "npm run precommit",
     "install": "node ./src/install.mjs",
     "precommit": "npm run precommit:eslint -- src",
-    "precommit:eslint": "../../../node_modules/.bin/eslint --report-unused-disable-directives --max-warnings 0"
+    "precommit:eslint": "node ../../../node_modules/eslint/bin/eslint.js --report-unused-disable-directives --max-warnings 0"
   },
   "skipBump": [],
   "dependencies": {

--- a/packages/support/cldr-data/src/install.mjs
+++ b/packages/support/cldr-data/src/install.mjs
@@ -90,7 +90,7 @@ let isNpm3;
 
   if (process.env.CLDR_URL) {
     console.warn('CLDR_URL is deprecated, use CLDR_DATA_URLS_JSON instead.');
-    srcUrl = srcUrl.replace('http://www.unicode.org/Public/cldr', process.env.CLDR_URL.replace(/\/$/u, ''));
+    srcUrl = srcUrl.replace('https://www.unicode.org/Public/cldr', process.env.CLDR_URL.replace(/\/$/u, ''));
   } else {
     if (process.env.CLDR_DATA_URLS_JSON) {
       srcUrl = process.env.CLDR_DATA_URLS_JSON;


### PR DESCRIPTION
> Fixes #4102.

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description

`cldr-data-downloader` we forked and ported to ESM earlier in PR #3998 wasn't working on Windows.

Under Node.js, there are two file path scheme:

- CJS use OS native file path (e.g. `C:\Users\...`);
- ESM requires URL-based file path (e.g. `file:///C:/Users/...`).

We mixed them up in the port. It was broken-but-working on Linux because we are using the path as a relative. However, under Windows, it exposed the issue.

## Design

We prefer OS native file path when passing the path externally, say, from `cldr-data` package to `cldr-data-downloader` package.

Internally, it depends. Because `mkdir` and other `fs` functions prefer OS native file path.

There is an utility function named `isUrl`. It is supposed to check if the path is a URL or OS native file path. However, it consider `C:\Users\...` is a URL, instead of OS native file path. We fixed it.

In the future, we should consider adding a PR validation pipeline that runs on Windows, in addition to Linux.

## Specific Changes

- Updated `index.js` and `util.js` in `cldr-data-downloader` to handle file path correctly

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
