### PR TITLE
[HIGH] Bump to 4.15.8-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.7",
+  "version": "4.15.8-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.7",
+      "version": "4.15.8-0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.7",
+  "version": "4.15.8-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -480,6 +480,16 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.15.7": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.15.7/webchat-es5.js",
+          "sha384-1T+LvOs6/1ShG/+c7tarxIR/J0dUIjrba2M9SbyOv9Ls8ElcnhLZFnLGdiVf/u4W"
+        ]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "hosted": {
       "assets": [
         [

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -477,6 +477,7 @@
           "sha384-Ik2jNknNTBCaI/NP3GRMfDCWKnApGSdYMcdA6EtEJkL1LtUZEdNdjeNkfZZk3UlS"
         ]
       ],
+      "deprecation": "This version of Web Chat is deprecated. Please upgrade as soon as possible. We will automatically upgrade this site on or after 2025-02-15.",
       "private": true,
       "versionFamily": "4"
     },


### PR DESCRIPTION
## Changelog Entry

No changelog for version bump.

## Description

Bump to `4.15.8-0` after release of `4.15.7`.

## Specific Changes

- `npm version prepatch --no-git-tag-version`
- Add `4.15.7` to `servicingPlan.json`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
