### PR TITLE
Bump to 4.15.7-0 and update servicingPlan.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.6",
+  "version": "4.15.7-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.6",
+      "version": "4.15.7-0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.6",
+  "version": "4.15.7-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -422,6 +422,7 @@
           "sha384-9o6xJEK8DboSm23+cyRi/6ROyiQFbCXgSN+GkpMXVtIC0QeYRPA9lD8MlXPikyub"
         ]
       ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-05-09.",
       "private": true,
       "versionFamily": "4"
     },
@@ -432,6 +433,7 @@
           "sha384-lUORlicC7NzeZQx9OQ8/uCjmblHgyo9cOV4Q4UlnTct4AXwWzNiS5+4w3rCcO/h5"
         ]
       ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-08-10.",
       "private": true,
       "versionFamily": "4"
     },
@@ -442,6 +444,7 @@
           "sha384-G/4GhuAj4f+IvvVgyTT1u6m5DjjdPI7hcrfgXmnWKC6uWtZkrI+jDkVk2MmJoclR"
         ]
       ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-09-15.",
       "private": true,
       "versionFamily": "4"
     },
@@ -452,6 +455,7 @@
           "sha384-9pDJTvPL0wLKBbhzIDeYtyOXpMQgf3VVqPMKPWKTs+p/J8oOqOEy0piRhj9Atlzz"
         ]
       ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-11-16.",
       "private": true,
       "versionFamily": "4"
     },
@@ -460,6 +464,17 @@
         [
           "https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-es5.js",
           "sha384-t278QukjDZq/zQN4GdMwm+wPjb3glhiqydECL5o9le9PfgGwgACfwkARzlGj6GeI"
+        ]
+      ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2024-12-01.",
+      "private": true,
+      "versionFamily": "4"
+    },
+    "4.15.6": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-es5.js",
+          "sha384-Ik2jNknNTBCaI/NP3GRMfDCWKnApGSdYMcdA6EtEJkL1LtUZEdNdjeNkfZZk3UlS"
         ]
       ],
       "private": true,

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -473,7 +473,7 @@
     "4.15.6": {
       "assets": [
         [
-          "https://cdn.botframework.com/botframework-webchat/4.15.5/webchat-es5.js",
+          "https://cdn.botframework.com/botframework-webchat/4.15.6/webchat-es5.js",
           "sha384-Ik2jNknNTBCaI/NP3GRMfDCWKnApGSdYMcdA6EtEJkL1LtUZEdNdjeNkfZZk3UlS"
         ]
       ],


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4535.

## Changelog Entry

(No CHANGELOG for version bump and servicing plan)

## Description

After release of 4.15.6, Update `package.json`/`package-lock.json` to 4.15.7-0.

Also add 4.15.6 to `servicingPlan.json`.

## Design

This is for post-release.

## Specific Changes

- Run `npm version --no-git-tag-version prepatch`
- Update `servicingPlan.json` with `4.15.6`
- Add deprecation notes for previous versirons

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
