### PR TITLE
Fix Adaptive Cards `TextBlock` element missing `aria-level`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4294](https://github.com/microsoft/BotFramework-WebChat/issues/4294). Screen reader should not read message twice when navigating in the chat history, by [@compulim](https://github.com/compulim), in PR [#4323](https://github.com/microsoft/BotFramework-WebChat/issues/4323)
 -  Fixes [#4295](https://github.com/microsoft/BotFramework-WebChat/issues/4295). Screen reader should not read suggested actions twice when message arrive in live region, by [@compulim](https://github.com/compulim), in PR [#4323](https://github.com/microsoft/BotFramework-WebChat/issues/4323)
 -  Fixes [#4325](https://github.com/microsoft/BotFramework-WebChat/issues/4325). `aria-keyshortcuts` should use modifier keys according to `KeyboardEvent` key values spec, by [@compulim](https://github.com/compulim), in PR [#4323](https://github.com/microsoft/BotFramework-WebChat/issues/4323)
+-  Fixes [#4327](https://github.com/microsoft/BotFramework-WebChat/issues/4327). In Adaptive Cards, `TextBlock` with `style="heading"` should have `aria-level` set, by [@compulim](https://github.com/compulim), in PR [#4329](https://github.com/microsoft/BotFramework-WebChat/issues/4329)
 
 ## [4.15.2] - 2022-05-09
 

--- a/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.speakProperty.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.speakProperty.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.animationCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.animationCard.html
@@ -63,6 +63,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.audio.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.audio.html
@@ -60,6 +60,7 @@
 
         audioElement.removeAttribute('controls');
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.audioCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.audioCard.html
@@ -60,6 +60,7 @@
 
         audioElement.removeAttribute('controls');
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.file.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.file.html
@@ -60,6 +60,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.heroCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.heroCard.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.image.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.image.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.receiptCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.receiptCard.html
@@ -56,6 +56,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.signInCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.signInCard.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.thumbnailCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.thumbnailCard.html
@@ -54,6 +54,7 @@
         await pageConditions.scrollToBottomCompleted();
         await pageConditions.liveRegionStabilized();
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.unknownCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.unknownCard.html
@@ -55,6 +55,7 @@
           await pageConditions.scrollToBottomCompleted();
           await pageConditions.liveRegionStabilized();
 
+          await pageObjects.verifyDOMIntegrity();
           await pageObjects.focusSendBoxTextBox();
 
           await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.video.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.video.html
@@ -60,6 +60,7 @@
 
         videoElement.removeAttribute('controls');
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/__tests__/html/accessibility.liveRegionAttachment.videoCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.videoCard.html
@@ -60,6 +60,7 @@
 
         videoElement.removeAttribute('controls');
 
+        await pageObjects.verifyDOMIntegrity();
         await pageObjects.focusSendBoxTextBox();
 
         await host.sendShiftTab(3);

--- a/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.ts
+++ b/packages/bundle/src/adaptiveCards/Styles/adaptiveCardHostConfig.ts
@@ -133,6 +133,9 @@ export default function createAdaptiveCardsHostConfig(styleOptions: FullBundleSt
         wrap: true
       },
       spacing: 8
+    },
+    textBlock: {
+      headingLevel: 1
     }
   };
 }

--- a/packages/test/page-object/src/globals/pageObjects/verifyDOMIntegrity.js
+++ b/packages/test/page-object/src/globals/pageObjects/verifyDOMIntegrity.js
@@ -3,16 +3,22 @@
 export default function verifyDOMIntegrity() {
   // If an element has "aria-labelledby", the label element must be present on the screen.
   [].forEach.call(document.querySelectorAll('[aria-labelledby]'), element => {
-    const labelId = element.getAttribute('aria-labelledby');
-    const labelElement = document.getElementById(labelId);
+    element
+      .getAttribute('aria-labelledby')
+      .split(' ')
+      .map(labelId => labelId.trim())
+      .filter(Boolean)
+      .forEach(labelId => {
+        const labelElement = document.getElementById(labelId);
 
-    if (!labelElement) {
-      const message = `verifyDOMIntegrity: Cannot find element referenced by aria-labelledby attribute with ID "${labelId}".`;
+        if (!labelElement) {
+          const message = `verifyDOMIntegrity: Cannot find element referenced by aria-labelledby attribute with ID "${labelId}".`;
 
-      console.warn(message, element);
+          console.warn(message, element);
 
-      throw new Error(message);
-    }
+          throw new Error(message);
+        }
+      });
   });
 
   // No two elements can have the same ID.
@@ -35,6 +41,19 @@ export default function verifyDOMIntegrity() {
 
     if (~className.indexOf('undefined')) {
       const message = `No elements should have the keyword "undefined" in it, we saw "${className}".`;
+
+      console.warn(message, element);
+
+      throw new Error(message);
+    }
+  });
+
+  // Elements of `role="heading"` must have `aria-level` set
+  [].forEach.call(document.querySelectorAll('[role="heading"]'), element => {
+    const ariaLevel = +element.getAttribute('aria-level');
+
+    if (!(ariaLevel >= 1 && ariaLevel === ~~ariaLevel)) {
+      const message = 'Elements of role="heading" must have aria-level set to an integer equal to or greater than 1.';
 
       console.warn(message, element);
 


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4327.

## Changelog Entry

### Fixed

-  Fixes [#4327](https://github.com/microsoft/BotFramework-WebChat/issues/4327). In Adaptive Cards, `TextBlock` with `style="heading"` should have `aria-level` set, by [@compulim](https://github.com/compulim), in PR [#4329](https://github.com/microsoft/BotFramework-WebChat/issues/4329)

## Description

By default, Adaptive Cards generate DOM with `role="heading"` without `aria-level` set. This violated [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) ([ARIA5](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA5)).

In order to set `aria-level`, we need to explicitly set `ACHostConfig.textBlock.headingLevel` to `1`. This is an [undocumented option](https://docs.microsoft.com/en-us/adaptive-cards/rendering-cards/host-config#schema-textblockconfig) introduced by https://github.com/microsoft/AdaptiveCards/issues/5635 and https://github.com/microsoft/AdaptiveCards/pull/5698.

## Design

This is code in [Adaptive Cards repo `card-elements.ts`](https://github.com/microsoft/AdaptiveCards/blob/ff28a1fd75d5dbe62d3fc3940f47652190f5a506/source/nodejs/adaptivecards/src/card-elements.ts#L920).

![image](https://user-images.githubusercontent.com/1622400/175752557-10980cc6-2855-40a6-9bd5-96cade07ffe7.png)

If the Adaptive Card `TextBlock` element has `style="heading"`, the `role="heading"` will be applied. However, `aria-level` is not set unless `ACHostConfig.textBlock.headingLevel` is set. This is an undocumented option and *required* for accessibility. Otherwise, we would fail with [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) ([ARIA5](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA5)).

We need to explicitly set `ACHostConfig.textBlock.headingLevel` to make sure `aria-level` is set on `role="heading"`. As we do not use heading, we default it to level 1.

## Specific Changes

- Update `adaptiveCardHostConfig.ts` to add `textBlock.headingLevel` to `1`
- Update `verifyDOMIntegrity.js` for verifying our DOM tree is good
- Add `verifyDOMIntegrity()` call to all card-related attachments

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
