### PR TITLE
Add rel="noopener noreferrer" to sample 05.custom-components/e.card-components

### DIFF
--- a/samples/05.custom-components/e.card-components/README.md
+++ b/samples/05.custom-components/e.card-components/README.md
@@ -81,7 +81,7 @@ Next, add the GitHub octocat svg and pull in information from `props` in our anc
 +   <div style={{ fontFamily: '\'Calibri\', \'Helvetica Neue\', Arial, sans-serif', margin: 20, textAlign: 'center' }}>
 +     <svg height="64" viewBox="0 0 16 16" version="1.1" width="64" aria-hidden="true"><path fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
       <p>
-+       <a href={ `https://github.com/${ encodeURI(props.owner) }/${ encodeURI(props.repo) }` } target="_blank">{ props.owner }/<br />{ props.repo }</a>
++       <a href={ `https://github.com/${ encodeURI(props.owner) }/${ encodeURI(props.repo) }` } rel="noopener noreferrer" target="_blank">{ props.owner }/<br />{ props.repo }</a>
       </p>
     </div>;
 ```

--- a/samples/05.custom-components/e.card-components/index.html
+++ b/samples/05.custom-components/e.card-components/index.html
@@ -43,7 +43,11 @@
             ></path>
           </svg>
           <p>
-            <a href={`https://github.com/${encodeURI(props.owner)}/${encodeURI(props.repo)}`} target="_blank">
+            <a
+              href={`https://github.com/${encodeURI(props.owner)}/${encodeURI(props.repo)}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               {props.owner}/<br />
               {props.repo}
             </a>


### PR DESCRIPTION
> Fixes #4564.

## Changelog Entry

(No CHANGELOG for patching samples)

## Description

The sample contains some HTML code snippets of `<a>`.

We should promote security by adding `rel="noopener noreferrer"`.

## Specific Changes

- Update README.md and code snippet with `rel="noopener noreferrer"`.

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] Security reviewed (no data URIs, check for nonce leak)
-  [x] ~Tests reviewed (coverage, legitimacy)~
