### PR TITLE
Add changelog and servicing plan from QFE 4.14.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Fixes [#4031](https://github.com/microsoft/BotFramework-WebChat/issues/4031). Updated [`05.custom-components/b.send-typing-indicator`](../../samples/05.custom-components/b.send-typing-indicator) to reply with `message` activity, instead of `typing` activity, in PR [#4063](https://github.com/microsoft/BotFramework-WebChat/pull/4063), by [@compulim](https://github.com/compulim)
 
+## [4.14.2] - 2022-09-06
+
+### Fixed
+
+-  QFE: Fixes [#4403](https://github.com/microsoft/BotFramework-WebChat/issues/4403). Patched Unicode CLDR database which caused file upload in Polish to appear blank, by [@compulim](https://github.com/compulim), in PR [#4406](https://github.com/microsoft/BotFramework-WebChat/pull/4406)
+
 ## [4.14.1] - 2021-09-07
 
 ### Fixed

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -385,6 +385,17 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.14.2": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.14.2/webchat-es5.js",
+          "sha384-rICoECir+m94sA3D9FN2nWP76JKfcGJA5uhCZ/nSM3JNYWtnqUk5mHCgVvgWE+if"
+        ]
+      ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-09-07.",
+      "private": true,
+      "versionFamily": "4"
+    },
     "4.15": {
       "redirects": [
         [


### PR DESCRIPTION
> Related to #4409.

## Changelog Entry

## [4.14.2] - 2022-09-06

### Fixed

-  QFE: Fixes [#4403](https://github.com/microsoft/BotFramework-WebChat/issues/4403). Patched Unicode CLDR database which caused file upload in Polish to appear blank, by [@compulim](https://github.com/compulim), in PR [#4406](https://github.com/microsoft/BotFramework-WebChat/pull/4406)

## Description

Adding CHANGELOG entries and `servicingPlan.json` for 4.14.2.

## Specific Changes

- Copy CHANGELOG entries from 4.14.2
- Add 4.14.2 to `servicingPlan.json`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
