### PR TITLE
Update `files` field in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 -  Resolves [#4301](https://github.com/microsoft/BotFramework-WebChat/issues/4301). Updated `Dockerfile` to support secure container supply chain, by [@compulim](https://github.com/compulim) in PR [#4303](https://github.com/microsoft/BotFramework-WebChat/pull/4303)
+-  Resolves [#4317](https://github.com/microsoft/BotFramework-WebChat/issues/4317). Updated `package.json` to allowlist `/dist`, `/lib`, `/src`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       -  New style options added `suggestedActionsVisualKeyboardIndicatorColor`, `suggestedActionsVisualKeyboardIndicatorStyle`, `suggestedActionsVisualKeyboardIndicatorWidth`
    -  Suggested actions container will be unmounted when there are no suggested action button to display
    -  Suggested actions container is not longer a live region. The suggested action buttons will now be narrated by the chat history live region
+-  Published NPM packages will now only includes `/dist`, `/lib`, and `/src` folders
+   -  Previously, `/dist` was missed from our NPM packages
 
 ### Changed
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,10 @@
   "bugs": {
     "url": "https://github.com/microsoft/BotFramework-WebChat/issues"
   },
+  "files": [
+    "lib/**/*",
+    "src/**/*"
+  ],
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/component#readme",
   "scripts": {
     "build": "npm run build:globalize && npm run build:typescript && npm run build:babel",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -17,6 +17,12 @@
     "url": "https://github.com/microsoft/BotFramework-WebChat/issues"
   },
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/#readme",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.map",
+    "lib/**/*",
+    "src/**/*"
+  ],
   "scripts": {
     "build": "npm run build:typescript && npm run build:babel && npm run build:webpack",
     "build:babel": "babel src --extensions .js,.ts,.tsx --ignore **/*.spec.js,**/*.spec.ts,**/*.spec.tsx,**/*.test.js,**/*.test.ts,**/*.test.tsx,__tests__/**/*.js,__tests__/**/*.ts,__tests__/**/*.tsx --out-dir lib --verbose",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -16,6 +16,10 @@
   "bugs": {
     "url": "https://github.com/microsoft/BotFramework-WebChat/issues"
   },
+  "files": [
+    "lib/**/*",
+    "src/**/*"
+  ],
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/component#readme",
   "scripts": {
     "build": "npm run build:typescript && npm run build:babel",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,10 @@
   "bugs": {
     "url": "https://github.com/microsoft/BotFramework-WebChat/issues"
   },
+  "files": [
+    "lib/**/*",
+    "src/**/*"
+  ],
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/packages/core#readme",
   "scripts": {
     "build": "npm run build:typescript && npm run build:babel",

--- a/packages/directlinespeech/package.json
+++ b/packages/directlinespeech/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0-0",
   "description": "Direct Line Speech SDK",
   "files": [
-    "dist/**/*",
-    "lib/**/*"
+    "dist/**/*.js",
+    "dist/**/*.map",
+    "lib/**/*",
+    "src/**/*"
   ],
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
> Fixes #4317.

## Changelog Entry

### Breaking changes

-  Published NPM packages will now only includes `/dist`, `/lib`, and `/src` folders
   -  Previously, `/dist` was missed from our NPM packages

### Changed

-  Resolves [#4317](https://github.com/microsoft/BotFramework-WebChat/issues/4317). Updated `package.json` to allowlist `/dist`, `/lib`, `/src`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

<!-- Please list the changes in a concise manner. -->

## -

-

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] I have added tests and executed them locally
-  [ ] I have updated `CHANGELOG.md`
-  [ ] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
