### PR TITLE
Add aria-labelledby and move button up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Fixes [#4558](https://github.com/microsoft/BotFramework-WebChat/issues/4558). In high contrast mode, "Retry" link button should use link color as defined by [CSS System Colors](https://w3c.github.io/csswg-drafts/css-color/#css-system-colors), by [@beyackle2](https://github.com/beyackle2) in PR [#4537](https://github.com/microsoft/BotFramework-WebChat/pull/4537)
 -  Fixes [#4566](https://github.com/microsoft/BotFramework-WebChat/issues/4566). For YouTube and Vimeo `<iframe>`, add `sandbox="allow-same-origin allow-scripts"`, by [@compulim](https://github.com/compulim) in PR [#4567](https://github.com/microsoft/BotFramework-WebChat/pull/4567)
--  Fixes [#4561](https://github.com/microsoft/BotFramework-WebChat/issues/4561). Header title of keyboard help dialog should be the `aria-labelledby` of the dialog and close button should be the first element of the header, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#4561](https://github.com/microsoft/BotFramework-WebChat/issues/4561). Header title of keyboard help dialog should be the `aria-labelledby` of the dialog and close button should be the first element of the header, by [@compulim](https://github.com/compulim) in PR [#4609](https://github.com/microsoft/BotFramework-WebChat/pull/4609)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Fixes [#4558](https://github.com/microsoft/BotFramework-WebChat/issues/4558). In high contrast mode, "Retry" link button should use link color as defined by [CSS System Colors](https://w3c.github.io/csswg-drafts/css-color/#css-system-colors), by [@beyackle2](https://github.com/beyackle2) in PR [#4537](https://github.com/microsoft/BotFramework-WebChat/pull/4537)
 -  Fixes [#4566](https://github.com/microsoft/BotFramework-WebChat/issues/4566). For YouTube and Vimeo `<iframe>`, add `sandbox="allow-same-origin allow-scripts"`, by [@compulim](https://github.com/compulim) in PR [#4567](https://github.com/microsoft/BotFramework-WebChat/pull/4567)
+-  Fixes [#4561](https://github.com/microsoft/BotFramework-WebChat/issues/4561). Header title of keyboard help dialog should be the `aria-labelledby` of the dialog and close button should be the first element of the header, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Changed
 

--- a/__tests__/html/accessibility.keyboardHelp.ariaLabel.html
+++ b/__tests__/html/accessibility.keyboardHelp.ariaLabel.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const store = testHelpers.createStore();
+
+        const directLine = testHelpers.createDirectLineEmulator(store);
+
+        WebChat.renderWebChat({ directLine, store }, document.getElementById('webchat'));
+
+        await pageConditions.uiConnected();
+
+        // SETUP: The focus should be on `document.body` initially.
+        await pageConditions.focusOn(document.body, 'document body');
+
+        // WHEN: TAB key is pressed.
+        await host.sendTab();
+
+        // THEN: It should focus on the close button.
+        await pageConditions.focusOn(pageElements.keyboardHelpScreenCloseButton(), 'keyboard help screen close button');
+
+        // THEN: The keyboard help screen dialog should have either `aria-label` or `aria-labelledby` saying "Keyboard controls".
+        const dialogElement = pageElements.keyboardHelpScreenCloseButton().closest('[role="dialog"]');
+
+        const ariaLabel = dialogElement.getAttribute('aria-label') || document.getElementById(dialogElement.getAttribute('aria-labelledby'))?.innerText;
+
+        expect(ariaLabel).toBe('Keyboard controls');
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/accessibility.keyboardHelp.ariaLabel.js
+++ b/__tests__/html/accessibility.keyboardHelp.ariaLabel.js
@@ -1,0 +1,5 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('keyboard help screen', () => {
+  test('should have a label', () => runHTML('accessibility.keyboardHelp.ariaLabel'));
+});

--- a/packages/component/src/Transcript/KeyboardHelp.tsx
+++ b/packages/component/src/Transcript/KeyboardHelp.tsx
@@ -7,6 +7,7 @@ import type { FC } from 'react';
 
 import useFocus from '../hooks/useFocus';
 import useStyleSet from '../hooks/useStyleSet';
+import useUniqueId from '../hooks/internal/useUniqueId';
 
 const { useLocalizer } = hooks;
 
@@ -37,6 +38,7 @@ const KeyboardHelp: FC<{}> = () => {
   const [{ keyboardHelp: keyboardHelpStyleSet }] = useStyleSet();
   const [shown, setShown] = useState(false);
   const focus = useFocus();
+  const headerLabelId = useUniqueId('webchat__keyboard-help__header');
   const localize = useLocalizer();
 
   const chatHistoryAccessItemsInMessageBody = localize('KEYBOARD_HELP_CHAT_HISTORY_ACCESS_ITEMS_IN_MESSAGE_BODY');
@@ -84,6 +86,7 @@ const KeyboardHelp: FC<{}> = () => {
     <div
       // When the dialog is not shown, "aria-hidden" helps to prevent scan mode from able to scan the content of the dialog.
       aria-hidden={!shown}
+      aria-labelledby={headerLabelId}
       className={classNames('webchat__keyboard-help', keyboardHelpStyleSet + '', {
         // Instead of using "hidden" attribute, we are using CSS to hide the dialog.
         // - When using "hidden", the close button will not be tabbable because it is pseudo removed from the DOM
@@ -96,27 +99,31 @@ const KeyboardHelp: FC<{}> = () => {
     >
       <div className="webchat__keyboard-help__box">
         <header>
-          <h2 className="webchat__keyboard-help__header">{header}</h2>
-        </header>
-        <button
-          aria-label={closeButtonAlt}
-          className="webchat__keyboard-help__close-button"
-          onClick={handleCloseButtonClick}
-          onFocus={handleCloseButtonFocus}
-          onKeyDown={handleCloseButtonKeyDown}
-          type="button"
-        >
-          <svg
-            className="webchat__keyboard-help__close-button_image"
-            // "focusable" attribute is only available in IE11 and "tabIndex={-1}" does not work.
-            focusable={false}
-            role="presentation"
-            viewBox="0 0 2048 2048"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-label={closeButtonAlt}
+            className="webchat__keyboard-help__close-button"
+            onClick={handleCloseButtonClick}
+            onFocus={handleCloseButtonFocus}
+            onKeyDown={handleCloseButtonKeyDown}
+            type="button"
           >
-            <path d="M2048 136l-888 888 888 888-136 136-888-888-888 888L0 1912l888-888L0 136 136 0l888 888L1912 0l136 136z" />
-          </svg>
-        </button>
+            <svg
+              className="webchat__keyboard-help__close-button_image"
+              // "focusable" attribute is only available in IE11 and "tabIndex={-1}" does not work.
+              focusable={false}
+              role="presentation"
+              viewBox="0 0 2048 2048"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M2048 136l-888 888 888 888-136 136-888-888-888 888L0 1912l888-888L0 136 136 0l888 888L1912 0l136 136z" />
+            </svg>
+          </button>
+          {/* "id" attribute is required when using "aria-labelledby". */}
+          {/* eslint-disable-next-line react/forbid-dom-props */}
+          <h2 className="webchat__keyboard-help__header" id={headerLabelId}>
+            {header}
+          </h2>
+        </header>
         <article className="webchat__keyboard-help__section">
           <header>
             <h3 className="webchat__keyboard-help__sub-header">{chatWindowHeader}</h3>


### PR DESCRIPTION
> Fixes #4609.

## Changelog Entry

### Fixed

-  Fixes [#4561](https://github.com/microsoft/BotFramework-WebChat/issues/4561). Header title of keyboard help dialog should be the `aria-labelledby` of the dialog and close button should be the first element of the header, by [@compulim](https://github.com/compulim) in PR [#4609](https://github.com/microsoft/BotFramework-WebChat/pull/4609)

## Description

We should have `aria-label` or `aria-labelledby` for the dialog header.

We should put close button (`<button>`) before the dialog header (`<h2>`). So, when the end-user press <kbd>DOWN</kbd> arrow key from the close button, screen reader would narrate "Keyboard controls".

## Design

Assume the screen reader cursor lands on the close button thru <kbd>TAB</kbd>, when the user press <kbd>DOWN</kbd> to instruct the screen reader to read the content (of the dialog), the user expects the screen reader to narrate the title of the dialog.

This means, close button would need to locate in front of the `<h2>`.

However, when the screen reader cursor lands on the close button from the transcript (or out of page), since the button resides inside the dialog, screen reader will narrate landmark role as well. Screen reader will narrate "keyboard controls dialog banner header close button". Then, when <kbd>DOWN</kbd> is pressed, it will narrate "heading level 2 keyboard controls".

I think both narration design is compliant to ARIA. This is just matter of taste.

The following video shows accessibility experience with this pull request.

https://user-images.githubusercontent.com/1622400/211921369-147600df-e1c0-4b22-86c7-a25a4c731d5c.mp4

In the future, we could consider using `<dialog>`/`HTMLDialogElement` to host the dialog. This needs more investigation.

## Specific Changes

- Add `aria-labelledby` to `<div role="dialog">` and points it to `<h2>`
- Move `<button>` inside the `<header>` container and before the `<h2>`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
