### PR TITLE
[HIGH] Bump to 4.15.6-0 and update servicing plan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.5",
+  "version": "4.15.6-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.5",
+      "version": "4.15.6-0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.5",
+  "version": "4.15.6-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -455,6 +455,16 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.15.5": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-es5.js",
+          "sha384-t278QukjDZq/zQN4GdMwm+wPjb3glhiqydECL5o9le9PfgGwgACfwkARzlGj6GeI"
+        ]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "hosted": {
       "assets": [
         [


### PR DESCRIPTION
# Checklist

## Build

1. [x] ~Bump MockBot to Bot Framework SDK release 4.15.5~ (not needed for patch release)
   - https://www.npmjs.com/package/botbuilder/v/latest
1. [x] ~Bump `botframework-directlinejs` to `x.y.z`~ (no newer version)
1. [x] Bump to `4.15.5`
   - [x] Update `CHANGELOG.md` to mark specific changes in `4.15.5`
   - [x] Run `npm version --no-git-tag-version 4.15.5`
   - [x] Merged into `main`, the PR number is #4521
   - Commit is `df55e01`
   - Do not merge any other unrelated changes after this PR. Any other PR merged, will need to be re-tested
1. [x] Run daily pipeline manually, set "generate release version number" to `true`
   - (This will not push to NPM or CDN)
   - Pipeline name is `BotFramework-WebChat-daily`
   - The build number is [`329656`](https://dev.azure.com/fuselabs/BotFramework-WebChat/_build/results?buildId=329656&view=results) and commit is `df55e01`
1. [x] Wait for [`WebChat-release-testing` pipeline](https://fuselabs.visualstudio.com/BotFramework-WebChat/_release?_a=releases&view=mine&definitionId=17) to complete
   - Pipeline name is `Push-Release-Testing-to-GitHub-Pages`
   - The release ID is [`436`](https://dev.azure.com/fuselabs/BotFramework-WebChat/_releaseProgress?_a=release-pipeline-progress&releaseId=3067)
1. [x] Check component governance and make sure there are no high/critical related to code under `/packages/` folder
   - There could be some for projects under `/samples/` folder, as they are pointing to previous version of Web Chat
1. [x] Add manual tests to `WebChat-release-testing` as needed

## Test

> The test should run against the build artifacts from Azure Pipelines.

1. [x] Manual testing on major browsers using `webchat-release-testing`
   - [x] Before starting testing, update all the browser version to latest
   - [x] Chrome 107.0.5304.107
   - [x] Edge 109.0.1503.0
   - [x] Firefox 106.0.5
   - [x] IE11 (Windows 11 22H2 22623.891)
   - [x] macOS Safari 16.0 (17614.1.25.9.10)
   - [x] iOS Safari 16.1
   - [x] iPadOS Safari 16.1 (20B82)
   - [x] Android Chrome 107.0.5304.105
1. [x] Test specific fixes related to `4.15.5` and previous releases
   <!-- Look at [`CHANGELOG.md`](https://github.com/microsoft/BotFramework-WebChat/blob/main/CHANGELOG.md) and list out PRs that were not covered with automated tests -->

## Release

1. [x] Make sure you are on `main` ~or `qfe`~ branch, run `git status` to check
1. [x] `git pull`
1. [x] Verify `/package.json`, `/package-lock.json`, and `CHANGELOG.md` has a version of `4.15.5`
1. [x] `git log`
   - Verify the latest commit is `df55e01`
1. [x] `git tag v4.15.5`
1. [x] `git push -u upstream v4.15.5`
   - You do not need to kick off a build again, use the previous build
1. [x] Create a new GitHub release, copy entries from `CHANGELOG.md`
   - [x] Subresource Integrity can be generated by
      - From local: `for file in $(ls *.js); do echo $file $(cat $file | openssl dgst -sha384 -binary | openssl base64 -A); done`
      - From CDN: `curl -H 'Accept-Encoding: gzip' https://cdn.botframework.com/botframework-webchat/4.15.5/webchat.js | gunzip - | openssl dgst -sha384 -binary | openssl base64 -A`
   - [x] Attach assets including 3 JS files, `stats.json` and 5 tarballs
      - You can copy the artifacts from `webchat-release-testing/drops`
      - Tarballs download from npmjs
         ```
         curl -LO https://registry.npmjs.org/botframework-directlinespeech-sdk/-/botframework-directlinespeech-sdk-4.15.5.tgz
         curl -LO https://registry.npmjs.org/botframework-webchat/-/botframework-webchat-4.15.5.tgz
         curl -LO https://registry.npmjs.org/botframework-webchat-core/-/botframework-webchat-core-4.15.5.tgz
         curl -LO https://registry.npmjs.org/botframework-webchat-api/-/botframework-webchat-api-4.15.5.tgz
         curl -LO https://registry.npmjs.org/botframework-webchat-component/-/botframework-webchat-component-4.15.5.tgz
         ```
1. [x] Kick off release to NPM
   - Release name is `[[PROD]]Push-WebChat-to-npmjs`
   - The build number is [329656](https://fuselabs.visualstudio.com/BotFramework-WebChat/_build/results?buildId=329656&view=results) release number is [`43`](https://fuselabs.visualstudio.com/BotFramework-WebChat/_releaseProgress?_a=release-pipeline-progress&releaseId=3068) and commit is `df55e01`
   - [x] Verify package content then click Resume
   - [x] Retain the release indefinitely
1. [x] Kick off release to CDN (cutoff at 2PM PST, Mon-Thu only)
   1. [x] Prepare the message for approval
      - [x] ~If there are any breaking changes, explain in the email if it will affect any customers~
      - Release name is `[[PROD]]Push-WebChat-to-Prod-CDN-with-approval`
      - The build number is [`329656`](https://fuselabs.visualstudio.com/BotFramework-WebChat/_build/results?buildId=329656&view=results), release number is [`47`](https://fuselabs.visualstudio.com/BotFramework-WebChat/_releaseProgress?_a=release-pipeline-progress&releaseId=3069) and commit is `df55e01`
      - Script build number is [`320590`](https://fuselabs.visualstudio.com/BotFramework-WebChat/_build/results?buildId=320590&view=results) (this is fixed)
   1. [x] Send message to approvers
   1. [x] Retain the build indefinitely

## Post-release verification - complete within 30 minutes after release to NPM

- [x] Test using `webchat-release-testing`
   1. [x] Clone https://github.com/corinagum/WebChat-release-testing/
   1. [x] `01.create-react-app`
      1. [x] Nuke `01.create-react-app/node_modules`
      1. [x] `npm install`
      1. [x] `npm install botframework-webchat@4.15.5` (just install the bundle package)
      1. [x] `npm run build`
   1. [x] Others
      -  Using script tags from https://github.com/microsoft/BotFramework-WebChat/releases/tag/v4.15.5, with subresource integrity
         ```html
         <script
           crossorigin="anonymous"
           integrity="sha384-yZ3Ugoikjn2nnqUATWlZR3e2PfDz/fopbI/J77anxs6pnoauHENVS3hObWSAOxmr"
           src="https://cdn.botframework.com/botframework-webchat/4.15.5/webchat.js"
         ></script>

         <script
           crossorigin="anonymous"
           integrity="sha384-t278QukjDZq/zQN4GdMwm+wPjb3glhiqydECL5o9le9PfgGwgACfwkARzlGj6GeI"
           src="https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-es5.js"
         ></script>

         <script
           crossorigin="anonymous"
           integrity="sha384-L/K5c9oKPS2+VbgxTOXnHL/fQQg9G+agAc1eB3I3t/+XnXdGHOqs8kMB9ViQTSMQ"
           src="https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-minimal.js"
         ></script>
         ```
   1. [x] `npx serve` (at repo root)
   1. [x] Go to http://localhost:5000/ to test, including IE11

## Notification to interested parties

- [x] Update partner page on Adaptive Cards doc
   - https://docs.microsoft.com/en-us/adaptive-cards/resources/partners
   - PR at https://github.com/MicrosoftDocs/AdaptiveCards/pull/486
- [x] Notify related parties for the following fixes
   - [x] Power Virtual Agents
   - [x] Omnichannel
   - [x] Pooja/Zhipeng
- [x] ~Update root README.md with feature notes -- Note: PR will be combined with post-release checklist PR~
   
---

# Post-release checklist

These are chores that we should do before starting the cycle to reduce ripple effects if we do it in mid-cycle.

Tips: 

- Clean your repo before start
- Remove `node_modules` from all folder
   - `git clean -fdx`
- Never delete `package-lock.json`
- If you mess it up, tableflip and redo
- In `component/package.json`
   - Remove reference to `botframework-webchat-core` by hand-modifying `package.json`
   - Then, `npm install` (symlinks will be broken afterward)
   - Then, add those references back by hand-modifying `package.json`
   - This also applies for other packages with similar dependencies/symlinks
   - To build afterward, do tableflip to rebuild those symlinks

## Applies to all releases

> This list should be copied to versions in the future.

- [x] ~If on QFE branch, make sure `CHANGELOG.md` and version number bump is cherry-picked to `main`~
   - [x] ~`git checkout main`~
   - [x] ~`git cherry-pick XXX` (the commitish for bumping version number and `CHANGELOG.md`)~
- [x] ~If needed, correct the date for 4.15.5 in `CHANGELOG.md` in PR #XXX~
   - ~There could be last minute fixes that could push the planned date later than the one in `CHANGELOG.md`~
- [x] Bump `package.json` to `4.15.6-0` in PR #4524
   - Run `npm version prepatch --no-git-tag-version`
- [x] Update [`servicingPlan.json`](https://github.com/microsoft/BotFramework-WebChat/blob/main/packages/embed/servicingPlan.json) in PR #4524
   - Add deprecation notes for previous versions
   - Subresource integrity hash from https://github.com/microsoft/BotFramework-WebChat/releases/tag/v4.15.5
- [x] ~Update all samples to use `4.15.5` in PR #XXXX~
   - Some samples are pointing to GitHub Releases because the sample need new features from daily build
   - Search "https://github.com/microsoft/BotFramework-WebChat/releases/download/"
      - And replace with "https://cdn.botframework.com/botframework-webchat/latest/"
- [ ] Clean up unnecessary branch on official repo
- [x] Understand production-hitting vulnerabilities
   - [x] Create a new folder
   - [x] Run `npm init` with default values
   - [x] Run `npm install botframework-webchat@4.15.5`
   - [x] Look at the result and see if there are any production-hitting vulnerabilities, investigate if needed
      - No vulnerabilities found
- [x] ~Bump in Power Virtual Agents~

## Applies to major/minor releases

### Bump all dependencies to latest version

In PR #4423, we are bumping most dependencies to latest version.

> After bumping, if a package broke compatibility, we should investigate:
>
> - Upgrade our code to use the latest package if possible, otherwise;
> - Add it to `package.json/skipBump` to prevent bumping deliberately:
>    - Skipping bump incur unpredictable technical debts, say, security issue found in the unsupported version, causing us slow to react
>    - Plausible reasons (non-exhaustive):
>       - Package is not ES5;
>       - Package is ESM and requires the whole dependency chain to be upgraded, however, it is technically impossible (unrelated to cost).

- [ ] Run `npm run bump`
- [ ] Run `npm audit fix` to make sure everything is fixed
- [ ] Test under IE11 to make sure all dependencies are working
- [ ] List steps to verify bumping `microsoft-cognitiveservices-speech-sdk`

### Update CI/CD pipeline to use latest images

Some pipelines are still using `windows-2016` image which will be deprecated soon, we need to update them.

- [ ] [CD pipeline](https://fuselabs.visualstudio.com/BotFramework-WebChat/_release?definitionId=5&view=mine&_a=releases) to `windows-latest`

### Bump Docker image

> The Docker image can be found at root `docker-compose.yml` and `Dockerfile*`.

- [x] ~Docker container for headless Chrome (#XXX)~
   - They recently moved from `3.14.159-xxx` tag scheme to a more sensible `87.0` tag scheme
   - Tags can be found at https://hub.docker.com/r/selenium/node-chrome/tags
   - Preferably in separate PR because screenshots change can be large occasionally
   - Run tests locally, as the screenshots can be slightly different
   - Also consider bumping to Edge-based images
