### PR TITLE
Add 4.15.2 to servicing plan

### DIFF
--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -414,6 +414,16 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.15.2": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.15.2/webchat-es5.js",
+          "sha384-lUORlicC7NzeZQx9OQ8/uCjmblHgyo9cOV4Q4UlnTct4AXwWzNiS5+4w3rCcO/h5"
+        ]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "hosted": {
       "assets": [
         [

--- a/samples/02.branding-styling-and-customization/j.activity-grouping/index.html
+++ b/samples/02.branding-styling-and-customization/j.activity-grouping/index.html
@@ -16,8 +16,10 @@
       This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to pointing to Web Chat's MyGet feed:
       https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
     -->
-    <!-- <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat-es5.js"></script> -->
-    <script src="https://github.com/microsoft/BotFramework-WebChat/releases/download/daily/webchat-es5.js"></script>
+    <script
+      crossorigin="anonymous"
+      src="https://cdn.botframework.com/botframework-webchat/latest/webchat-es5.js"
+    ></script>
     <style>
       html,
       body {


### PR DESCRIPTION
> Related to #4275.

## Changelog Entry

(No changelog for `servicingPlan.json` change)

## Description

After post-production, we need to add `4.15.2` to `servicingPlan.json`.

Also, update samples to use `4.15.2`.

## Specific Changes

- Added `4.15.2` to `servicingPlan.json`
- Updated a sample to use `/latest/` instead of from GitHub releases

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
