### PR TITLE
Bump react-film@3.1.1-main.df870ea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645)
+-  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645) and PR [#4648](https://github.com/microsoft/BotFramework-WebChat/pull/4648)
 
 ### Fixed
 

--- a/__tests__/html/suggestedActions.scroll.html
+++ b/__tests__/html/suggestedActions.scroll.html
@@ -25,10 +25,7 @@
         await pageConditions.numActivitiesShown(2);
 
         // WHEN: The right flipper button is clicked.
-        document.querySelector('[aria-label="Suggested actions"] [aria-label="right"]').click();
-
-        // TODO: This will be updated from "left/right" to "next/previous" when the carousel support customizing the aria-label. Commented out for now.
-        // document.querySelector('[aria-label="Suggested actions"] [aria-label="next"]').click();
+        document.querySelector('[aria-label="Suggested actions"] [aria-label="Next"]').click();
 
         // THEN: It should scroll to the right.
         await pageConditions.became(
@@ -38,10 +35,7 @@
         );
 
         // WHEN: The left flipper button is clicked.
-        document.querySelector('[aria-label="Suggested actions"] [aria-label="left"]').click();
-
-        // TODO: This will be updated from "left/right" to "next/previous" when the carousel support customizing the aria-label. Commented out for now.
-        // document.querySelector('[aria-label="Suggested actions"] [aria-label="previous"]').click();
+        document.querySelector('[aria-label="Suggested actions"] [aria-label="Previous"]').click();
 
         // THEN: It should scroll back to the origin.
         await pageConditions.became(

--- a/__tests__/html/suggestedActions.scroll.rtl.html
+++ b/__tests__/html/suggestedActions.scroll.rtl.html
@@ -26,10 +26,7 @@
         await pageConditions.numActivitiesShown(2);
 
         // WHEN: The right flipper button is clicked.
-        document.querySelector('[aria-label="Suggested actions"] [aria-label="left"]').click();
-
-        // TODO: This will be updated from "left/right" to "next/previous" when the carousel support customizing the aria-label. Commented out for now.
-        // document.querySelector('[aria-label="Suggested actions"] [aria-label="next"]').click();
+        document.querySelector('[aria-label="Suggested actions"] [aria-label="Next"]').click();
 
         // THEN: It should scroll to the right.
         await pageConditions.became(
@@ -39,10 +36,7 @@
         );
 
         // WHEN: The left flipper button is clicked.
-        document.querySelector('[aria-label="Suggested actions"] [aria-label="right"]').click();
-
-        // TODO: This will be updated from "left/right" to "next/previous" when the carousel support customizing the aria-label. Commented out for now.
-        // document.querySelector('[aria-label="Suggested actions"] [aria-label="previous"]').click();
+        document.querySelector('[aria-label="Suggested actions"] [aria-label="Previous"]').click();
 
         // THEN: It should scroll back to the origin.
         await pageConditions.became(

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -19,7 +19,7 @@
         "memoize-one": "6.0.0",
         "prop-types": "15.8.1",
         "react-dictate-button": "2.0.1",
-        "react-film": "3.1.0",
+        "react-film": "3.1.1-main.df870ea",
         "react-redux": "7.2.8",
         "react-say": "2.1.0",
         "react-scroll-to-bottom": "4.2.0",
@@ -380,6 +380,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
       "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -908,6 +909,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
       "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -1849,25 +1851,21 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.0.tgz",
-      "integrity": "sha512-xVnpDAAbtxL1dsuSelU5A7BnY/lftws0wUexNJZTPsvX/1tM4GZJbclgODhvW4E+NH7E5VFcH0bBn30NvniPJA==",
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.0.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "stylis": "4.1.3"
       }
     },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
@@ -1882,15 +1880,15 @@
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.10.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.1.tgz",
-      "integrity": "sha512-uZTj3Yz5D69GE25iFZcIQtibnVCFsc/6+XIozyL3ycgWvEdif2uEw9wlUt6umjLr4Keg9K6xRPHmD8LGi+6p1A==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
+        "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "node_modules/@emotion/css": {
@@ -1924,9 +1922,9 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -1936,9 +1934,9 @@
       }
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.0",
@@ -2610,9 +2608,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/core-js": {
-      "version": "3.25.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
-      "integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -3619,16 +3617,17 @@
       }
     },
     "node_modules/react-film": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-film/-/react-film-3.1.0.tgz",
-      "integrity": "sha512-4hIJroKXleVYy2Hk3oStz7Fn4KVweEgWZE8u0YW1+FAd7UDjUWIFR9wl9XPVknBowLiD1ZJumjIF6Imx6Uhsbw==",
+      "version": "3.1.1-main.df870ea",
+      "resolved": "https://registry.npmjs.org/react-film/-/react-film-3.1.1-main.df870ea.tgz",
+      "integrity": "sha512-gMJqQ6LNfV0DnjLdmFZEQyBxLZExQKcNjeHd5ktXVTVjgHHZ3fY2Dkchk1Lj9ovYr8quK1zFacu4f1cNP+9hqQ==",
       "dependencies": {
-        "@emotion/css": "11.1.3",
-        "classnames": "2.3.1",
-        "core-js": "3.12.1",
+        "@babel/runtime-corejs3": "7.20.13",
+        "@emotion/css": "11.10.6",
+        "classnames": "2.3.2",
+        "core-js": "3.28.0",
         "math-random": "2.0.1",
-        "memoize-one": "5.2.1",
-        "prop-types": "15.7.2"
+        "memoize-one": "6.0.0",
+        "prop-types": "15.8.1"
       },
       "peerDependencies": {
         "react": ">= 16.8.6",
@@ -3636,53 +3635,15 @@
       }
     },
     "node_modules/react-film/node_modules/@emotion/css": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
-      "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.6.tgz",
+      "integrity": "sha512-88Sr+3heKAKpj9PCqq5A1hAmAkoSIvwEq1O2TwDij7fUtsJpdkV4jMTISSTouFeRvsGvXIpuSuDQ4C1YdfNGXw==",
       "dependencies": {
-        "@emotion/babel-plugin": "^11.0.0",
-        "@emotion/cache": "^11.1.3",
-        "@emotion/serialize": "^1.0.0",
-        "@emotion/sheet": "^1.0.0",
-        "@emotion/utils": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-film/node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
-    "node_modules/react-film/node_modules/core-js": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.1.tgz",
-      "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/react-film/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-    },
-    "node_modules/react-film/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0"
       }
     },
     "node_modules/react-is": {
@@ -4038,9 +3999,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -4597,7 +4558,8 @@
     "@babel/helper-plugin-utils": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.18.9",
@@ -4952,6 +4914,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
       "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -5592,22 +5555,21 @@
       }
     },
     "@emotion/babel-plugin": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.0.tgz",
-      "integrity": "sha512-xVnpDAAbtxL1dsuSelU5A7BnY/lftws0wUexNJZTPsvX/1tM4GZJbclgODhvW4E+NH7E5VFcH0bBn30NvniPJA==",
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -5618,15 +5580,15 @@
       }
     },
     "@emotion/cache": {
-      "version": "11.10.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.1.tgz",
-      "integrity": "sha512-uZTj3Yz5D69GE25iFZcIQtibnVCFsc/6+XIozyL3ycgWvEdif2uEw9wlUt6umjLr4Keg9K6xRPHmD8LGi+6p1A==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
       "requires": {
         "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
+        "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "@emotion/css": {
@@ -5652,9 +5614,9 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "requires": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -5664,9 +5626,9 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
     },
     "@emotion/unitless": {
       "version": "0.8.0",
@@ -6190,9 +6152,9 @@
       }
     },
     "core-js": {
-      "version": "3.25.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
-      "integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ=="
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw=="
     },
     "core-js-compat": {
       "version": "3.25.3",
@@ -6949,53 +6911,29 @@
       }
     },
     "react-film": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-film/-/react-film-3.1.0.tgz",
-      "integrity": "sha512-4hIJroKXleVYy2Hk3oStz7Fn4KVweEgWZE8u0YW1+FAd7UDjUWIFR9wl9XPVknBowLiD1ZJumjIF6Imx6Uhsbw==",
+      "version": "3.1.1-main.df870ea",
+      "resolved": "https://registry.npmjs.org/react-film/-/react-film-3.1.1-main.df870ea.tgz",
+      "integrity": "sha512-gMJqQ6LNfV0DnjLdmFZEQyBxLZExQKcNjeHd5ktXVTVjgHHZ3fY2Dkchk1Lj9ovYr8quK1zFacu4f1cNP+9hqQ==",
       "requires": {
-        "@emotion/css": "11.1.3",
-        "classnames": "2.3.1",
-        "core-js": "3.12.1",
+        "@babel/runtime-corejs3": "7.20.13",
+        "@emotion/css": "11.10.6",
+        "classnames": "2.3.2",
+        "core-js": "3.28.0",
         "math-random": "2.0.1",
-        "memoize-one": "5.2.1",
-        "prop-types": "15.7.2"
+        "memoize-one": "6.0.0",
+        "prop-types": "15.8.1"
       },
       "dependencies": {
         "@emotion/css": {
-          "version": "11.1.3",
-          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
-          "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+          "version": "11.10.6",
+          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.6.tgz",
+          "integrity": "sha512-88Sr+3heKAKpj9PCqq5A1hAmAkoSIvwEq1O2TwDij7fUtsJpdkV4jMTISSTouFeRvsGvXIpuSuDQ4C1YdfNGXw==",
           "requires": {
-            "@emotion/babel-plugin": "^11.0.0",
-            "@emotion/cache": "^11.1.3",
-            "@emotion/serialize": "^1.0.0",
-            "@emotion/sheet": "^1.0.0",
-            "@emotion/utils": "^1.0.0"
-          }
-        },
-        "classnames": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-        },
-        "core-js": {
-          "version": "3.12.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.1.tgz",
-          "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw=="
-        },
-        "memoize-one": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "@emotion/babel-plugin": "^11.10.6",
+            "@emotion/cache": "^11.10.5",
+            "@emotion/serialize": "^1.1.1",
+            "@emotion/sheet": "^1.2.1",
+            "@emotion/utils": "^1.2.0"
           }
         }
       }
@@ -7286,9 +7224,9 @@
       }
     },
     "stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -75,7 +75,7 @@
     "memoize-one": "6.0.0",
     "prop-types": "15.8.1",
     "react-dictate-button": "2.0.1",
-    "react-film": "3.1.0",
+    "react-film": "3.1.1-main.df870ea",
     "react-redux": "7.2.8",
     "react-say": "2.1.0",
     "react-scroll-to-bottom": "4.2.0",


### PR DESCRIPTION
> Related to #4643.

## Changelog Entry

### Added

-  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645) and PR [#4648](https://github.com/microsoft/BotFramework-WebChat/pull/4648)

## Description

This is to test an imminent release that would target two areas:

- Customize `aria-label` for left/right flipper
- Avoided global pollution of `core-js`

Once this looks good, we will create another pull request to bump to production release.

## Specific Changes

- Bump `react-film` to @3.1.1-main.df870ea
   - Added
      - Added `leftFlipperAriaLabel` and `rightFlipperAriaLabel` for customizing the `aria-label` attribute for flipper buttons, by [@compulim](https://github.com/compulim), in PR [#98](https://github.com/spyip/react-film/pull/98)
   - Changes
      - Avoided global pollution via `@babel/runtime-corejs3`, by [@compulim](https://github.com/compulim), in PR [#99](https://github.com/spyip/react-film/pull/99)
      - Bundle is now built using Webpack for compatibility with IE Mode, by [@compulim](https://github.com/compulim), in PR [#99](https://github.com/spyip/react-film/pull/99)
      - Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#99](https://github.com/spyip/react-film/pull/99)

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed`
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
