### PR TITLE
`package.json` is inconsistent with `package-lock.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -  Fixes [#4403](https://github.com/microsoft/BotFramework-WebChat/issues/4403). Patched Unicode CLDR database which caused file upload in Polish to appear blank, by [@compulim](https://github.com/compulim), in PR [#4404](https://github.com/microsoft/BotFramework-WebChat/pull/4404)
+-  Fixes [#4412](https://github.com/microsoft/BotFramework-WebChat/issues/4412). Fixed inconsistent in `packages/support/cldr-data/package.json`, by [@compulim](https://github.com/compulim), in PR [#4411](https://github.com/microsoft/BotFramework-WebChat/pull/4411)
 
 ### Changed
 

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
   "version": "0.0.0",
   "command": {
     "bootstrap": {
+      "forceLocal": true,
       "npmClientArgs": [
         "--legacy-peer-deps"
       ]

--- a/packages/support/cldr-data/package.json
+++ b/packages/support/cldr-data/package.json
@@ -50,7 +50,7 @@
   "skipBump": [],
   "dependencies": {
     "cldr-data-downloader": "0.3.5-0",
-    "glob": "^7.2.0",
+    "glob": "^8.0.3",
     "read-pkg": "^7.1.0",
     "read-pkg-up": "^9.1.0"
   }


### PR DESCRIPTION
> Fixes #4412.

## Changelog Entry

### Fixed

-  Fixes [#4412](https://github.com/microsoft/BotFramework-WebChat/issues/4412). Fixed inconsistent in `packages/support/cldr-data/package.json`, by [@compulim](https://github.com/compulim), in PR [#4411](https://github.com/microsoft/BotFramework-WebChat/pull/4411)

## Description

In #4392, we missed committing `packages/support/cldr-data/package.json`. However, CI PR validation passed for unknown reason. Both our daily build and some dev boxes failed.

We are also enabling `--force-local` switch in Lerna to make sure this won't get pass CI PR validation next time.

## Design

When running `lerna bootstrap --ci`, it may regard the `--ci` flag for a few reasons (non-exhaustive):

- [NPM version is `< 5.7.0`](https://github.com/lerna/lerna/blob/main/commands/bootstrap/index.js#L115)
- [Hoisting is enabled](https://github.com/lerna/lerna/blob/main/commands/bootstrap/index.js#L119)
- [Installing local packages that do not match filters from registry](https://github.com/lerna/lerna/blob/main/commands/bootstrap/index.js#L156) (unless `--force-local` is specified)

Since we adopted `cldr-data`, we are hitting point 3, thus, `lerna` disabled `--ci`.

We are adding a new `--force-local` switch to make sure we use the local version of `cldr-data` instead of NPM.

## Specific Changes

- Update `packages/support/cldr-data/package.json` to use `glob@^8.0.3`
   - We are using caret version as this package is used for pre-compile, and not production
- Update `lerna.json` and add `--force-local` flag

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
