### PR TITLE
Ersuo/adding send status telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Added function to emit status change telemetry event for activities. PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631) [@Erli-ms](https://github.com/Erli-ms)
-
-### Added
+-  Added function to emit status change telemetry event for activities, by [@Erli-ms](https://github.com/Erli-ms), in PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631)
 
 -  Added ability for developers to customize Web Chat by extending the default UI without having to re-implement existing components. [@dawolff-ms](https://github.com/dawolff-ms) in PR [#4539](https://github.com/microsoft/BotFramework-WebChat/pull/4539)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Added function to emit status change telemetry event for activities. PR [#4627](https://github.com/microsoft/BotFramework-WebChat/pull/4627) [@Erli-ms](https://github.com/Erli-ms)
+-  Added function to emit status change telemetry event for activities. PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631) [@Erli-ms](https://github.com/Erli-ms)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Added function to emit status change telemetry event for activities, by [@Erli-ms](https://github.com/Erli-ms), in PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631)
 
--  Added ability for developers to customize Web Chat by extending the default UI without having to re-implement existing components. [@dawolff-ms](https://github.com/dawolff-ms) in PR [#4539](https://github.com/microsoft/BotFramework-WebChat/pull/4539)
+-  Added ability for developers to customize Web Chat by extending the default UI without having to re-implement existing components, by [@dawolff-ms](https://github.com/dawolff-ms), in PR [#4539](https://github.com/microsoft/BotFramework-WebChat/pull/4539)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+-  Added function to emit status change telemetry event for activities. PR [#4627](https://github.com/microsoft/BotFramework-WebChat/pull/4627) [@Erli-ms](https://github.com/Erli-ms)
+
+### Added
+
 -  Added ability for developers to customize Web Chat by extending the default UI without having to re-implement existing components. [@dawolff-ms](https://github.com/dawolff-ms) in PR [#4539](https://github.com/microsoft/BotFramework-WebChat/pull/4539)
 
 ### Fixed

--- a/__tests__/hooks/useTrackDimension.js
+++ b/__tests__/hooks/useTrackDimension.js
@@ -37,12 +37,18 @@ describe('useTrackDimension', () => {
     await pageObjects.runHook('useTrackDimension', [], trackDimension => trackDimension('hello', 'aloha'));
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('ping'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements.length)).resolves.toBe(1);
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping').length)
+    ).resolves.toBe(1);
 
     await pageObjects.runHook('useTrackDimension', [], trackDimension => trackDimension('hello'));
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('ping2'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() =>
+        window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping' || name === 'ping2')
+      )
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -81,7 +87,9 @@ describe('useTrackDimension', () => {
     await pageObjects.runHook('useTrackDimension', [], trackDimension => trackDimension(123, 'hello'));
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('ping'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -105,7 +113,9 @@ describe('useTrackDimension', () => {
     await pageObjects.runHook('useTrackDimension', [], trackDimension => trackDimension('hello', 123));
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('ping'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,

--- a/__tests__/hooks/useTrackDimension.js
+++ b/__tests__/hooks/useTrackDimension.js
@@ -15,7 +15,7 @@ describe('useTrackDimension', () => {
           const { data, dimensions, duration, error, name, type } = event;
 
           name !== 'init' &&
-            (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+            window.WebChatTest.telemetryMeasurements.push({
               data,
               dimensions,
               duration,
@@ -24,6 +24,9 @@ describe('useTrackDimension', () => {
               type
             });
         }
+      },
+      setup: () => {
+        window.WebChatTest.telemetryMeasurements = [];
       }
     });
 

--- a/__tests__/hooks/useTrackEvent.js
+++ b/__tests__/hooks/useTrackEvent.js
@@ -37,7 +37,9 @@ describe('useTrackEvent', () => {
   test('should track simple event', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('hello'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -61,7 +63,9 @@ describe('useTrackEvent', () => {
   test('should track simple event using info explicitly', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent.info('hello'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -85,7 +89,9 @@ describe('useTrackEvent', () => {
   test('should track numeric event', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent.warn('hello', 123));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": 123,
@@ -109,7 +115,9 @@ describe('useTrackEvent', () => {
   test('should track numeric event', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent.debug('hello', 'aloha'));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": "aloha",
@@ -133,7 +141,9 @@ describe('useTrackEvent', () => {
   test('should track complex event', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent.error('hello', { one: 1, hello: 'aloha' }));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": Object {
@@ -160,18 +170,24 @@ describe('useTrackEvent', () => {
   test('should not track event with boolean data', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('hello', true));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toBeFalsy();
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toHaveLength(0);
   });
 
   test('should not track event with incompatible complex data', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent('hello', { truthy: true }));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toBeFalsy();
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toHaveLength(0);
   });
 
   test('should not track event with invalid name', async () => {
     await pageObjects.runHook('useTrackEvent', [], trackEvent => trackEvent(123));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toBeFalsy();
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'hello'))
+    ).resolves.toHaveLength(0);
   });
 });

--- a/__tests__/hooks/useTrackEvent.js
+++ b/__tests__/hooks/useTrackEvent.js
@@ -15,7 +15,7 @@ describe('useTrackEvent', () => {
           const { data, dimensions, duration, error, level, name, type } = event;
 
           name !== 'init' &&
-            (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+            window.WebChatTest.telemetryMeasurements.push({
               data,
               dimensions,
               duration,
@@ -25,6 +25,9 @@ describe('useTrackEvent', () => {
               type
             });
         }
+      },
+      setup: () => {
+        window.WebChatTest.telemetryMeasurements = [];
       }
     });
 

--- a/__tests__/hooks/useTrackException.js
+++ b/__tests__/hooks/useTrackException.js
@@ -19,7 +19,7 @@ describe('useTrackException', () => {
               data,
               dimensions,
               duration,
-              error: error.message,
+              error: error?.message,
               fatal,
               name,
               type
@@ -37,7 +37,8 @@ describe('useTrackException', () => {
   test('should track exception', async () => {
     await pageObjects.runHook('useTrackException', [], trackException => trackException(new Error('artificial error')));
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ error }) => error)))
+      .resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -63,7 +64,8 @@ describe('useTrackException', () => {
       trackException(new Error('non-fatal error'), false)
     );
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ error }) => error)))
+      .resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,

--- a/__tests__/hooks/useTrackException.js
+++ b/__tests__/hooks/useTrackException.js
@@ -15,7 +15,7 @@ describe('useTrackException', () => {
           const { data, dimensions, duration, error, fatal, name, type } = event;
 
           name !== 'init' &&
-            (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+            window.WebChatTest.telemetryMeasurements.push({
               data,
               dimensions,
               duration,
@@ -25,6 +25,9 @@ describe('useTrackException', () => {
               type
             });
         }
+      },
+      setup: () => {
+        window.WebChatTest.telemetryMeasurements = [];
       }
     });
 

--- a/__tests__/hooks/useTrackTiming.js
+++ b/__tests__/hooks/useTrackTiming.js
@@ -15,7 +15,7 @@ describe('useTrackTiming', () => {
           const { data, dimensions, duration, error, name, type } = event;
 
           name !== 'init' &&
-            (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+            window.WebChatTest.telemetryMeasurements.push({
               data,
               dimensions,
               duration,
@@ -25,10 +25,13 @@ describe('useTrackTiming', () => {
             });
         }
       },
-      setup: () =>
+      setup: () => {
         window.WebChatTest.loadScript('https://unpkg.com/lolex@4.0.1/lolex.js').then(() => {
           window.WebChatTest.clock = lolex.install();
-        })
+        });
+
+        window.WebChatTest.telemetryMeasurements = [];
+      }
     });
 
     driver = setup.driver;
@@ -43,7 +46,9 @@ describe('useTrackTiming', () => {
       pageObjects.runHook('useTrackTiming', [], trackTiming => trackTiming('ping', () => 123))
     ).resolves.toBe(123);
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -88,7 +93,9 @@ describe('useTrackTiming', () => {
 
     await expect(driver.executeScript(() => window.WebChatTest.result)).resolves.toBe(123);
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'ping'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,

--- a/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
+++ b/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(
+        async function () {
+          const store = testHelpers.createStore();
+
+          const directLine = testHelpers.createDirectLineEmulator(store);
+          const telemetryEventTracking = [];
+          WebChat.renderWebChat(
+            {
+              directLine,
+              store,
+              styleOptions: {
+                groupTimestamp: 60000,
+                sendTimeout: 5000
+              },
+              onTelemetry: (event) => {
+                if (event?.name === 'send-status:change') {
+                  telemetryEventTracking.push(event);
+                }
+              },
+            },
+            document.getElementById('webchat')
+          );
+
+          await pageConditions.uiConnected();
+
+          await directLine.emulateIncomingActivity('Aloha!');
+
+          await pageConditions.became(
+            'send message successfully',
+            () => pageElements.activityStatuses()[0]?.innerText.indexOf('Just now') !== -1,
+            1000
+          );
+
+          expect(telemetryEventTracking.length).toEqual(0);
+        },
+        { ignoreErrors: true }
+      );
+    </script>
+  </body>
+</html>

--- a/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
+++ b/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
@@ -30,13 +30,13 @@
 
           await pageConditions.uiConnected();
 
-          //GIVEN: Simulate an ingress activity
+          // GIVEN: Simulate an ingress activity of "Aloha!".
           await directLine.emulateIncomingActivity('Aloha!');
 
-          //WHEN: The activity rendered
+          // WHEN: The activity is rendered.
           await pageConditions.numActivitiesShown(1);
 
-          //THEN: No status change event should be logged
+          // THEN: No status change event should be logged for incoming activities.
           expect(telemetryEventTracking.length).toEqual(0);
         }
       );

--- a/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
+++ b/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
@@ -19,10 +19,6 @@
             {
               directLine,
               store,
-              styleOptions: {
-                groupTimestamp: 60000,
-                sendTimeout: 5000
-              },
               onTelemetry: (event) => {
                 if (event?.name === 'send-status:change') {
                   telemetryEventTracking.push(event);
@@ -34,17 +30,15 @@
 
           await pageConditions.uiConnected();
 
+          //GIVEN: Simulate an ingress activity
           await directLine.emulateIncomingActivity('Aloha!');
 
-          await pageConditions.became(
-            'send message successfully',
-            () => pageElements.activityStatuses()[0]?.innerText.indexOf('Just now') !== -1,
-            1000
-          );
+          //WHEN: The activity rendered
+          await pageConditions.numActivitiesShown(1);
 
+          //THEN: No status change event should be logged
           expect(telemetryEventTracking.length).toEqual(0);
-        },
-        { ignoreErrors: true }
+        }
       );
     </script>
   </body>

--- a/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.js
+++ b/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.js
@@ -1,0 +1,6 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('ActivityStatusTelemetry', () => {
+  test('activity status telemetry should not be logged when incoming activity received', () =>
+    runHTML('activityStatusTelemetry.ignoreStatusChange.incomingActivity.html'));
+});

--- a/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
@@ -30,7 +30,7 @@
               name: 'test.txt'
             }
           ]
-        }
+        };
         const store = testHelpers.createStore();
 
         const directLine = testHelpers.createDirectLineEmulator(store);
@@ -39,7 +39,7 @@
         WebChat.renderWebChat(
           {
             directLine,
-            onTelemetry: (event) => {
+            onTelemetry: event => {
               if (event?.name === 'send-status:change') {
                 telemetryEventTracking.push(event.data);
               }
@@ -49,34 +49,35 @@
           document.getElementById('webchat')
         );
 
+        // GIVEN: Web Chat is connected.
         await pageConditions.uiConnected();
 
-        //GIVEN: send an attachment outgoing activity and resolve it afterwards
-        await(
-          await directLine.emulateOutgoingActivity(testAttachmentActivity)
-        ).resolveAll();
-
-        //WHEN: Activity displayed
+        // WHEN: An outgoing activity with attachments is sent.
+        await (await directLine.emulateOutgoingActivity(testAttachmentActivity)).resolveAll();
         await pageConditions.numActivitiesShown(1);
 
-        //THEN: The status change event emitted: 'undefined -> sending' and 'sending -> sent'
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'true',
-            key: expect.any(String),
-            status: 'sending',
-            type: 'message'
-          },
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'true',
-            key: expect.any(String),
-            prevStatus: 'sending',
-            status: 'sent',
-            type: 'message'
-          }
-        ]));
+        // THEN: It should emit 2 events in order:
+        //       - undefined -> sending
+        //       - sending -> sent
+        expect(telemetryEventTracking).toEqual(
+          expect.arrayContaining([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'true',
+              key: expect.any(String),
+              status: 'sending',
+              type: 'message'
+            },
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'true',
+              key: expect.any(String),
+              prevStatus: 'sending',
+              status: 'sent',
+              type: 'message'
+            }
+          ])
+        );
       });
     </script>
   </body>

--- a/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
@@ -34,49 +34,50 @@
         const store = testHelpers.createStore();
 
         const directLine = testHelpers.createDirectLineEmulator(store);
-
         const telemetryEventTracking = [];
+
         WebChat.renderWebChat(
           {
             directLine,
-            store,
             onTelemetry: (event) => {
-              telemetryEventTracking.push(event);
+              if (event?.name === 'send-status:change') {
+                telemetryEventTracking.push(event.data);
+              }
             },
-            styleOptions: {
-              sendTimeout: 5000
-            }
+            store
           },
           document.getElementById('webchat')
         );
 
         await pageConditions.uiConnected();
 
-        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity(testAttachmentActivity);
-        await sendMessage1stAttempt.echoBack();
-        sendMessage1stAttempt.resolvePostActivity();
+        //GIVEN: send an attachment outgoing activity and resolve it afterwards
+        await(
+          await directLine.emulateOutgoingActivity(testAttachmentActivity)
+        ).resolveAll();
 
-        await pageConditions.became(
-          'successfully sent message',
-          () => {
-            return pageElements.activityStatuses()[0]?.innerText.indexOf('Just now') !== -1
+        //WHEN: Activity displayed
+        await pageConditions.numActivitiesShown(1);
+
+        //THEN: The status change event emitted: 'undefined -> sending' and 'sending -> sent'
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'true',
+            key: expect.any(String),
+            status: 'sending',
+            type: 'message'
           },
-          1000
-        );
-
-        const expectedEventName = 'send-status:change';
-        let lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          currentStatus: "sent",
-          previousStatus: "sending",
-          clientActivityID: expect.any(String),
-          type: "message",
-          key: expect.any(String),
-          hasAttachment: "true"
-        });
-        expect(lastRecord.name).toEqual(expectedEventName);
-      },
-      { ignoreErrors: true });
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'true',
+            key: expect.any(String),
+            prevStatus: 'sending',
+            status: 'sent',
+            type: 'message'
+          }
+        ]));
+      });
     </script>
   </body>
 </html>

--- a/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
@@ -10,6 +10,27 @@
     <div id="webchat"></div>
     <script>
       run(async function () {
+        const testAttachmentActivity = {
+          type: 'message',
+          id: 'CONVERSATION_ID-o|00000',
+          timestamp: '2000-01-23T12:34:56.12345Z',
+          channelId: 'directline',
+          from: {
+            id: 'webchat-mockbot',
+            name: 'webchat-mockbot'
+          },
+          conversation: {
+            id: 'CONVERSATION_ID-o'
+          },
+          locale: 'en-US',
+          attachments: [
+            {
+              contentUrl: 'https://bing.com/',
+              contentType: 'text/plain',
+              name: 'test.txt'
+            }
+          ]
+        }
         const store = testHelpers.createStore();
 
         const directLine = testHelpers.createDirectLineEmulator(store);
@@ -31,7 +52,7 @@
 
         await pageConditions.uiConnected();
 
-        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('sending to sent');
+        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity(testAttachmentActivity);
         await sendMessage1stAttempt.echoBack();
         sendMessage1stAttempt.resolvePostActivity();
 
@@ -43,7 +64,7 @@
           1000
         );
 
-        const expectedEventName = "send-status:change";
+        const expectedEventName = 'send-status:change';
         let lastRecord = telemetryEventTracking.pop();
         expect(lastRecord.data).toEqual({
           currentStatus: "sent",
@@ -51,7 +72,7 @@
           clientActivityID: expect.any(String),
           type: "message",
           key: expect.any(String),
-          hasAttachment: "false"
+          hasAttachment: "true"
         });
         expect(lastRecord.name).toEqual(expectedEventName);
       },

--- a/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.js
+++ b/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.js
@@ -1,0 +1,4 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+test('text url attachment sent from bot should trigger status change telemetry event', () => runHTML('activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html')
+);

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
@@ -20,10 +20,9 @@
             directLine,
             store,
             onTelemetry: (event) => {
-              telemetryEventTracking.push(event);
-            },
-            styleOptions: {
-              sendTimeout: 5000
+              if (event.name == 'send-status:change') {
+                telemetryEventTracking.push(event.data);
+              }
             }
           },
           document.getElementById('webchat')
@@ -31,12 +30,14 @@
 
         await pageConditions.uiConnected();
 
+        //GIVEN: Send out 2 outgoing messages and reject afterwards
         const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('Egress message 1, sending to send failed');
         sendMessage1stAttempt.rejectPostActivity(new Error('artificial error for egress message 1'));
 
         const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity('Egress message 2,  sending to send failed');
         sendMessage2ndAttempt.rejectPostActivity(new Error('artificial error for egress message 2'));
 
+        //WHEN: The activities become 'Send failed'
         await pageConditions.became(
           'failed to send message',
           () => {
@@ -46,28 +47,39 @@
           1000
         );
 
-        const expectedEventName = 'send-status:change';
-        let lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          currentStatus: 'send failed',
-          previousStatus: 'sending',
-          clientActivityID: expect.any(String),
-          type: 'message',
-          key: expect.any(String),
-          hasAttachment: 'false'
-        });
-        expect(lastRecord.name).toEqual(expectedEventName);
-        
-        lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          currentStatus: 'send failed',
-          previousStatus: 'sending',
-          clientActivityID: expect.any(String),
-          type: 'message',
-          key: expect.any(String),
-          hasAttachment: 'false'
-        });
-        expect(lastRecord.name).toEqual(expectedEventName);
+        //THEN: 2 'undefined to sending' events and 2 'sending to send failed' events must be emitted
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+        {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            status: 'sending',
+            type: 'message'
+          },
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            status: 'sending',
+            type: 'message'
+          },
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            prevStatus: 'sending',
+            status: 'send failed',
+            type: 'message'
+          },
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            prevStatus: 'sending',
+            status: 'send failed',
+            type: 'message'
+          },
+        ]));
       },
       { ignoreErrors: true });
     </script>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
@@ -31,10 +31,10 @@
 
         await pageConditions.uiConnected();
 
-        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('Egress message 1');
+        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('Egress message 1, sending to send failed');
         sendMessage1stAttempt.rejectPostActivity(new Error('artificial error for egress message 1'));
 
-        const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity('Egress message 2');
+        const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity('Egress message 2,  sending to send failed');
         sendMessage2ndAttempt.rejectPostActivity(new Error('artificial error for egress message 2'));
 
         await pageConditions.became(
@@ -46,22 +46,26 @@
           1000
         );
 
-        const expectedEventName = "send-status:change";
+        const expectedEventName = 'send-status:change';
         let lastRecord = telemetryEventTracking.pop();
         expect(lastRecord.data).toEqual({
-          currentStatus: "send failed",
-          previousStatus: "sending",
+          currentStatus: 'send failed',
+          previousStatus: 'sending',
           clientActivityID: expect.any(String),
-          type: "message"
+          type: 'message',
+          key: expect.any(String),
+          hasAttachment: 'false'
         });
         expect(lastRecord.name).toEqual(expectedEventName);
         
         lastRecord = telemetryEventTracking.pop();
         expect(lastRecord.data).toEqual({
-          currentStatus: "send failed",
-          previousStatus: "sending",
+          currentStatus: 'send failed',
+          previousStatus: 'sending',
           clientActivityID: expect.any(String),
-          type: "message"
+          type: 'message',
+          key: expect.any(String),
+          hasAttachment: 'false'
         });
         expect(lastRecord.name).toEqual(expectedEventName);
       },

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
@@ -9,79 +9,90 @@
   <body>
     <div id="webchat"></div>
     <script>
-      run(async function () {
-        const store = testHelpers.createStore();
+      run(
+        async function () {
+          const store = testHelpers.createStore();
 
-        const directLine = testHelpers.createDirectLineEmulator(store);
+          const directLine = testHelpers.createDirectLineEmulator(store);
 
-        const telemetryEventTracking = [];
-        WebChat.renderWebChat(
-          {
-            directLine,
-            store,
-            onTelemetry: (event) => {
-              if (event.name == 'send-status:change') {
-                telemetryEventTracking.push(event.data);
+          const telemetryEventTracking = [];
+
+          WebChat.renderWebChat(
+            {
+              directLine,
+              store,
+              onTelemetry: event => {
+                if (event.name == 'send-status:change') {
+                  telemetryEventTracking.push(event.data);
+                }
               }
+            },
+            document.getElementById('webchat')
+          );
+
+          await pageConditions.uiConnected();
+
+          // GIVEN: 2 outgoing messages.
+          const sendMessage1stAttempt = await directLine.emulateOutgoingActivity(
+            'Egress message 1, sending to send failed'
+          );
+          const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity(
+            'Egress message 2,  sending to send failed'
+          );
+
+          // WHEN: Both messages are rejected.
+          sendMessage1stAttempt.rejectPostActivity(new Error('artificial error for egress message 1'));
+          sendMessage2ndAttempt.rejectPostActivity(new Error('artificial error for egress message 2'));
+
+          // THEN: The activities should become "Send failed".
+          await pageConditions.became(
+            'failed to send message',
+            () => {
+              return (
+                pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.' &&
+                pageElements.activityStatuses()[1]?.innerText === 'Send failed. Retry.'
+              );
+            },
+            1000
+          );
+
+          // THEN: It should emit 2 x "undefined -> sending" events, followed by 2 x "sending to send failed" events.
+          //       We send 2 messages because we want to make sure only 2 x 2 events are emitted.
+          expect(telemetryEventTracking).toEqual([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              status: 'sending',
+              type: 'message'
+            },
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              status: 'sending',
+              type: 'message'
+            },
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              prevStatus: 'sending',
+              status: 'send failed',
+              type: 'message'
+            },
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              prevStatus: 'sending',
+              status: 'send failed',
+              type: 'message'
             }
-          },
-          document.getElementById('webchat')
-        );
-
-        await pageConditions.uiConnected();
-
-        //GIVEN: Send out 2 outgoing messages and reject afterwards
-        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('Egress message 1, sending to send failed');
-        sendMessage1stAttempt.rejectPostActivity(new Error('artificial error for egress message 1'));
-
-        const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity('Egress message 2,  sending to send failed');
-        sendMessage2ndAttempt.rejectPostActivity(new Error('artificial error for egress message 2'));
-
-        //WHEN: The activities become 'Send failed'
-        await pageConditions.became(
-          'failed to send message',
-          () => {
-            return pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.' &&
-            pageElements.activityStatuses()[1]?.innerText === 'Send failed. Retry.'
-          },
-          1000
-        );
-
-        //THEN: 2 'undefined to sending' events and 2 'sending to send failed' events must be emitted
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-        {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            status: 'sending',
-            type: 'message'
-          },
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            status: 'sending',
-            type: 'message'
-          },
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            prevStatus: 'sending',
-            status: 'send failed',
-            type: 'message'
-          },
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            prevStatus: 'sending',
-            status: 'send failed',
-            type: 'message'
-          },
-        ]));
-      },
-      { ignoreErrors: true });
+          ]);
+        },
+        { ignoreErrors: true }
+      );
     </script>
   </body>
 </html>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const store = testHelpers.createStore();
+
+        const directLine = testHelpers.createDirectLineEmulator(store);
+
+        const telemetryEventTracking = [];
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store,
+            onTelemetry: (event) => {
+              telemetryEventTracking.push(event);
+            },
+            styleOptions: {
+              sendTimeout: 5000
+            }
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+
+        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('Egress message 1');
+        sendMessage1stAttempt.rejectPostActivity(new Error('artificial error for egress message 1'));
+
+        const sendMessage2ndAttempt = await directLine.emulateOutgoingActivity('Egress message 2');
+        sendMessage2ndAttempt.rejectPostActivity(new Error('artificial error for egress message 2'));
+
+        await pageConditions.became(
+          'failed to send message',
+          () => {
+            return pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.' &&
+            pageElements.activityStatuses()[1]?.innerText === 'Send failed. Retry.'
+          },
+          1000
+        );
+
+        const expectedEventName = "send-status:change";
+        let lastRecord = telemetryEventTracking.pop();
+        expect(lastRecord.data).toEqual({
+          currentStatus: "send failed",
+          previousStatus: "sending",
+          clientActivityID: expect.any(String),
+          type: "message"
+        });
+        expect(lastRecord.name).toEqual(expectedEventName);
+        
+        lastRecord = telemetryEventTracking.pop();
+        expect(lastRecord.data).toEqual({
+          currentStatus: "send failed",
+          previousStatus: "sending",
+          clientActivityID: expect.any(String),
+          type: "message"
+        });
+        expect(lastRecord.name).toEqual(expectedEventName);
+      },
+      { ignoreErrors: true });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.js
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.js
@@ -1,0 +1,6 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('ActivityStatusTelemetry', () => {
+  test('activity status telemetry logged when activity status changed from "sending" to "send failed"', () =>
+    runHTML('activityStatusTelemetry.sendingToSendFailed.html'));
+});

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
@@ -9,94 +9,85 @@
   <body>
     <div id="webchat"></div>
     <script>
-      async function createDirectLineForTest() {
-        const directLine = await testHelpers.createDirectLineWithTranscript([], {
-          overridePostActivity: activity => {
-            if (activity.type === 'message') {
-              setTimeout(() => {
-                directLine.activityDeferredObservable.next({
-                  ...activity,
-                  id: 'a00001',
-                  timestamp: new Date().toISOString()
-                });
-              }, 100);
+      const store = testHelpers.createStore();
+      const directLine = testHelpers.createDirectLineEmulator(store);
 
-              return new Observable(observer => {
-                setTimeout(() => observer.next('a00001'), 800);
-              });
-            } else {
-              return workingDirectLine.postActivity(activity);
-            }
-          }
-        });
-
-        return directLine;
-      }
-
-      function activityChannelDataStateBecame(expectedState) {
-        if (typeof expectedState === 'undefined') {
-          return pageConditions.became(
-            `Activity "channelData.state" should be undefined`,
-            () => !('state' in pageObjects.getActivities()[0].channelData),
-            1000
-          );
-        }
-
-        return pageConditions.became(
-          `Activity "channelData.state" should be "${expectedState}"`,
-          () => pageObjects.getActivities()[0].channelData?.state === expectedState,
-          1000
-        );
-      }
+      const telemetryEventTracking = [];
 
       run(async function () {
-        const telemetryEventTracking = [];
+        const clock = lolex.install();
         WebChat.renderWebChat(
           {
-            directLine: await createDirectLineForTest(),
-            store: testHelpers.createStore(),
+            directLine,
+            store,
             onTelemetry: (event) => {
-              telemetryEventTracking.push(event);
+              if (event.name == 'send-status:change') {
+                telemetryEventTracking.push(event.data);
+              }
             },
-            styleOptions: {
-              sendTimeout: 500
-            }
           },
           document.getElementById('webchat')
         );
-
         await pageConditions.webChatRendered();
 
-        // SETUP: Send a message
-        await pageConditions.uiConnected();
-        await pageObjects.sendMessageViaSendBox('Hello, World!', { waitForSend: false });
+        //GIVEN: User send out a message
+        const sendingUserEgressMessage = directLine.emulateOutgoingActivity({
+          channelData: { 'webchat:sequence-id': 1 },
+          from: { role: 'user' },
+          text: 'msg from user.',
+          type: 'message'
+        })
 
-        // // THEN: `channelData.state` should be "sent".
-        await activityChannelDataStateBecame('sent');
+        //WHEN: Activity displayed in sending status
+        await pageConditions.numActivitiesShown(1);
 
-        const expectedEventName = 'send-status:change';
-        let lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          previousStatus: 'send failed',
-          currentStatus: 'sent',
-          clientActivityID: expect.any(String),
-          type: 'message',
-          key: expect.any(String),
-          hasAttachment: 'false'
-        });
+        //THEN: The status change event emitted: undefined -> sending
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            status: 'sending',
+            type: 'message'
+          },
+        ]));
 
-        expect(lastRecord.name).toEqual(expectedEventName);
-        
-        lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          currentStatus: 'send failed',
-          previousStatus: 'sending',
-          clientActivityID: expect.any(String),
-          type: 'message',
-          key: expect.any(String),
-          hasAttachment: 'false'
-        });
-        expect(lastRecord.name).toEqual(expectedEventName);
+        //GIVEN: Wait for 20 seconds to let the activity times out
+        clock.tick(20000);
+
+        //WHEN: Sending message timeout and message status turns into 'Send failed. Retry'
+        await pageConditions.became(
+            'failed to send message',
+            () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
+            1000
+        );
+
+        //THEN: Telemetry event should be emitted: sending -> send failed
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            prevStatus: 'sending',
+            status: 'send failed',
+            type: 'message'
+          }
+        ]));
+
+        //GIVEN: Resolved the egressing message
+        await (await (await sendingUserEgressMessage).resolveAll());
+
+        //THEN: Telemetry event should be emitted: send failed -> sent
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            prevStatus: 'send failed',
+            status: 'sent',
+            type: 'message'
+          }
+        ]));
       });
     </script>
   </body>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
@@ -20,74 +20,86 @@
           {
             directLine,
             store,
-            onTelemetry: (event) => {
+            onTelemetry: event => {
               if (event.name == 'send-status:change') {
                 telemetryEventTracking.push(event.data);
               }
-            },
+            }
           },
           document.getElementById('webchat')
         );
         await pageConditions.webChatRendered();
 
-        //GIVEN: User send out a message
-        const sendingUserEgressMessage = directLine.emulateOutgoingActivity({
+        // WHEN: User send out a message
+        const sendingUserEgressMessage = await directLine.emulateOutgoingActivity({
           channelData: { 'webchat:sequence-id': 1 },
           from: { role: 'user' },
           text: 'msg from user.',
           type: 'message'
-        })
+        });
 
-        //WHEN: Activity displayed in sending status
         await pageConditions.numActivitiesShown(1);
 
-        //THEN: The status change event emitted: undefined -> sending
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            status: 'sending',
-            type: 'message'
-          },
-        ]));
-
-        //GIVEN: Wait for 20 seconds to let the activity times out
-        clock.tick(20000);
-
-        //WHEN: Sending message timeout and message status turns into 'Send failed. Retry'
-        await pageConditions.became(
-            'failed to send message',
-            () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
-            1000
+        // THEN: A telemetry event should be emitted: undefined -> sending
+        expect(telemetryEventTracking).toEqual(
+          expect.arrayContaining([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              status: 'sending',
+              type: 'message'
+            }
+          ])
         );
 
-        //THEN: Telemetry event should be emitted: sending -> send failed
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            prevStatus: 'sending',
-            status: 'send failed',
-            type: 'message'
-          }
-        ]));
+        // GIVEN: Wait for 20 seconds to let the activity times out.
+        clock.tick(20000);
 
-        //GIVEN: Resolved the egressing message
-        await (await (await sendingUserEgressMessage).resolveAll());
+        // THEN: The message status should turns into "Send failed. Retry."
+        await pageConditions.became(
+          'failed to send message',
+          () => pageElements.activityStatuses()[0]?.innerText === 'Send failed. Retry.',
+          1000
+        );
 
-        //THEN: Telemetry event should be emitted: send failed -> sent
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            prevStatus: 'send failed',
-            status: 'sent',
-            type: 'message'
-          }
-        ]));
+        // THEN: A telemetry event should be emitted: sending -> send failed
+        expect(telemetryEventTracking).toEqual(
+          expect.arrayContaining([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              prevStatus: 'sending',
+              status: 'send failed',
+              type: 'message'
+            }
+          ])
+        );
+
+        // GIVEN: The outgoing message successfully sent.
+        await sendingUserEgressMessage.resolveAll();
+
+        // THEN: The message status should turns into "Just now"
+        await pageConditions.became(
+          'message successfully sent',
+          () => pageElements.activityStatuses()[0]?.innerText.includes('Just now'),
+          1000
+        );
+
+        // THEN: A telemetry event should be emitted: send failed -> sent
+        expect(telemetryEventTracking).toEqual(
+          expect.arrayContaining([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              prevStatus: 'send failed',
+              status: 'sent',
+              type: 'message'
+            }
+          ])
+        );
       });
     </script>
   </body>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      async function createDirectLineForTest() {
+        const directLine = await testHelpers.createDirectLineWithTranscript([], {
+          overridePostActivity: activity => {
+            if (activity.type === 'message') {
+              setTimeout(() => {
+                directLine.activityDeferredObservable.next({
+                  ...activity,
+                  id: 'a00001',
+                  timestamp: new Date().toISOString()
+                });
+              }, 100);
+
+              return new Observable(observer => {
+                setTimeout(() => observer.next('a00001'), 800);
+              });
+            } else {
+              return workingDirectLine.postActivity(activity);
+            }
+          }
+        });
+
+        return directLine;
+      }
+
+      function activityChannelDataStateBecame(expectedState) {
+        if (typeof expectedState === 'undefined') {
+          return pageConditions.became(
+            `Activity "channelData.state" should be undefined`,
+            () => !('state' in pageObjects.getActivities()[0].channelData),
+            1000
+          );
+        }
+
+        return pageConditions.became(
+          `Activity "channelData.state" should be "${expectedState}"`,
+          () => pageObjects.getActivities()[0].channelData?.state === expectedState,
+          1000
+        );
+      }
+
+      run(async function () {
+        const telemetryEventTracking = [];
+        WebChat.renderWebChat(
+          {
+            directLine: await createDirectLineForTest(),
+            store: testHelpers.createStore(),
+            onTelemetry: (event) => {
+              telemetryEventTracking.push(event);
+            },
+            styleOptions: {
+              sendTimeout: 500
+            }
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.webChatRendered();
+
+        // SETUP: Send a message
+        await pageConditions.uiConnected();
+        await pageObjects.sendMessageViaSendBox('Hello, World!', { waitForSend: false });
+
+        // // THEN: `channelData.state` should be "sent".
+        await activityChannelDataStateBecame('sent');
+
+        const expectedEventName = "send-status:change";
+        let lastRecord = telemetryEventTracking.pop();
+        expect(lastRecord.data).toEqual({
+          previousStatus: "send failed",
+          currentStatus: "sent",
+          clientActivityID: expect.any(String),
+          type: "message"
+        });
+
+        expect(lastRecord.name).toEqual(expectedEventName);
+        
+        lastRecord = telemetryEventTracking.pop();
+        expect(lastRecord.data).toEqual({
+          currentStatus: "send failed",
+          previousStatus: "sending",
+          clientActivityID: expect.any(String),
+          type: "message"
+        });
+        expect(lastRecord.name).toEqual(expectedEventName);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
@@ -74,23 +74,27 @@
         // // THEN: `channelData.state` should be "sent".
         await activityChannelDataStateBecame('sent');
 
-        const expectedEventName = "send-status:change";
+        const expectedEventName = 'send-status:change';
         let lastRecord = telemetryEventTracking.pop();
         expect(lastRecord.data).toEqual({
-          previousStatus: "send failed",
-          currentStatus: "sent",
+          previousStatus: 'send failed',
+          currentStatus: 'sent',
           clientActivityID: expect.any(String),
-          type: "message"
+          type: 'message',
+          key: expect.any(String),
+          hasAttachment: 'false'
         });
 
         expect(lastRecord.name).toEqual(expectedEventName);
         
         lastRecord = telemetryEventTracking.pop();
         expect(lastRecord.data).toEqual({
-          currentStatus: "send failed",
-          previousStatus: "sending",
+          currentStatus: 'send failed',
+          previousStatus: 'sending',
           clientActivityID: expect.any(String),
-          type: "message"
+          type: 'message',
+          key: expect.any(String),
+          hasAttachment: 'false'
         });
         expect(lastRecord.name).toEqual(expectedEventName);
       });

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.js
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.js
@@ -1,0 +1,6 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('ActivityStatusTelemetry', () => {
+  test('activity status telemetry logged when activity status changed from "sending" to "send failed" to "sent"', () =>
+    runHTML('activityStatusTelemetry.sendingToSendFailedToSent.html'));
+});

--- a/__tests__/html/activityStatusTelemetry.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSent.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <div id="webchat"></div>
+    <script>
+      run(async function () {
+        const store = testHelpers.createStore();
+
+        const directLine = testHelpers.createDirectLineEmulator(store);
+
+        const telemetryEventTracking = [];
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store,
+            onTelemetry: (event) => {
+              telemetryEventTracking.push(event);
+            },
+            styleOptions: {
+              sendTimeout: 5000
+            }
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+
+        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('sending to sent');
+        await sendMessage1stAttempt.echoBack();
+        sendMessage1stAttempt.resolvePostActivity();
+
+        await pageConditions.became(
+          'failed to send message',
+          () => {
+            return pageElements.activityStatuses()[0]?.innerText.indexOf('Just now') !== -1
+          },
+          1000
+        );
+
+        console.log("debugging activity status: ", pageElements.activityStatuses());
+
+        const expectedEventName = "send-status:change";
+        let lastRecord = telemetryEventTracking.pop();
+        expect(lastRecord.data).toEqual({
+          currentStatus: "sent",
+          previousStatus: "sending",
+          clientActivityID: expect.any(String),
+          type: "message"
+        });
+        expect(lastRecord.name).toEqual(expectedEventName);
+      },
+      { ignoreErrors: true });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/activityStatusTelemetry.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSent.html
@@ -18,7 +18,7 @@
         WebChat.renderWebChat(
           {
             directLine,
-            onTelemetry: (event) => {
+            onTelemetry: event => {
               if (event?.name === 'send-status:change') {
                 telemetryEventTracking.push(event.data);
               }
@@ -30,32 +30,30 @@
 
         await pageConditions.uiConnected();
 
-        //GIVEN: send an attachment outgoing activity and resolve it afterwards
-        await(
-          await directLine.emulateOutgoingActivity('sending to sent')
-        ).resolveAll();
-
-        //WHEN: Activity displayed
+        // WHEN: A message activity "sending to sent" is sent.
+        await (await directLine.emulateOutgoingActivity('sending to sent')).resolveAll();
         await pageConditions.numActivitiesShown(1);
 
-        //THEN: The status change event emitted: 'undefined -> sending' and 'sending -> sent'
-        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            status: 'sending',
-            type: 'message'
-          },
-          {
-            clientActivityID: expect.any(String),
-            hasAttachment: 'false',
-            key: expect.any(String),
-            prevStatus: 'sending',
-            status: 'sent',
-            type: 'message'
-          }
-        ]));
+        // THEN: Two telemetry events should be emitted: "undefined -> sending" and "sending -> sent"
+        expect(telemetryEventTracking).toEqual(
+          expect.arrayContaining([
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              status: 'sending',
+              type: 'message'
+            },
+            {
+              clientActivityID: expect.any(String),
+              hasAttachment: 'false',
+              key: expect.any(String),
+              prevStatus: 'sending',
+              status: 'sent',
+              type: 'message'
+            }
+          ])
+        );
       });
     </script>
   </body>

--- a/__tests__/html/activityStatusTelemetry.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSent.html
@@ -13,49 +13,50 @@
         const store = testHelpers.createStore();
 
         const directLine = testHelpers.createDirectLineEmulator(store);
-
         const telemetryEventTracking = [];
+
         WebChat.renderWebChat(
           {
             directLine,
-            store,
             onTelemetry: (event) => {
-              telemetryEventTracking.push(event);
+              if (event?.name === 'send-status:change') {
+                telemetryEventTracking.push(event.data);
+              }
             },
-            styleOptions: {
-              sendTimeout: 5000
-            }
+            store
           },
           document.getElementById('webchat')
         );
 
         await pageConditions.uiConnected();
 
-        const sendMessage1stAttempt = await directLine.emulateOutgoingActivity('sending to sent');
-        await sendMessage1stAttempt.echoBack();
-        sendMessage1stAttempt.resolvePostActivity();
+        //GIVEN: send an attachment outgoing activity and resolve it afterwards
+        await(
+          await directLine.emulateOutgoingActivity('sending to sent')
+        ).resolveAll();
 
-        await pageConditions.became(
-          'successfully sent message',
-          () => {
-            return pageElements.activityStatuses()[0]?.innerText.indexOf('Just now') !== -1
+        //WHEN: Activity displayed
+        await pageConditions.numActivitiesShown(1);
+
+        //THEN: The status change event emitted: 'undefined -> sending' and 'sending -> sent'
+        expect(telemetryEventTracking).toEqual(expect.arrayContaining([
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            status: 'sending',
+            type: 'message'
           },
-          1000
-        );
-
-        const expectedEventName = "send-status:change";
-        let lastRecord = telemetryEventTracking.pop();
-        expect(lastRecord.data).toEqual({
-          currentStatus: "sent",
-          previousStatus: "sending",
-          clientActivityID: expect.any(String),
-          type: "message",
-          key: expect.any(String),
-          hasAttachment: "false"
-        });
-        expect(lastRecord.name).toEqual(expectedEventName);
-      },
-      { ignoreErrors: true });
+          {
+            clientActivityID: expect.any(String),
+            hasAttachment: 'false',
+            key: expect.any(String),
+            prevStatus: 'sending',
+            status: 'sent',
+            type: 'message'
+          }
+        ]));
+      });
     </script>
   </body>
 </html>

--- a/__tests__/html/activityStatusTelemetry.sendingToSent.js
+++ b/__tests__/html/activityStatusTelemetry.sendingToSent.js
@@ -1,0 +1,6 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('ActivityStatusTelemetry', () => {
+  test('activity status telemetry logged when activity status changed from "sending" to "sent"', () =>
+    runHTML('activityStatusTelemetry.sendingToSent.html'));
+});

--- a/__tests__/telemetry.js
+++ b/__tests__/telemetry.js
@@ -10,12 +10,13 @@ jest.setTimeout(20000);
 
 describe('telemetry', () => {
   test('should collect "init" event', async () => {
+
     const { driver } = await setupWebDriver({
       props: {
         onTelemetry: event => {
           const { data, dimensions, duration, error, fatal, name, type, value } = event;
 
-          (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+          window.WebChatTest.telemetryMeasurements.push({
             data,
             dimensions,
             duration,
@@ -26,6 +27,9 @@ describe('telemetry', () => {
             value
           });
         }
+      },
+      setup: () => {
+        window.WebChatTest.telemetryMeasurements = [];
       }
     });
 

--- a/__tests__/telemetry.js
+++ b/__tests__/telemetry.js
@@ -31,7 +31,9 @@ describe('telemetry', () => {
 
     await driver.wait(uiConnected(), timeouts.directLine);
 
-    await expect(driver.executeScript(() => window.WebChatTest.telemetryMeasurements)).resolves.toMatchInlineSnapshot(`
+    await expect(
+      driver.executeScript(() => window.WebChatTest.telemetryMeasurements.filter(({ name }) => name === 'init'))
+    ).resolves.toMatchInlineSnapshot(`
       Array [
         Object {
           "data": null,
@@ -56,15 +58,18 @@ describe('telemetry', () => {
   test('should collect fatal error', async () => {
     const { driver, pageObjects } = await setupWebDriver({
       props: {
-        activityMiddleware: () => () => ({ activity: { text = '' } }) => {
-          return () => {
-            if (~text.indexOf('error')) {
-              throw new Error('artificial error');
-            }
+        activityMiddleware:
+          () =>
+          () =>
+          ({ activity: { text = '' } }) => {
+            return () => {
+              if (~text.indexOf('error')) {
+                throw new Error('artificial error');
+              }
 
-            return false;
-          };
-        },
+              return false;
+            };
+          },
         onTelemetry: event => {
           const { data, dimensions, duration, error, fatal, name, type, value } = event;
 

--- a/__tests__/upload.js
+++ b/__tests__/upload.js
@@ -19,7 +19,7 @@ describe('upload a picture', () => {
         onTelemetry: event => {
           const { data, dimensions, duration, error, fatal, name, type, value } = event;
 
-          (window.WebChatTest.telemetryMeasurements || (window.WebChatTest.telemetryMeasurements = [])).push({
+          window.WebChatTest.telemetryMeasurements.push({
             data,
             dimensions,
             duration,
@@ -30,6 +30,9 @@ describe('upload a picture', () => {
             value
           });
         }
+      },
+      setup: () => {
+        window.WebChatTest.telemetryMeasurements = [];
       },
       // TODO: [P3] Offline bot did not reply with a downloadable attachment, so we need to use production bot
       useProductionBot: true

--- a/__tests__/upload.js
+++ b/__tests__/upload.js
@@ -41,7 +41,11 @@ describe('upload a picture', () => {
     await driver.wait(minNumActivitiesShown(2), timeouts.directLine);
     await driver.wait(allImagesLoaded(), timeouts.fetchImage);
 
-    const telemetryMeasurements = await driver.executeScript(() => window.WebChatTest.telemetryMeasurements);
+    const telemetryMeasurements = await driver.executeScript(() =>
+      window.WebChatTest.telemetryMeasurements.filter(({ name }) =>
+        ['init', 'sendFiles', 'sendFiles:makeThumbnail'].includes(name)
+      )
+    );
 
     expect(telemetryMeasurements).toHaveProperty('length', 4);
     expect(telemetryMeasurements[2]).toHaveProperty('name', 'sendFiles:makeThumbnail');

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -53,9 +53,10 @@ When the following hooks are called, one or more event measurements will be emit
 
 ### Other events
 
-| Name   | Description                                |
-| ------ | ------------------------------------------ |
-| `init` | Emit when telemetry system has initialized |
+| Name                 | Description                                                                                                                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`               | Emit when telemetry system has initialized                                                                                                                                                                             |
+| `send-status:change` | Emit when activity status changes from `sending` to `sent`, `sending` to `send failed` and `send failed` to `sent`. Including `currentStatus`, `previousStatus`, `clientActivityID`, `key`, `hasAttachment` and `type` |
 
 ### Exceptions
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -53,10 +53,10 @@ When the following hooks are called, one or more event measurements will be emit
 
 ### Other events
 
-| Name                 | Description                                                                                                                                                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `init`               | Emit when telemetry system has initialized                                                                                                                                                                             |
-| `send-status:change` | Emit when activity status changes from `sending` to `sent`, `sending` to `send failed` and `send failed` to `sent`. Including `currentStatus`, `previousStatus`, `clientActivityID`, `key`, `hasAttachment` and `type` |
+| Name                 | Description                                                                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`               | Emit when telemetry system has initialized                                                                                                                                                                                            |
+| `send-status:change` | Emit when activity status changes from `undefined` to `sending`, `sending` to `sent`, `sending` to `send failed` and `send failed` to `sent`. Including `status`, `prevStatus`, `clientActivityID`, `key`, `hasAttachment` and `type` |
 
 ### Exceptions
 
@@ -118,6 +118,19 @@ interface TelemetryTimingEndMeasurementEvent extends TelemetryMeasurementEvent {
    timingId: string;
    duration: number;
 }
+```
+
+To collect `send-status:change` events, the data emitted will be in the type below:
+
+```ts
+type TelemetrySendStatusChangePayload = {
+   clientActivityID?: string;
+   hasAttachment?: 'true' | 'false';
+   key: string;
+   prevStatus?: 'sending' | 'send failed' | 'sent';
+   status: 'sending' | 'send failed' | 'sent';
+   type?: string;
+};
 ```
 
 Web Chat may emit a large number of dimensions and measurements to your `onTelemetry` handler. As your telemetry service provider may limit number of dimensions and measurements for a single session or property, you are advised to pick and choose the data you needed before transmitting them to your provider.

--- a/packages/api/src/hooks/Composer.tsx
+++ b/packages/api/src/hooks/Composer.tsx
@@ -612,9 +612,8 @@ const ComposerCore: FC<ComposerCoreProps> = ({
   return (
     <WebChatAPIContext.Provider value={context}>
       <ActivitySendStatusComposer>
-        <ActivitySendStatusTelemetryComposer>
-          {typeof children === 'function' ? children(context) : children}
-        </ActivitySendStatusTelemetryComposer>
+        {typeof children === 'function' ? children(context) : children}
+        <ActivitySendStatusTelemetryComposer />
       </ActivitySendStatusComposer>
       {onTelemetry && <Tracker />}
     </WebChatAPIContext.Provider>

--- a/packages/api/src/hooks/Composer.tsx
+++ b/packages/api/src/hooks/Composer.tsx
@@ -36,6 +36,7 @@ import ActivityAcknowledgementComposer from '../providers/ActivityAcknowledgemen
 import ActivityKeyerComposer from '../providers/ActivityKeyer/ActivityKeyerComposer';
 import ActivityMiddleware from '../types/ActivityMiddleware';
 import ActivitySendStatusComposer from '../providers/ActivitySendStatus/ActivitySendStatusComposer';
+import ActivitySendStatusTelemetryComposer from '../providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer';
 import AttachmentForScreenReaderMiddleware from '../types/AttachmentForScreenReaderMiddleware';
 import AttachmentMiddleware from '../types/AttachmentMiddleware';
 import AvatarMiddleware from '../types/AvatarMiddleware';
@@ -611,7 +612,9 @@ const ComposerCore: FC<ComposerCoreProps> = ({
   return (
     <WebChatAPIContext.Provider value={context}>
       <ActivitySendStatusComposer>
-        {typeof children === 'function' ? children(context) : children}
+        <ActivitySendStatusTelemetryComposer>
+          {typeof children === 'function' ? children(context) : children}
+        </ActivitySendStatusTelemetryComposer>
       </ActivitySendStatusComposer>
       {onTelemetry && <Tracker />}
     </WebChatAPIContext.Provider>

--- a/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
+++ b/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
@@ -22,7 +22,8 @@ const ActivitySendStatusTelemetryComposer = () => {
           previousStatus: previousStatus.toString(),
           clientActivityID: activity?.channelData?.clientActivityID,
           type: activity?.type?.toString(),
-          key
+          key,
+          hasAttachment: activity.type === 'message' && activity.attachments?.length > 0 ? 'true' : 'false'
         };
         trackEvent && trackEvent('send-status:change', telemetryPayload);
       }

--- a/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
+++ b/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
@@ -1,10 +1,8 @@
-// import React, { FC, PropsWithChildren, ReactNode } from 'react';
-
 import { useGetActivityByKey, useSendStatusByActivityKey, useTrackEvent } from '../../hooks';
 
 import usePrevious from '../../hooks/internal/usePrevious';
 
-const ActivitySendStatusTelemetryComposer: React.FC<{ children?: any }> = ({ children }) => {
+const ActivitySendStatusTelemetryComposer = () => {
   const [activityToSendStatusMap] = useSendStatusByActivityKey();
   const previousActivityToSendStatusMap = usePrevious(activityToSendStatusMap);
   const getActivityByKey = useGetActivityByKey();
@@ -23,13 +21,14 @@ const ActivitySendStatusTelemetryComposer: React.FC<{ children?: any }> = ({ chi
           currentStatus: currentStatus.toString(),
           previousStatus: previousStatus.toString(),
           clientActivityID: activity?.channelData?.clientActivityID,
-          type: activity?.type?.toString()
+          type: activity?.type?.toString(),
+          key
         };
         trackEvent && trackEvent('send-status:change', telemetryPayload);
       }
     }
   }
-  return children;
+  return null;
 };
 
 export default ActivitySendStatusTelemetryComposer;

--- a/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
+++ b/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
@@ -23,7 +23,7 @@ const ActivitySendStatusTelemetryComposer = () => {
           clientActivityID: activity?.channelData?.clientActivityID,
           type: activity?.type?.toString(),
           key,
-          hasAttachment: activity.type === 'message' && activity.attachments?.length > 0 ? 'true' : 'false'
+          hasAttachment: activity?.type === 'message' && activity?.attachments?.length > 0 ? 'true' : 'false'
         };
         trackEvent && trackEvent('send-status:change', telemetryPayload);
       }

--- a/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
+++ b/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
@@ -1,0 +1,35 @@
+// import React, { FC, PropsWithChildren, ReactNode } from 'react';
+
+import { useGetActivityByKey, useSendStatusByActivityKey, useTrackEvent } from '../../hooks';
+
+import usePrevious from '../../hooks/internal/usePrevious';
+
+const ActivitySendStatusTelemetryComposer: React.FC<{ children?: any }> = ({ children }) => {
+  const [activityToSendStatusMap] = useSendStatusByActivityKey();
+  const previousActivityToSendStatusMap = usePrevious(activityToSendStatusMap);
+  const getActivityByKey = useGetActivityByKey();
+  const trackEvent = useTrackEvent();
+
+  if (activityToSendStatusMap && previousActivityToSendStatusMap) {
+    const allActivityKeys = activityToSendStatusMap.keys();
+
+    for (const key of allActivityKeys) {
+      const currentStatus = activityToSendStatusMap.get(key);
+      const previousStatus = previousActivityToSendStatusMap.get(key);
+
+      if (!!currentStatus && !!previousStatus && currentStatus !== previousStatus) {
+        const activity = getActivityByKey(key);
+        const telemetryPayload = {
+          currentStatus: currentStatus.toString(),
+          previousStatus: previousStatus.toString(),
+          clientActivityID: activity?.channelData?.clientActivityID,
+          type: activity?.type?.toString()
+        };
+        trackEvent && trackEvent('send-status:change', telemetryPayload);
+      }
+    }
+  }
+  return children;
+};
+
+export default ActivitySendStatusTelemetryComposer;

--- a/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
+++ b/packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
@@ -27,18 +27,20 @@ const ActivitySendStatusTelemetryComposer = () => {
       // This telemetry data point only emit changes in outgoing activities.
       if (status && status !== prevStatus) {
         const activity = getActivityByKey(key);
+
         const telemetryPayload: TelemetrySendStatusChangePayload = {
-          clientActivityID: activity?.channelData?.clientActivityID,
-          hasAttachment: activity?.type === 'message' && activity?.attachments?.length > 0 ? 'true' : 'false',
+          clientActivityID: activity?.channelData.clientActivityID,
+          hasAttachment: activity?.type === 'message' && activity.attachments?.length > 0 ? 'true' : 'false',
           key,
           status,
-          type: activity?.type?.toString()
+          type: activity?.type
         };
 
-        //only add prevStatus if it is NOT null/undefined
+        // Only add prevStatus if it is NOT null/undefined
         if (prevStatus) {
           telemetryPayload.prevStatus = prevStatus;
         }
+
         trackEvent('send-status:change', telemetryPayload);
       }
     }


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4500.

## Changelog Entry

- Added function to emit status change telemetry event for activities, by [@Erli-ms](https://github.com/Erli-ms), in PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631)

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Added an ActivityStatusTelemetryComposer inside of ActivitySendStatusComposer. Whenever the activity status changes, the ActivityStatusTelemetryComposer collects the map of concerned activities and triggers trackEvent to emit the event. Consumers of the events can react accordingly. This feature is requested by D365 OmniChannel team. 

## Design

Added a new provider to look at send status of every activity. Whenever send status of any activities changed, it will call `onTelemetry` event to fire its changes.

## Specific Changes

<!-- Please list the changes in a concise manner. -->
- packages/api/src/providers/ActivitySendStatusTelemetry/ActivitySendStatusTelemetryComposer.tsx
    - creating a new composer triggered whenever the control got re-rendered.
    - collect the activities which status changed
    - invoke trackEvent to emit the event to the telemetry logger
    - `{ status, prevStatus, ClientActivityID, type, hasAttachment, key}` is emitted to the telemetry logger
- packages/api/src/hooks/Composer.tsx
    - added the ActivitySendStatusTelemetryComposer as a children component to ActivitySendStatusComposer
- tests/html/activityStatusTelemetry.sendingToSendFailed.html
    - added test to verify expected event been emitted with the activity status changed from 'sending' to 'send failed'
- tests/html/activityStatusTelemetry.sendingToSendFailedToSent.html
    - added test to verify expected event been emitted with the activity status changed from 'sending' to 'send failed' and from 'send failed' to 'sent'
-  tests/html/activityStatusTelemetry.sendingToSent.html
    - added test to verify expected event been emitted with the activity status changed from 'sending' to 'sent'
- tests/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
    - added test to verify expected event been emitted with when attachment activity status changed from 'sending' to 'sent'
- tests/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
    - added test to verify incoming activity does not emit any status change event


## -

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
