### PR TITLE
[HIGH] Unset `forced-colors` after running accessibility.liveRegion.activityStatus.sendFailed.contrast test

### DIFF
--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.contrast.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.contrast.html
@@ -16,12 +16,8 @@
           const directLine = testHelpers.createDirectLineEmulator(store);
 
           await host.sendDevToolsCommand('Emulation.setEmulatedMedia', {
-          features: [
-            {
-              name: 'forced-colors',
-              value: 'active'
-            }
-          ]});
+            features: [{ name: 'forced-colors', value: 'active' }]
+          });
 
           WebChat.renderWebChat(
             {
@@ -37,29 +33,21 @@
 
           await pageConditions.uiConnected();
 
-          const { disconnect, flush } = pageObjects.observeLiveRegion();
+          const sendMessage = await directLine.emulateOutgoingActivity('Hello, World!');
 
-          try {
-            const sendMessage = await directLine.emulateOutgoingActivity('Hello, World!');
+          await directLine.emulateIncomingActivity('Aloha!');
 
-            await directLine.emulateIncomingActivity('Aloha!');
+          sendMessage.rejectPostActivity(new Error('artificial error'));
 
-            sendMessage.rejectPostActivity(new Error('artificial error'));
+          await pageConditions.became(
+            'failed to send message',
+            () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
+            1000
+          );
 
-            await pageConditions.became(
-              'failed to send message',
-              () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
-              1000
-            );
-            
-          } finally {
-            
-            await host.snapshot();
-
-            disconnect();
-          }
+          await host.snapshot();
         },
-        { ignoreErrors: true }
+        { ignoreErrors: 'artificial error' }
       );
     </script>
   </body>

--- a/packages/test/harness/src/browser/globals/run.js
+++ b/packages/test/harness/src/browser/globals/run.js
@@ -10,15 +10,18 @@ export default function () {
 
       // Run the test, signal start by host.ready().
       // On success or failure, call host.done() or host.error() correspondingly.
-      return host
-        .sendDevToolsCommand('Emulation.setEmulatedMedia', {
-          // Setting "value" to "" (empty string) does not unset "forced-colors".
-          features: [{ name: 'forced-colors', value: 'none' }]
-        })
-        .then(host.ready)
-        .then(fn)
-        .then(() => host.done(doneOptions))
-        .catch(host.error);
+      // This function will be executed in both Jest and "npm run browser".
+      return (
+        host
+          // Previous run may have enabled "forced-colors", we should unset it.
+          .sendDevToolsCommand('Emulation.setEmulatedMedia', {
+            features: [{ name: 'forced-colors', value: '' }]
+          })
+          .then(host.ready)
+          .then(fn)
+          .then(() => host.done(doneOptions))
+          .catch(host.error)
+      );
     })
   );
 }

--- a/packages/test/harness/src/browser/globals/run.js
+++ b/packages/test/harness/src/browser/globals/run.js
@@ -17,6 +17,8 @@ export default function () {
           .sendDevToolsCommand('Emulation.setEmulatedMedia', {
             features: [{ name: 'forced-colors', value: '' }]
           })
+          // Some tests may have changed the time zone, we should unset it.
+          .then(() => host.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'Etc/UTC' }))
           .then(host.ready)
           .then(fn)
           .then(() => host.done(doneOptions))

--- a/packages/test/harness/src/browser/globals/run.js
+++ b/packages/test/harness/src/browser/globals/run.js
@@ -10,7 +10,11 @@ export default function () {
 
       // Run the test, signal start by host.ready().
       // On success or failure, call host.done() or host.error() correspondingly.
-      return Promise.resolve()
+      return host
+        .sendDevToolsCommand('Emulation.setEmulatedMedia', {
+          // Setting "value" to "" (empty string) does not unset "forced-colors".
+          features: [{ name: 'forced-colors', value: 'none' }]
+        })
         .then(host.ready)
         .then(fn)
         .then(() => host.done(doneOptions))

--- a/packages/test/harness/src/host/dev/index.js
+++ b/packages/test/harness/src/host/dev/index.js
@@ -64,7 +64,6 @@ async function main() {
     process.once('SIGTERM', terminate);
 
     try {
-      await webDriver.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'Etc/UTC' });
       // eslint-disable-next-line no-magic-numbers
       await webDriver.get(process.argv[2] || 'http://localhost:5080/');
 

--- a/packages/test/harness/src/host/jest/runHTML.js
+++ b/packages/test/harness/src/host/jest/runHTML.js
@@ -52,10 +52,6 @@ global.runHTML = async function runHTML(url, options = DEFAULT_OPTIONS) {
 
     global.__operation__ = `loading URL ${absoluteURL.toString()}`;
 
-    await webDriver.sendDevToolsCommand('Emulation.setEmulatedMedia', {
-      // Setting "value" to "" (empty string) does not unset "forced-colors".
-      features: [{ name: 'forced-colors', value: 'none' }]
-    });
     await webDriver.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'Etc/UTC' });
     await webDriver.get(absoluteURL);
 

--- a/packages/test/harness/src/host/jest/runHTML.js
+++ b/packages/test/harness/src/host/jest/runHTML.js
@@ -52,7 +52,6 @@ global.runHTML = async function runHTML(url, options = DEFAULT_OPTIONS) {
 
     global.__operation__ = `loading URL ${absoluteURL.toString()}`;
 
-    await webDriver.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'Etc/UTC' });
     await webDriver.get(absoluteURL);
 
     global.__operation__ = 'setting class name for body element';

--- a/packages/test/harness/src/host/jest/runHTML.js
+++ b/packages/test/harness/src/host/jest/runHTML.js
@@ -52,6 +52,10 @@ global.runHTML = async function runHTML(url, options = DEFAULT_OPTIONS) {
 
     global.__operation__ = `loading URL ${absoluteURL.toString()}`;
 
+    await webDriver.sendDevToolsCommand('Emulation.setEmulatedMedia', {
+      // Setting "value" to "" (empty string) does not unset "forced-colors".
+      features: [{ name: 'forced-colors', value: 'none' }]
+    });
     await webDriver.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'Etc/UTC' });
     await webDriver.get(absoluteURL);
 


### PR DESCRIPTION
> Fixes #4569.

## Changelog Entry

### Fixed

-  Fixes [#4569](https://github.com/microsoft/BotFramework-WebChat/issues/4569). Before running test, high contrast mode should be reset, by [@compulim](https://github.com/compulim) in PR [#4570](https://github.com/microsoft/BotFramework-WebChat/pull/4570)

## Description

After running `accessibility.liveRegion.activityStatus.sendFailed.contrast` test, it enabled high contrast mode for subsequent browser sessions.

As we recycle browser sessions (teardown after 5 runs or 5 minutes), this pollutes other tests.

Some other tests also polluted time zone in `npm run browser`. So, time zone is also reset consistently before each run.

## Design

We should reset `Emulation.setEmulatedMedia/forced-colors` before every run.

"Before every run" is better than "after every run" because we can continue to debug in high contrast mode during `npm run browser` environment until next run.

We are moving all reset logics to `testharness/src/browser/globals/run.js` for consistency.

Today, we have a few places to reset an environment:
- (Obsoleted) Dev `host/dev/index.js` (in Node VM), these resets only run at start of `npm run browser`, they will be moved away
- (Obsoleted) Jest `host/jest/runHTML.js` (in Jest VM), these resets will be moved away
- (New) `browser/globals/run.js` (in HTML VM), these resets run before every test
- (Kept) Jest `host/jest-server/index.js/prepareSession`, these resets are for "resetting after browser session return to the pool", these should be very generic resets that fits everyone and not specific to Web Chat

## Specific Changes

- In `testharness/src/browser/globals/run.js`, unset `Emulation.setEmulatedMedia` and `Emulation.setTimezoneOverride`
- Remove `Emulation.setTimezoneOverride` from other places

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
