### PR TITLE
Decouple botframework-directlinejs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4644](https://github.com/microsoft/BotFramework-WebChat/pull/4644)
 
 ## [4.15.7] - 2023-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+-  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ## [4.15.7] - 2023-02-15
 
 ### Added

--- a/packages/core/src/sagas/connectSaga.js
+++ b/packages/core/src/sagas/connectSaga.js
@@ -2,7 +2,6 @@
 
 import { call, cancel, cancelled, fork, put, race, take } from 'redux-saga/effects';
 
-import { ConnectionStatus } from 'botframework-directlinejs';
 import decode from 'jwt-decode';
 
 import { CONNECT } from '../actions/connect';
@@ -15,7 +14,9 @@ import { DISCONNECT, DISCONNECT_PENDING, DISCONNECT_FULFILLED } from '../actions
 
 import { RECONNECT } from '../actions/reconnect';
 
-const { Connecting: CONNECTING, Online: ONLINE, Uninitialized: UNINITIALIZED } = ConnectionStatus;
+const CONNECTING = 1;
+const ONLINE = 2;
+const UNINITIALIZED = 0;
 
 function randomUserID() {
   return `r_${uniqueID().substr(0, 10)}`;


### PR DESCRIPTION
> Fixes #4643.

## Changelog Entry

### Added

-  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4644](https://github.com/microsoft/BotFramework-WebChat/pull/4644)

## Description

Outside of `createDirectLine`, Web Chat should decouple itself from `botframework-directlinejs`.

We found that the only coupling is at `connectSaga.js`, which it imported implementation code from `bf-dljs`. For other places, it is importing only the types.

After this is done, we saw a 11.5% decrease in bundle size, if only our root UI component is imported.

## Design

Web Chat generally decouple itself from `bf-dljs`. Only typing (non-runtime code) and explicit-import (`import { createDirectLine } from 'bf-wc'`) is coupled to `bf-dljs`.

Once this is done, when importing our root UI component, we saw a sharp decrease of app bundle size:

```ts
import { ReactWebChat } from 'botframework-webchat/lib/ReactWebChat';
```

However, note should be taken. `ReactWebChat` is NOT expected to be imported via `bf-wc/lib/ReactWebChat`. Web Chat should carefully design its named exports for this to fully work. And named exports could means breaking changes for web devs who use NPM version of Web Chat.

## Specific Changes

- Update `connectSaga.js` and bring DLJS `ConnectionStatus` in `connectSaga`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
