### PR TITLE
Bad return value from groupActivityMiddleware should be tolerated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4325](https://github.com/microsoft/BotFramework-WebChat/issues/4325). `aria-keyshortcuts` should use modifier keys according to `KeyboardEvent` key values spec, by [@compulim](https://github.com/compulim), in PR [#4323](https://github.com/microsoft/BotFramework-WebChat/issues/4323)
 -  Fixes [#4327](https://github.com/microsoft/BotFramework-WebChat/issues/4327). In Adaptive Cards, `TextBlock` with `style="heading"` should have `aria-level` set, by [@compulim](https://github.com/compulim), in PR [#4329](https://github.com/microsoft/BotFramework-WebChat/issues/4329)
 -  Fixes [#3949](https://github.com/microsoft/BotFramework-WebChat/issues/3949). For accessibility reasons, buttons in Adaptive Cards should be `role="button"` instead of `role="menubar"`/`role="menuitem"`, by [@compulim](https://github.com/compulim), in PR [#4263](https://github.com/microsoft/BotFramework-WebChat/issues/4263)
--  Fixes [#4211](https://github.com/microsoft/BotFramework-WebChat/issues/4211). Screen reader should read when an activity was failed to send, by [@compulim](https://github.com/compulim), in PR [#4326](https://github.com/microsoft/BotFramework-WebChat/issues/4326), also fixed:
+-  Fixes [#4211](https://github.com/microsoft/BotFramework-WebChat/issues/4211). Screen reader should read when an activity was failed to send, by [@compulim](https://github.com/compulim), in PR [#4362](https://github.com/microsoft/BotFramework-WebChat/pull/4362), also fixed:
    -  The "send failed" status on the activity should show up as soon as the chat adapter failed to send the activity
+-  Fixes [#4312](https://github.com/microsoft/BotFramework-WebChat/issues/4312). `groupActivityMiddleware` returning invalid value should not throw exceptions, by [@compulim](https://github.com/compulim), in PR [#4378](https://github.com/microsoft/BotFramework-WebChat/pull/4378).
 
 ## Changes
 

--- a/__tests__/html/activityGrouping.customMiddleware.html
+++ b/__tests__/html/activityGrouping.customMiddleware.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      function bin(items, grouping) {
+        let lastBin;
+        const bins = [];
+        let lastItem;
+
+        items.forEach(item => {
+          if (lastItem && grouping(lastItem, item)) {
+            lastBin.push(item);
+          } else {
+            lastBin = [item];
+            bins.push(lastBin);
+          }
+
+          lastItem = item;
+        });
+
+        return bins;
+      }
+
+      run(async function () {
+        const store = testHelpers.createStore();
+
+        const directLine = testHelpers.createDirectLineEmulator(store);
+
+        const activityMiddleware =
+          () =>
+          next =>
+          (...args) => {
+            const component = next(...args);
+
+            if (component && args[0].activity.from.role === 'channel') {
+              return () =>
+                React.createElement(
+                  'div',
+                  {
+                    style: {
+                      color: '#999',
+                      fontFamily: 'Calibri, sans-serif',
+                      fontSize: 'smaller',
+                      textAlign: 'center'
+                    }
+                  },
+                  args[0].activity.text
+                );
+            }
+
+            return component;
+          };
+
+        function renderWebChatWithProps(props) {
+          WebChat.renderWebChat(
+            {
+              activityMiddleware,
+              directLine,
+              store,
+              ...props
+            },
+            document.getElementById('webchat')
+          );
+        }
+
+        renderWebChatWithProps();
+
+        await pageConditions.uiConnected();
+
+        // SETUP: Receive a channel message.
+        await directLine.emulateIncomingActivity({
+          from: { role: 'channel' },
+          text: 'An agent will be available shortly.',
+          type: 'message'
+        });
+
+        // SETUP: Receive a bot message.
+        await directLine.emulateIncomingActivity({
+          text: 'Hello, World!',
+          timestamp: new Date().toISOString(),
+          type: 'message'
+        });
+
+        // SETUP: Receive another bot message.
+        await directLine.emulateIncomingActivity({
+          text: 'Aloha!',
+          timestamp: new Date().toISOString(),
+          type: 'message'
+        });
+
+        // WHEN: `groupActivitiesMiddleware` is invalid (undefined).
+        renderWebChatWithProps({
+          groupActivitiesMiddleware:
+            () =>
+            next =>
+            (...args) =>
+              undefined
+        });
+
+        // THEN: It should group activities by themselves.
+        pageConditions.became(
+          'should have 2 timestamps',
+          () =>
+            pageElements
+              .activityStatuses()
+              .map(element => !!element?.querySelector('[aria-hidden]')?.innerText)
+              .filter(Boolean).length === 2,
+          1000
+        );
+
+        // WHEN: `groupActivitiesMiddleware` is invalid (() => false).
+        renderWebChatWithProps({
+          groupActivitiesMiddleware:
+            () =>
+            next =>
+            (...args) =>
+            () =>
+              false
+        });
+
+        // THEN: It should group activities by themselves.
+        pageConditions.became(
+          'should have 2 timestamps',
+          () =>
+            pageElements
+              .activityStatuses()
+              .map(element => !!element?.querySelector('[aria-hidden]')?.innerText)
+              .filter(Boolean).length === 2,
+          1000
+        );
+
+        // WHEN: `groupActivitiesMiddleware` is invalid ({ sender: undefined, status: undefined }).
+        renderWebChatWithProps({
+          groupActivitiesMiddleware:
+            () =>
+            next =>
+            (...args) =>
+            () => ({ sender: undefined, status: undefined })
+        });
+
+        // THEN: It should group activities by themselves.
+        pageConditions.became(
+          'should have 2 timestamps',
+          () =>
+            pageElements
+              .activityStatuses()
+              .map(element => !!element?.querySelector('[aria-hidden]')?.innerText)
+              .filter(Boolean).length === 2,
+          1000
+        );
+
+        // WHEN: `groupActivitiesMiddleware` is invalid (not all activities are grouped).
+        renderWebChatWithProps({
+          groupActivitiesMiddleware:
+            () =>
+            next =>
+            (...args) =>
+            () => ({ sender: [], status: [] })
+        });
+
+        // THEN: It should group activities by themselves.
+        pageConditions.became(
+          'should have 2 timestamps',
+          () =>
+            pageElements
+              .activityStatuses()
+              .map(element => !!element?.querySelector('[aria-hidden]')?.innerText)
+              .filter(Boolean).length === 2,
+          1000
+        );
+
+        // WHEN: `groupActivitiesMiddleware` is unset.
+        renderWebChatWithProps();
+
+        // THEN: It should group activities using defaults.
+        pageConditions.became(
+          'should have 1 timestamp',
+          () =>
+            pageElements
+              .activityStatuses()
+              .map(element => !!element?.querySelector('[aria-hidden]')?.innerText)
+              .filter(Boolean).length === 1,
+          1000
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/activityGrouping.customMiddleware.js
+++ b/__tests__/html/activityGrouping.customMiddleware.js
@@ -1,0 +1,5 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('activity grouping', () => {
+  test('should accept valid or invalid custom middleware', () => runHTML('activityGrouping.customMiddleware.html'));
+});

--- a/packages/test/page-object/src/globals/testHelpers/createDirectLineEmulator.js
+++ b/packages/test/page-object/src/globals/testHelpers/createDirectLineEmulator.js
@@ -64,6 +64,7 @@ export default function createDirectLineEmulator(store) {
           type: 'message'
         };
       } else {
+        activity = updateIn(activity, ['from', 'role'], role => role || 'bot');
         activity = updateIn(activity, ['timestamp'], timestamp =>
           typeof timestamp === 'number' ? new Date(now + timestamp).toISOString() : timestamp
         );


### PR DESCRIPTION
> Fixes #4312.

## Changelog Entry

### Fixed

-  Fixes [#4312](https://github.com/microsoft/BotFramework-WebChat/issues/4312). `groupActivityMiddleware` returning invalid value should not throw exceptions, by [@compulim](https://github.com/compulim), in PR [#4378](https://github.com/microsoft/BotFramework-WebChat/pull/4378).

## Description

In 4.14.0, even the `groupActivityMiddleware` returned invalid value, say, `() => false`, it will tolerate it.

In 4.15.0,  we did not tolerate bad return value. Thus, it is causing the issue mentioned in #4312.

## Design

Modify the `useActivityTreeWithRenderer` to tolerate bad input by defaulting it to an empty array.

## Specific Changes

- Modify the `useActivityTreeWithRenderer` to tolerate bad input by defaulting it to an empty array.
- Added tests to make sure Web Chat will tolerate bad `groupActivityMiddleware`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
