### PR TITLE
Prepare to release 4.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.15.7] - 2023-02-15
+
 ### Added
 
 -  Added function to emit status change telemetry event for activities, by [@Erli-ms](https://github.com/Erli-ms), in PR [#4631](https://github.com/microsoft/BotFramework-WebChat/pull/4631)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.7-0",
+  "version": "4.15.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.7-0",
+      "version": "4.15.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.7-0",
+  "version": "4.15.7",
   "private": true,
   "files": [
     "lib/**/*"


### PR DESCRIPTION
## Changelog Entry

(No CHANGELOG for bumping version)

## Description

This is to mark 4.15.7 in `CHANGELOG.md` and `package.json`.

## Specific Changes

- Add a section 4.15.7 to `CHANGELOG.md`
- Run `npm version 4.15.7 --no-git-tag-version`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
