### PR TITLE
Bump to Adaptive Cards 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+-  Bumped Adaptive Cards to [`adaptivecards@2.11.1`](https://npmjs.com/package/adaptivecards), by [@compulim](https://github.com/compulim) in PR [#4424](https://github.com/microsoft/BotFramework-WebChat/pull/4424)
 -  Bumped all dependencies to the latest versions, by [@compulim](https://github.com/compulim) in PR [#4423](https://github.com/microsoft/BotFramework-WebChat/pull/4423)
    -  Production dependencies
       -  [`@babel/runtime@7.19.0`](https://npmjs.com/package/@babel/runtime)

--- a/__tests__/html/accessibility.adaptiveCard.disabled.focus.withShowCard.html
+++ b/__tests__/html/accessibility.adaptiveCard.disabled.focus.withShowCard.html
@@ -146,8 +146,13 @@
         // WHEN: Pressing TAB key.
         await host.sendKeys('TAB');
 
-        // THEN: It should focus on the first textbox (this is done by Adaptive Cards, they set tabindex="-1" on other buttons).
-        //       We just verify whatever behavior they have.
+        // THEN: It should focus on the "Skip" button.
+        expect(document.activeElement).toBe(document.querySelector('button[title="Skip"]'));
+
+        // WHEN: Pressing TAB key again.
+        await host.sendKeys('TAB');
+
+        // THEN: It should focus on the textbox.
         expect(document.activeElement).toBe(document.querySelector('input'));
 
         // WHEN: Pressing TAB key.

--- a/__tests__/html/accessibility.adaptiveCard.disabled.inputs.html
+++ b/__tests__/html/accessibility.adaptiveCard.disabled.inputs.html
@@ -77,6 +77,7 @@
             'DOWN', // What color do you want? Red
             'DOWN', // Green
             'TAB',
+            'TAB', // AC 2.11: Checkbox group container has tabindex="0"
             'SPACE', // What colors do you want? Red
             'TAB',
             'SPACE', // Green

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.event.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.event.html
@@ -29,15 +29,35 @@
 
           await pageConditions.uiConnected();
 
-          const { flush } = pageObjects.observeLiveRegion();
+          const { disconnect, flush } = pageObjects.observeLiveRegion();
 
-          const sendMessage = await directLine.emulateOutgoingActivity({ name: 'hello', type: 'event', value: 'aloha' });
+          try {
+            const sendMessage = await directLine.emulateOutgoingActivity({
+              name: 'hello',
+              type: 'event',
+              value: 'aloha'
+            });
 
-          sendMessage.rejectPostActivity(new Error('artificial error'));
+            sendMessage.rejectPostActivity(new Error('artificial error'));
 
-          await directLine.emulateIncomingActivity('Aloha!');
+            await directLine.emulateIncomingActivity('Aloha!');
 
-          expect(flush()).toEqual(['Bot said:\nAloha!']);
+            await pageConditions.became(
+              'live region narrated bot message',
+              () => {
+                try {
+                  expect(flush()).toEqual(['Bot said:\nAloha!']);
+
+                  return true;
+                } catch {
+                  return false;
+                }
+              },
+              1000
+            );
+          } finally {
+            disconnect();
+          }
         },
         { ignoreErrors: true }
       );

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.html
@@ -29,21 +29,45 @@
 
           await pageConditions.uiConnected();
 
-          const { flush } = pageObjects.observeLiveRegion();
+          const { disconnect, flush } = pageObjects.observeLiveRegion();
 
-          const sendMessage = await directLine.emulateOutgoingActivity('Hello, World!');
+          try {
+            const sendMessage = await directLine.emulateOutgoingActivity('Hello, World!');
 
-          await directLine.emulateIncomingActivity('Aloha!');
+            await directLine.emulateIncomingActivity('Aloha!');
 
-          sendMessage.rejectPostActivity(new Error('artificial error'));
+            sendMessage.rejectPostActivity(new Error('artificial error'));
 
-          await pageConditions.became(
-            'failed to send message',
-            () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
-            1000
-          );
+            await pageConditions.became(
+              'failed to send message',
+              () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
+              1000
+            );
 
-          expect(flush()).toEqual(['You said:\nHello, World!', 'Bot said:\nAloha!', 'Failed to send message.']);
+            const liveRegionText = [];
+
+            await pageConditions.became(
+              'live region narrated failed to send message',
+              () => {
+                try {
+                  liveRegionText.push(...flush());
+
+                  expect(liveRegionText).toEqual([
+                    'You said:\nHello, World!',
+                    'Bot said:\nAloha!',
+                    'Failed to send message.'
+                  ]);
+
+                  return true;
+                } catch (err) {
+                  return false;
+                }
+              },
+              1000
+            );
+          } finally {
+            disconnect();
+          }
         },
         { ignoreErrors: true }
       );

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.typing.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.typing.html
@@ -29,15 +29,31 @@
 
           await pageConditions.uiConnected();
 
-          const { flush } = pageObjects.observeLiveRegion();
+          const { disconnect, flush } = pageObjects.observeLiveRegion();
 
-          const sendMessage = await directLine.emulateOutgoingActivity({ type: 'typing' });
+          try {
+            const sendMessage = await directLine.emulateOutgoingActivity({ type: 'typing' });
 
-          sendMessage.rejectPostActivity(new Error('artificial error'));
+            sendMessage.rejectPostActivity(new Error('artificial error'));
 
-          await directLine.emulateIncomingActivity('Aloha!');
+            await directLine.emulateIncomingActivity('Aloha!');
 
-          expect(flush()).toEqual(['Bot said:\nAloha!']);
+            await pageConditions.became(
+              'live region narrated bot message',
+              () => {
+                try {
+                  expect(flush()).toEqual(['Bot said:\nAloha!']);
+
+                  return true;
+                } catch {
+                  return false;
+                }
+              },
+              1000
+            );
+          } finally {
+            disconnect();
+          }
         },
         { ignoreErrors: true }
       );

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.19.0",
-        "adaptivecards": "2.10.0",
+        "adaptivecards": "2.11.1",
         "botframework-directlinejs": "0.15.1",
         "classnames": "2.3.2",
         "core-js": "3.25.3",
@@ -24,7 +24,7 @@
         "prop-types": "15.8.1",
         "sanitize-html": "2.7.2",
         "url-search-params-polyfill": "8.1.1",
-        "uuid": "8",
+        "uuid": "8.3.2",
         "web-speech-cognitive-services": "7.1.1",
         "whatwg-fetch": "3.6.2"
       },
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/adaptivecards": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-2.10.0.tgz",
-      "integrity": "sha512-QcgXGFlX3rgIfZkxvQY896zEVBh30mE37z3XKhcQW2OqSUrVH6dNT78MkM//W4wRdrZizSHqXKLaKyVVxAgVFg=="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-2.11.1.tgz",
+      "integrity": "sha512-dyF23HK+lRMEreexJgHz4y9U5B0ZuGk66N8nhwXRnICyYjq8hE4A6n8rLoV/CNY2QAZ0iRjOIR2J8U7M1CKl8Q=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -8267,9 +8267,9 @@
       "dev": true
     },
     "adaptivecards": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-2.10.0.tgz",
-      "integrity": "sha512-QcgXGFlX3rgIfZkxvQY896zEVBh30mE37z3XKhcQW2OqSUrVH6dNT78MkM//W4wRdrZizSHqXKLaKyVVxAgVFg=="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-2.11.1.tgz",
+      "integrity": "sha512-dyF23HK+lRMEreexJgHz4y9U5B0ZuGk66N8nhwXRnICyYjq8hE4A6n8rLoV/CNY2QAZ0iRjOIR2J8U7M1CKl8Q=="
     },
     "agent-base": {
       "version": "6.0.2",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.19.0",
-    "adaptivecards": "2.10.0",
+    "adaptivecards": "2.11.1",
     "botframework-directlinejs": "0.15.1",
     "botframework-directlinespeech-sdk": "0.0.0-0",
     "botframework-webchat-api": "0.0.0-0",

--- a/packages/test/page-object/src/globals/pageObjects/observeLiveRegion.js
+++ b/packages/test/page-object/src/globals/pageObjects/observeLiveRegion.js
@@ -22,6 +22,7 @@ export default function observeLiveRegion() {
   mutationObserver.observe(liveRegionElement, { childList: true });
 
   return {
+    disconnect: () => mutationObserver.disconnect(),
     flush: () => liveRegionInnerTexts.splice(0),
     getInnerTexts: () => Object.freeze([...liveRegionInnerTexts])
   };


### PR DESCRIPTION
> Also fixed #4417.

## Changelog Entry

### Changed

-  Bumped Adaptive Cards to [`adaptivecards@2.11.1`](https://npmjs.com/package/adaptivecards), by [@compulim](https://github.com/compulim) in PR [#4424](https://github.com/microsoft/BotFramework-WebChat/pull/4424)

## Description

Bump Adaptive Cards to 2.11.1.

## Specific Changes

- Bumped to [`adaptivecards@2.11.1`](https://npmjs.com/package/adaptivecards)
- Fixed some tests positively impacted by accessibility fixes done in Adaptive Cards library
   - `accessibility.adaptiveCard.disabled.inputs.html`: Button group container now become tabbable through `tabindex="0"`
   - `accessibility.adaptiveCard.disabled.focus.withShowCard.html`: "Show card" button no longer causes other buttons in the same card to be unable to focus
- Improved reliability of some tests related to live region narrations
   - We use `useEffect` to render something which we would expect in tests
   - Rather than calling `expect` immediately, we should use `waitFor` those expectations

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
