### PR TITLE
Hotfix Unicode CLDR database

### DIFF
--- a/packages/support/cldr-data/package.json
+++ b/packages/support/cldr-data/package.json
@@ -35,6 +35,7 @@
   "files": [
     "src/index.js",
     "src/install.mjs",
+    "src/patch.mjs",
     "urls.json"
   ],
   "scripts": {
@@ -42,7 +43,7 @@
     "bump:dev": "npm install $(cat package.json | jq -r '(.devDependencies | keys) - .skipBump | .[]' | awk '{print $1 \"@latest\"}')",
     "bump:prod": "npm install $(cat package.json | jq -r '(.dependencies | keys) - .skipBump | .[]' | awk '{print $1 \"@latest\"}')",
     "eslint": "npm run precommit",
-    "install": "node ./src/install.mjs",
+    "install": "node ./src/install.mjs && node ./src/patch.mjs",
     "precommit": "npm run precommit:eslint -- src",
     "precommit:eslint": "node ../../../node_modules/eslint/bin/eslint.js --report-unused-disable-directives --max-warnings 0"
   },

--- a/packages/support/cldr-data/src/patch.mjs
+++ b/packages/support/cldr-data/src/patch.mjs
@@ -1,0 +1,143 @@
+import { fileURLToPath } from 'url';
+import { resolve } from 'path';
+import fs from 'fs/promises';
+
+// There is an issue in the Unicode CLDR database (v36):
+//
+// - Polish has 4 different plural types: "one", "few", "many", "other"
+// - However, some units, say "short/digital-kilobyte", only have "other" defined
+// - When we localize 1024 (number) into kilobytes, it use the "one" type
+// - Since "short/digital-kilobyte/one" is not defined in the database, `globalize` throw exception
+//
+// In all of our supported languages, we also observed the same issue in Portuguese as well.
+//
+// As a hotfix, we are patching the Unicode CLDR database for all `[long/short/narrow]/digital-*` rules to make sure it include all plurals needed for that language.
+//
+// For a long term fix, we should move forward to a newer version of CLDR database, which is outlined in https://github.com/rxaviers/cldr-data-npm/issues/78.
+
+let FORBIDDEN_PROPERTY_NAMES;
+
+function getForbiddenPropertyNames() {
+  return (
+    FORBIDDEN_PROPERTY_NAMES ||
+    (FORBIDDEN_PROPERTY_NAMES = Object.freeze(
+      Array.from(
+        new Set([
+          // As-of writing, `Object.prototype` includes:
+          //   __defineGetter__
+          //   __defineSetter__
+          //   __lookupGetter__
+          //   __lookupSetter
+          //   __proto__
+          //   constructor
+          //   hasOwnProperty
+          //   isPrototypeOf
+          //   propertyIsEnumerable
+          //   toLocaleString
+          //   toString
+          //   valueOf
+          ...Object.getOwnPropertyNames(Object.prototype),
+
+          'prototype'
+        ])
+      )
+    ))
+  );
+}
+
+function isForbiddenPropertyName(propertyName) {
+  return getForbiddenPropertyNames().includes(propertyName);
+}
+
+function toDist(filename) {
+  if (filename.includes('..')) {
+    throw new Error('Filename cannot contains "..".');
+  }
+
+  return resolve(fileURLToPath(import.meta.url), '../../dist/', filename);
+}
+
+(async function () {
+  // The function will make sure access to the path is limited.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const plurals = JSON.parse(await fs.readFile(toDist('supplemental/plurals.json'), 'utf8'));
+
+  const languagePlurals = new Map();
+
+  Object.entries(plurals.supplemental['plurals-type-cardinal']).forEach(([language, pluralsTypeCardinal]) => {
+    const plurals = ['other'];
+
+    languagePlurals.set(language, plurals);
+
+    if (!(`pluralRule-count-other` in pluralsTypeCardinal)) {
+      throw new Error(`Language ${language} does not have plural type "other".`);
+    }
+
+    ['zero', 'one', 'two', 'few', 'many'].forEach(pluralType => {
+      `pluralRule-count-${pluralType}` in pluralsTypeCardinal && plurals.push(pluralType);
+    });
+  });
+
+  const patchedLanguages = [];
+
+  await Promise.all(
+    Array.from(languagePlurals.entries()).map(async ([language, supportedPluralTypes]) => {
+      if (!/^[\w-]+$/u.test(language) && isForbiddenPropertyName(language)) {
+        throw new Error(`Invalid language code "${language}".`);
+      }
+
+      let units;
+
+      try {
+        // The function will make sure access to the path is limited.
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        units = JSON.parse(await fs.readFile(toDist(`main/${language}/units.json`), 'utf8'));
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          return;
+        }
+
+        throw err;
+      }
+
+      let numFound = 0;
+
+      ['long', 'short', 'narrow'].forEach(form => {
+        // Both "language" and "form" are filtered and free of forbidden values.
+        // eslint-disable-next-line security/detect-object-injection
+        Object.entries(units.main[language].units[form]).forEach(([unitName, entry]) => {
+          if (!unitName.startsWith('digital-')) {
+            return;
+          }
+
+          if ('unitPattern-count-other' in entry) {
+            const { 'unitPattern-count-other': other } = entry;
+
+            supportedPluralTypes.forEach(pluralType => {
+              const name = `unitPattern-count-${pluralType}`;
+
+              if (!(name in entry)) {
+                // "name" is free of forbidden values.
+                // eslint-disable-next-line security/detect-object-injection
+                entry[name] = other;
+                numFound++;
+              }
+            });
+          }
+        });
+      });
+
+      if (numFound) {
+        patchedLanguages.push(`${language} (${numFound} issues)`);
+
+        // The function will make sure access to the path is limited.
+        // eslint-disable-next-line security/detect-non-literal-fs-filename, no-magic-numbers
+        await fs.writeFile(toDist(`main/${language}/units-patched.json`), JSON.stringify(units, null, 2));
+      }
+    })
+  );
+
+  // We are display output in CLI.
+  // eslint-disable-next-line no-console
+  console.log(`Patched ${patchedLanguages.length} languages: ${patchedLanguages.join(', ')}.`);
+})();


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4403.

## Changelog Entry

### Fixed

-  Fixes [#4403](https://github.com/microsoft/BotFramework-WebChat/issues/4403). Patched Unicode CLDR database which caused file upload in Polish to appear blank, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)

## Description

Unicode CLDR v36 database downloaded by `cldr-data-downloader` has inconsistencies and causing issues for file upload in Polish.

## Design

This is hotfixing the database by patching it to include necessary fields. This is not a long term fix.

## Specific Changes

- Added a new patch script to `cldr-data` to run on `install`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
