### PR TITLE
HTML tests: use <main> for container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645) and PR [#4648](https://github.com/microsoft/BotFramework-WebChat/pull/4648)
 -  Related to [#4650](https://github.com/microsoft/BotFramework-WebChat/issues/4650). Added automated accessibility check using [`axe-core`](https://npmjs.com/package/axe-core)
-   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#4683](https://github.com/microsoft/BotFramework-WebChat/pull/4683)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 -  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645) and PR [#4648](https://github.com/microsoft/BotFramework-WebChat/pull/4648)
+-  Related to [#4650](https://github.com/microsoft/BotFramework-WebChat/issues/4650). Added automated accessibility check using [`axe-core`](https://npmjs.com/package/axe-core)
+   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Resolved [#4643](https://github.com/microsoft/BotFramework-WebChat/issues/4643). Decoupling `botframework-directlinejs` from business logic of Web Chat for better tree-shaking, by [@compulim](https://github.com/compulim), in PR [#4645](https://github.com/microsoft/BotFramework-WebChat/pull/4645) and PR [#4648](https://github.com/microsoft/BotFramework-WebChat/pull/4648)
 -  Related to [#4650](https://github.com/microsoft/BotFramework-WebChat/issues/4650). Added automated accessibility check using [`axe-core`](https://npmjs.com/package/axe-core)
-   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#4683](https://github.com/microsoft/BotFramework-WebChat/pull/4683)
+   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#4684](https://github.com/microsoft/BotFramework-WebChat/pull/4684)
 
 ### Fixed
 

--- a/__tests__/html/accessibility.accessibleName.activityStatus.sendFailed.html
+++ b/__tests__/html/accessibility.accessibleName.activityStatus.sendFailed.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.accessibleName.simple.html
+++ b/__tests__/html/accessibility.accessibleName.simple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.activity.stackedLayoutRole.html
+++ b/__tests__/html/accessibility.activity.stackedLayoutRole.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.adaptiveCard.ariaPushed.html
+++ b/__tests__/html/accessibility.adaptiveCard.ariaPushed.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createActivity(text) {
         return {

--- a/__tests__/html/accessibility.adaptiveCard.disabled.focus.html
+++ b/__tests__/html/accessibility.adaptiveCard.disabled.focus.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="https://unpkg.com/react@18.1.0/umd/react.production.min.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const {

--- a/__tests__/html/accessibility.adaptiveCard.disabled.focus.withShowCard.html
+++ b/__tests__/html/accessibility.adaptiveCard.disabled.focus.withShowCard.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="https://unpkg.com/react@18.1.0/umd/react.production.min.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const {

--- a/__tests__/html/accessibility.adaptiveCard.disabled.inputs.html
+++ b/__tests__/html/accessibility.adaptiveCard.disabled.inputs.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const store = testHelpers.createStore();
       let directLine;

--- a/__tests__/html/accessibility.adaptiveCard.withTapAction.html
+++ b/__tests__/html/accessibility.adaptiveCard.withTapAction.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.adaptiveCard.withoutTapAction.html
+++ b/__tests__/html/accessibility.adaptiveCard.withoutTapAction.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.aria-roledescription.html
+++ b/__tests__/html/accessibility.aria-roledescription.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.attachment.aria.html
+++ b/__tests__/html/accessibility.attachment.aria.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.attachment.carouselLayoutRole.html
+++ b/__tests__/html/accessibility.attachment.carouselLayoutRole.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.attachment.stackedLayoutRole.html
+++ b/__tests__/html/accessibility.attachment.stackedLayoutRole.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.delayActivity.raceCondition.html
+++ b/__tests__/html/accessibility.delayActivity.raceCondition.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // This test is to make sure we don't regress issue #3431, a race condition:
 

--- a/__tests__/html/accessibility.delayActivity.typingActivity.html
+++ b/__tests__/html/accessibility.delayActivity.typingActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.html
+++ b/__tests__/html/accessibility.delayActivity.typingActivityWithoutReplyToActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.delayActivity.withReplyToId.html
+++ b/__tests__/html/accessibility.delayActivity.withReplyToId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.delayActivity.withoutReplyToId.html
+++ b/__tests__/html/accessibility.delayActivity.withoutReplyToId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.heroCard.heading.html
+++ b/__tests__/html/accessibility.heroCard.heading.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.ariaLabel.html
+++ b/__tests__/html/accessibility.keyboardHelp.ariaLabel.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.clickCloseButton.html
+++ b/__tests__/html/accessibility.keyboardHelp.clickCloseButton.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.clickThru.html
+++ b/__tests__/html/accessibility.keyboardHelp.clickThru.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.darkTheme.html
+++ b/__tests__/html/accessibility.keyboardHelp.darkTheme.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.escapeKey.html
+++ b/__tests__/html/accessibility.keyboardHelp.escapeKey.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.forcedColors.html
+++ b/__tests__/html/accessibility.keyboardHelp.forcedColors.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.reducedHeight.html
+++ b/__tests__/html/accessibility.keyboardHelp.reducedHeight.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         // SETUP: Browser window size with height of 480px.

--- a/__tests__/html/accessibility.keyboardHelp.reducedWidth.html
+++ b/__tests__/html/accessibility.keyboardHelp.reducedWidth.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         // SETUP: Browser window size with height of 480px.

--- a/__tests__/html/accessibility.keyboardHelp.tabKey.html
+++ b/__tests__/html/accessibility.keyboardHelp.tabKey.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.keyboardHelp.zeroHeight.html
+++ b/__tests__/html/accessibility.keyboardHelp.zeroHeight.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         // SETUP: Browser window size with height of 42px.

--- a/__tests__/html/accessibility.landmarkRole.invalid.html
+++ b/__tests__/html/accessibility.landmarkRole.invalid.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.landmarkRole.valid.html
+++ b/__tests__/html/accessibility.landmarkRole.valid.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.contrast.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.contrast.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.event.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.event.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.typing.html
+++ b/__tests__/html/accessibility.liveRegion.activityStatus.sendFailed.typing.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/accessibility.liveRegionActivity.htmlInMarkdown.html
+++ b/__tests__/html/accessibility.liveRegionActivity.htmlInMarkdown.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="https://unpkg.com/markdown-it@12.0.6/dist/markdown-it.min.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const baseActivity = {

--- a/__tests__/html/accessibility.liveRegionActivity.performance.html
+++ b/__tests__/html/accessibility.liveRegionActivity.performance.html
@@ -9,7 +9,7 @@
     <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const baseActivity = {

--- a/__tests__/html/accessibility.liveRegionActivity.speakOverrideAttachments.html
+++ b/__tests__/html/accessibility.liveRegionActivity.speakOverrideAttachments.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const timestamp = new Date(2000, 0, 1, 12, 34, 56, 789).toISOString();

--- a/__tests__/html/accessibility.liveRegionActivity.text.html
+++ b/__tests__/html/accessibility.liveRegionActivity.text.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.windowSize(360, 800, document.getElementById('webchat'));

--- a/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.speakProperty.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.adaptiveCard.speakProperty.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.animationCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.animationCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.audio.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.audio.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.audioCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.audioCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.file.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.file.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.heroCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.heroCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.image.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.image.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.receiptCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.receiptCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.signInCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.signInCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.thumbnailCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.thumbnailCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.unknownCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.unknownCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.video.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.video.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionAttachment.videoCard.html
+++ b/__tests__/html/accessibility.liveRegionAttachment.videoCard.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/accessibility.liveRegionSuggestedActions.withMessage.html
+++ b/__tests__/html/accessibility.liveRegionSuggestedActions.withMessage.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const baseActivity = {

--- a/__tests__/html/accessibility.liveRegionSuggestedActions.withoutMessage.html
+++ b/__tests__/html/accessibility.liveRegionSuggestedActions.withoutMessage.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const baseActivity = {

--- a/__tests__/html/accessibility.sendBox.alertEmptyMessage.multilineTextBox.enter.html
+++ b/__tests__/html/accessibility.sendBox.alertEmptyMessage.multilineTextBox.enter.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.sendBox.alertEmptyMessage.sendButton.html
+++ b/__tests__/html/accessibility.sendBox.alertEmptyMessage.sendButton.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.sendBox.alertEmptyMessage.singleLineTextBox.enter.html
+++ b/__tests__/html/accessibility.sendBox.alertEmptyMessage.singleLineTextBox.enter.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.sendBox.alertOffline.sendButton.html
+++ b/__tests__/html/accessibility.sendBox.alertOffline.sendButton.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/accessibility.stackedLayout.withoutText.html
+++ b/__tests__/html/accessibility.stackedLayout.withoutText.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.suggestedActions.altText.html
+++ b/__tests__/html/accessibility.suggestedActions.altText.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/accessibility.suggestedActions.carouselLayout.ariaAttributes.html
+++ b/__tests__/html/accessibility.suggestedActions.carouselLayout.ariaAttributes.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.suggestedActions.flowLayout.ariaAttributes.html
+++ b/__tests__/html/accessibility.suggestedActions.flowLayout.ariaAttributes.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.suggestedActions.stackedLayout.ariaAttributes.html
+++ b/__tests__/html/accessibility.suggestedActions.stackedLayout.ariaAttributes.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/accessibility.transcript.initialEmpty.html
+++ b/__tests__/html/accessibility.transcript.initialEmpty.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/activity.unknownActivity.html
+++ b/__tests__/html/activity.unknownActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/activity.unknownAttachment.html
+++ b/__tests__/html/activity.unknownAttachment.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/activityGrouping.avatarMiddleware.atBottom.html
+++ b/__tests__/html/activityGrouping.avatarMiddleware.atBottom.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useMemo },

--- a/__tests__/html/activityGrouping.avatarMiddleware.html
+++ b/__tests__/html/activityGrouping.avatarMiddleware.html
@@ -42,7 +42,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useMemo },

--- a/__tests__/html/activityGrouping.customMiddleware.html
+++ b/__tests__/html/activityGrouping.customMiddleware.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function bin(items, grouping) {
         let lastBin;

--- a/__tests__/html/activityGrouping.disableTimestamp.html
+++ b/__tests__/html/activityGrouping.disableTimestamp.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/activityGrouping.groupingActivityStatus.html
+++ b/__tests__/html/activityGrouping.groupingActivityStatus.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.windowSize(undefined, 1280, document.getElementById('webchat'));

--- a/__tests__/html/activityGrouping.legacyActivityMiddleware.html
+++ b/__tests__/html/activityGrouping.legacyActivityMiddleware.html
@@ -27,7 +27,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       run(async function () {
         await host.windowSize(undefined, 1280, document.getElementById('webchat'));

--- a/__tests__/html/activityGrouping.legacyActivityStatusMiddleware.html
+++ b/__tests__/html/activityGrouping.legacyActivityStatusMiddleware.html
@@ -22,7 +22,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/activityStatus.sendFailed.noEchoBack.html
+++ b/__tests__/html/activityStatus.sendFailed.noEchoBack.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest() {
         return testHelpers.createDirectLineWithTranscript([], {

--- a/__tests__/html/activityStatus.sendFailed.postActivity.error.html
+++ b/__tests__/html/activityStatus.sendFailed.postActivity.error.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
        async function createDirectLineForTest() {
         const directLine = await testHelpers.createDirectLineWithTranscript([], {

--- a/__tests__/html/activityStatus.sendFailed.postActivity.noReturnValue.html
+++ b/__tests__/html/activityStatus.sendFailed.postActivity.noReturnValue.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       async function createDirectLineForTest() {
         const directLine = await testHelpers.createDirectLineWithTranscript([], {

--- a/__tests__/html/activityStatus.sent.echoBack.after.postActivity.html
+++ b/__tests__/html/activityStatus.sent.echoBack.after.postActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       async function createDirectLineForTest() {
         const directLine = await testHelpers.createDirectLineWithTranscript([], {

--- a/__tests__/html/activityStatus.sent.echoBack.before.postActivity.html
+++ b/__tests__/html/activityStatus.sent.echoBack.before.postActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       async function createDirectLineForTest() {
         const directLine = await testHelpers.createDirectLineWithTranscript([], {

--- a/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
+++ b/__tests__/html/activityStatusTelemetry.ignoreStatusChange.incomingActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendFiles.attachmentUrl.sendingToSent.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const testAttachmentActivity = {

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailed.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSendFailedToSent.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const store = testHelpers.createStore();
       const directLine = testHelpers.createDirectLineEmulator(store);

--- a/__tests__/html/activityStatusTelemetry.sendingToSent.html
+++ b/__tests__/html/activityStatusTelemetry.sendingToSent.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/adaptiveCards.assumeBorderBox.html
+++ b/__tests__/html/adaptiveCards.assumeBorderBox.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // Adaptive Card assume it is always hosted in "border-box" mode.
       run(async function () {

--- a/__tests__/html/adaptiveCards.parserMaxVersion.html
+++ b/__tests__/html/adaptiveCards.parserMaxVersion.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/adaptiveCards.tapAction.html
+++ b/__tests__/html/adaptiveCards.tapAction.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/attachment.allowedProtocol.html
+++ b/__tests__/html/attachment.allowedProtocol.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const canvas = document.createElement('canvas');

--- a/__tests__/html/attachment.allowedProtocol.oauthCard.html
+++ b/__tests__/html/attachment.allowedProtocol.oauthCard.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/attachment.fileContent.blobURL.html
+++ b/__tests__/html/attachment.fileContent.blobURL.html
@@ -9,7 +9,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const {

--- a/__tests__/html/attachment.forbiddenProtocol.html
+++ b/__tests__/html/attachment.forbiddenProtocol.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/attachment.forbiddenProtocol.oauthCard.html
+++ b/__tests__/html/attachment.forbiddenProtocol.oauthCard.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/autoScroll.acknowledgement.html
+++ b/__tests__/html/autoScroll.acknowledgement.html
@@ -23,7 +23,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <div class="button-bar">
       <button class="add-activity-button">Add activity with 10 lines</button>
       <br />

--- a/__tests__/html/autoScroll.afterSend.html
+++ b/__tests__/html/autoScroll.afterSend.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/autoScroll.eventActivity.html
+++ b/__tests__/html/autoScroll.eventActivity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createActivity(text) {
         return {

--- a/__tests__/html/autoScroll.snap.activity.html
+++ b/__tests__/html/autoScroll.snap.activity.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const directLine = testHelpers.createDirectLineWithTranscript([createActivity(20)]);
       const store = testHelpers.createStore();

--- a/__tests__/html/autoScroll.snap.activityAndPage.html
+++ b/__tests__/html/autoScroll.snap.activityAndPage.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const directLine = testHelpers.createDirectLineWithTranscript([createActivity(20)]);
       const store = testHelpers.createStore();

--- a/__tests__/html/autoScroll.snap.default.html
+++ b/__tests__/html/autoScroll.snap.default.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const directLine = testHelpers.createDirectLineWithTranscript([createActivity(20)]);
       const store = testHelpers.createStore();

--- a/__tests__/html/autoScroll.snap.page.html
+++ b/__tests__/html/autoScroll.snap.page.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const directLine = testHelpers.createDirectLineWithTranscript([createActivity(20)]);
       const store = testHelpers.createStore();

--- a/__tests__/html/autoScroll.withPostBack.activity.html
+++ b/__tests__/html/autoScroll.withPostBack.activity.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createActivity(text) {
         return {

--- a/__tests__/html/autoScroll.withPostBack.page.html
+++ b/__tests__/html/autoScroll.withPostBack.page.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createActivity(text) {
         return {

--- a/__tests__/html/autoScroll.withSuggestedActions.submitAdaptiveCards.html
+++ b/__tests__/html/autoScroll.withSuggestedActions.submitAdaptiveCards.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/avatar.emptyInitials.html
+++ b/__tests__/html/avatar.emptyInitials.html
@@ -23,7 +23,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useMemo }

--- a/__tests__/html/avatar.undefinedInitials.html
+++ b/__tests__/html/avatar.undefinedInitials.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useMemo }

--- a/__tests__/html/cardAction.adaptiveCard.cardAgenda.html
+++ b/__tests__/html/cardAction.adaptiveCard.cardAgenda.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/cardAction.adaptiveCard.cardAgendaTranscript.html
+++ b/__tests__/html/cardAction.adaptiveCard.cardAgendaTranscript.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/cardAction.adaptiveCard.disallowedScheme.html
+++ b/__tests__/html/cardAction.adaptiveCard.disallowedScheme.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/cardAction.adaptiveCard.openURL.html
+++ b/__tests__/html/cardAction.adaptiveCard.openURL.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/cardAction.adaptiveCard.parseValidation.html
+++ b/__tests__/html/cardAction.adaptiveCard.parseValidation.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/cardAction.heroCard.disallowedScheme.html
+++ b/__tests__/html/cardAction.heroCard.disallowedScheme.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/cardAction.heroCard.openURL.html
+++ b/__tests__/html/cardAction.heroCard.openURL.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/carousel.flipperButton.html
+++ b/__tests__/html/carousel.flipperButton.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/carousel.flipperButton.rtl.html
+++ b/__tests__/html/carousel.flipperButton.rtl.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/carousel.navigation.tab.cardInput.html
+++ b/__tests__/html/carousel.navigation.tab.cardInput.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/carousel.navigation.tab.html
+++ b/__tests__/html/carousel.navigation.tab.html
@@ -12,7 +12,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/chatAdapter.directLineAppServiceExtension.html
+++ b/__tests__/html/chatAdapter.directLineAppServiceExtension.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/chatAdapter.directLineSpeech.html
+++ b/__tests__/html/chatAdapter.directLineSpeech.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/chatAdapter.nullFields.html
+++ b/__tests__/html/chatAdapter.nullFields.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         function createDirectLineForTest(options) {

--- a/__tests__/html/chatAdapter.sequenceId.directLine.outgoing.html
+++ b/__tests__/html/chatAdapter.sequenceId.directLine.outgoing.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const BASE_TIMESTAMP = +new Date(2020, 0, 1, 12, 34);
 

--- a/__tests__/html/chatAdapter.sequenceId.noSequenceId.html
+++ b/__tests__/html/chatAdapter.sequenceId.noSequenceId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const BASE_TIMESTAMP = +new Date(2020, 0, 1, 12, 34);
 

--- a/__tests__/html/chatAdapter.sequenceId.simple.html
+++ b/__tests__/html/chatAdapter.sequenceId.simple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const BASE_TIMESTAMP = +new Date(2020, 0, 1, 12, 34);
 

--- a/__tests__/html/chatHistory.restore.sent.html
+++ b/__tests__/html/chatHistory.restore.sent.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install({ now: new Date('2022-11-11T19:34:00.000Z') });

--- a/__tests__/html/conversationStartProperties.noLocaleIsSent.html
+++ b/__tests__/html/conversationStartProperties.noLocaleIsSent.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/conversationStartProperties.sendEnUs.html
+++ b/__tests__/html/conversationStartProperties.sendEnUs.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/conversationStartProperties.sendInvalidType.html
+++ b/__tests__/html/conversationStartProperties.sendInvalidType.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/conversationStartProperties.sendNonExisting.html
+++ b/__tests__/html/conversationStartProperties.sendNonExisting.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/conversationStartProperties.sendNonISOFormat.html
+++ b/__tests__/html/conversationStartProperties.sendNonISOFormat.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/conversationStartProperties.sendZhCn.html
+++ b/__tests__/html/conversationStartProperties.sendZhCn.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       // TODO: We should update this test with new MockBot.
       run(async function () {

--- a/__tests__/html/customization.basicWebChat.restructure.html
+++ b/__tests__/html/customization.basicWebChat.restructure.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },
@@ -49,7 +49,7 @@
 
         const container = document.getElementById('webchat');
         expect(container?.firstChild).not.toBeUndefined();
-        
+
         const surface = container.firstChild;
         expect(surface.className).toContain(classes.surface);
         expect(surface.role).toEqual(role);

--- a/__tests__/html/deprecated.localize.html
+++ b/__tests__/html/deprecated.localize.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         WebChat: {

--- a/__tests__/html/directLine.postActivity.localTimezone.html
+++ b/__tests__/html/directLine.postActivity.localTimezone.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'America/Los_Angeles' });

--- a/__tests__/html/directLine.postActivity.localTimezone.noIntl.html
+++ b/__tests__/html/directLine.postActivity.localTimezone.noIntl.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.sendDevToolsCommand('Emulation.setTimezoneOverride', { timezoneId: 'America/Los_Angeles' });

--- a/__tests__/html/directLine.setUserId.html
+++ b/__tests__/html/directLine.setUserId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         let userId;

--- a/__tests__/html/focusManagement.disableAdaptiveCard.manual.html
+++ b/__tests__/html/focusManagement.disableAdaptiveCard.manual.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/focusManagement.disableHeroCard.obsolete.html
+++ b/__tests__/html/focusManagement.disableHeroCard.obsolete.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         WebChat: {

--- a/__tests__/html/focusManagement.disableUI.html
+++ b/__tests__/html/focusManagement.disableUI.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/focusManagement.scrollToEndButton.receiveHeroCard.html
+++ b/__tests__/html/focusManagement.scrollToEndButton.receiveHeroCard.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/focusManagement.scrollToEndButton.receiveMessage.html
+++ b/__tests__/html/focusManagement.scrollToEndButton.receiveMessage.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/focusManagement.sendBoxTextBoxSubmit.html
+++ b/__tests__/html/focusManagement.sendBoxTextBoxSubmit.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/focusManagement.sendFailedRetry.html
+++ b/__tests__/html/focusManagement.sendFailedRetry.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/focusManagement.suggestedActions.html
+++ b/__tests__/html/focusManagement.suggestedActions.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/heroCard.actions.html
+++ b/__tests__/html/heroCard.actions.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/hooks.useCreateActivityRenderer.html
+++ b/__tests__/html/hooks.useCreateActivityRenderer.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useCreateActivityStatusRenderer.html
+++ b/__tests__/html/hooks.useCreateActivityStatusRenderer.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useCreateAvatarRenderer.html
+++ b/__tests__/html/hooks.useCreateAvatarRenderer.html
@@ -29,7 +29,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useGetSendTimeoutForActivity.html
+++ b/__tests__/html/hooks.useGetSendTimeoutForActivity.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useObserveScrollPosition.html
+++ b/__tests__/html/hooks.useObserveScrollPosition.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useRenderActivity.html
+++ b/__tests__/html/hooks.useRenderActivity.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useRenderActivityStatus.html
+++ b/__tests__/html/hooks.useRenderActivityStatus.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useRenderAttachment.html
+++ b/__tests__/html/hooks.useRenderAttachment.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useRenderAvatar.html
+++ b/__tests__/html/hooks.useRenderAvatar.html
@@ -29,7 +29,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/hooks.useScrollTo.activityID.html
+++ b/__tests__/html/hooks.useScrollTo.activityID.html
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useScrollTo.keepScrollToEndButton.html
+++ b/__tests__/html/hooks.useScrollTo.keepScrollToEndButton.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useScrollToEnd.hideScrollToEndButton.html
+++ b/__tests__/html/hooks.useScrollToEnd.hideScrollToEndButton.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useScrollUpDown.html
+++ b/__tests__/html/hooks.useScrollUpDown.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         WebChat: {

--- a/__tests__/html/hooks.useSendTimeoutForActivity.html
+++ b/__tests__/html/hooks.useSendTimeoutForActivity.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useLayoutEffect, useRef, useState },

--- a/__tests__/html/hooks.useTextBox.html
+++ b/__tests__/html/hooks.useTextBox.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         WebChat: {

--- a/__tests__/html/locale.keep.html
+++ b/__tests__/html/locale.keep.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/localization.customization.html
+++ b/__tests__/html/localization.customization.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([]);

--- a/__tests__/html/localization.fileUpload.polish.html
+++ b/__tests__/html/localization.fileUpload.polish.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/markdown.attributes.curlyBrackets.html
+++ b/__tests__/html/markdown.attributes.curlyBrackets.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.windowSize(undefined, 1440, document.getElementById('webchat'));

--- a/__tests__/html/markdown.disableRenderMarkdown.html
+++ b/__tests__/html/markdown.disableRenderMarkdown.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/markdown.noJavaScriptScheme.html
+++ b/__tests__/html/markdown.noJavaScriptScheme.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/markdown.rel.html
+++ b/__tests__/html/markdown.rel.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/middleware.liveRegionAttachment.noWarning.returnFalse.html
+++ b/__tests__/html/middleware.liveRegionAttachment.noWarning.returnFalse.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/middleware.liveRegionAttachment.noWarning.returnRenderFunction.html
+++ b/__tests__/html/middleware.liveRegionAttachment.noWarning.returnRenderFunction.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/middleware.liveRegionAttachment.warning.returnElement.html
+++ b/__tests__/html/middleware.liveRegionAttachment.warning.returnElement.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/middleware.liveRegionAttachment.warning.returnRenderFunctionReturnFalse.html
+++ b/__tests__/html/middleware.liveRegionAttachment.warning.returnRenderFunctionReturnFalse.html
@@ -11,7 +11,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         ReactDOM: { render },

--- a/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.html
+++ b/__tests__/html/middleware.obsoleteAdaptiveCard.anchor.html
@@ -9,7 +9,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const attachmentMiddleware = () => next => card => {

--- a/__tests__/html/offlineUI.fatalError.html
+++ b/__tests__/html/offlineUI.fatalError.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/offlineUI.firstConnect.html
+++ b/__tests__/html/offlineUI.firstConnect.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         const UNINITIALIZED = 0;

--- a/__tests__/html/offlineUI.invalidCredentials.html
+++ b/__tests__/html/offlineUI.invalidCredentials.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         const FAILED = 4;

--- a/__tests__/html/offlineUI.networkInterrupt.html
+++ b/__tests__/html/offlineUI.networkInterrupt.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         function createDirectLineForTest(options) {

--- a/__tests__/html/offlineUI.slowNetwork.firstConnect.html
+++ b/__tests__/html/offlineUI.slowNetwork.firstConnect.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         // This part of code is running in the JavaScript VM in Chromium.

--- a/__tests__/html/offlineUI.slowNetwork.reconnect.html
+++ b/__tests__/html/offlineUI.slowNetwork.reconnect.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         const CONNECTING = 1;

--- a/__tests__/html/replyToId.firstSetOfActivities.html
+++ b/__tests__/html/replyToId.firstSetOfActivities.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/replyToId.subsequentSetOfActivities.html
+++ b/__tests__/html/replyToId.subsequentSetOfActivities.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/scrollToEndButton.click.html
+++ b/__tests__/html/scrollToEndButton.click.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const paragraphs = [

--- a/__tests__/html/scrollToEndButton.containerSize.html
+++ b/__tests__/html/scrollToEndButton.containerSize.html
@@ -46,7 +46,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { Fragment, useCallback, useState },

--- a/__tests__/html/scrollToEndButton.customization.html
+++ b/__tests__/html/scrollToEndButton.customization.html
@@ -38,7 +38,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       run(async function () {
         const paragraphs = [

--- a/__tests__/html/scrollToEndButton.notFlashy.html
+++ b/__tests__/html/scrollToEndButton.notFlashy.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       run(async function () {
         const {

--- a/__tests__/html/scrollToEndButton.persistWhileCallingUseScrollTo.html
+++ b/__tests__/html/scrollToEndButton.persistWhileCallingUseScrollTo.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       run(async function () {
         const {

--- a/__tests__/html/scrollToEndButton.tabOrder.html
+++ b/__tests__/html/scrollToEndButton.tabOrder.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/scrollToEndButton.typingIndicator.html
+++ b/__tests__/html/scrollToEndButton.typingIndicator.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/scrollToEndButton.visibility.html
+++ b/__tests__/html/scrollToEndButton.visibility.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/scrollToEndButton.withEventActivities.html
+++ b/__tests__/html/scrollToEndButton.withEventActivities.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         function createEventActivity() {

--- a/__tests__/html/sendBox.button.styleOptions.html
+++ b/__tests__/html/sendBox.button.styleOptions.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([]);

--- a/__tests__/html/sendBox.buttonAlignment.html
+++ b/__tests__/html/sendBox.buttonAlignment.html
@@ -51,7 +51,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { Fragment, useCallback, useEffect, useMemo, useState },

--- a/__tests__/html/sendFiles.attachmentUrl.html
+++ b/__tests__/html/sendFiles.attachmentUrl.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/sendFiles.textFiles.html
+++ b/__tests__/html/sendFiles.textFiles.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/simple.html
+++ b/__tests__/html/simple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/simple.rootClassName.html
+++ b/__tests__/html/simple.rootClassName.html
@@ -12,7 +12,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/simple.throwError.html
+++ b/__tests__/html/simple.throwError.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         // This is to test if the test harness can capture errors correctly.

--- a/__tests__/html/speech.customAudioConfig.html
+++ b/__tests__/html/speech.customAudioConfig.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const { authorizationToken, region } = await fetch(

--- a/__tests__/html/speechRecognition.simple.html
+++ b/__tests__/html/speechRecognition.simple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       const {
         testHelpers: {

--- a/__tests__/html/styleOptions.deprecated.hideScrollToEndButton.html
+++ b/__tests__/html/styleOptions.deprecated.hideScrollToEndButton.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/styleOptions.deprecated.newMessageButtonFontSize.html
+++ b/__tests__/html/styleOptions.deprecated.newMessageButtonFontSize.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/styleOptions.emojiSet.custom.html
+++ b/__tests__/html/styleOptions.emojiSet.custom.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/styleOptions.emojiSet.default.html
+++ b/__tests__/html/styleOptions.emojiSet.default.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/styleOptions.emojiSet.disabled.html
+++ b/__tests__/html/styleOptions.emojiSet.disabled.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/styleOptions.emojiSet.enabled.html
+++ b/__tests__/html/styleOptions.emojiSet.enabled.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/styleOptions.scrollToEndButtonBehavior.html
+++ b/__tests__/html/styleOptions.scrollToEndButtonBehavior.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const paragraphs = [

--- a/__tests__/html/styleOptions.scrollToEndButtonFontSize.html
+++ b/__tests__/html/styleOptions.scrollToEndButtonFontSize.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const paragraphs = [

--- a/__tests__/html/suggestedActions.accessKey.html
+++ b/__tests__/html/suggestedActions.accessKey.html
@@ -35,7 +35,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <input accesskey="S" class="form-input" type="text" value="This box is outside." />
     <script type="text/babel" data-presets="env,stage-3,react">
       const {

--- a/__tests__/html/suggestedActions.layout.html
+++ b/__tests__/html/suggestedActions.layout.html
@@ -42,7 +42,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useEffect, useMemo, useState },

--- a/__tests__/html/suggestedActions.noAccessKey.html
+++ b/__tests__/html/suggestedActions.noAccessKey.html
@@ -26,7 +26,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/suggestedActions.rovingTabIndex.escapeKey.html
+++ b/__tests__/html/suggestedActions.rovingTabIndex.escapeKey.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.rovingTabIndex.resetAfterClick.html
+++ b/__tests__/html/suggestedActions.rovingTabIndex.resetAfterClick.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.rovingTabIndex.vertical.html
+++ b/__tests__/html/suggestedActions.rovingTabIndex.vertical.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.rovingTabIndex.wraparound.html
+++ b/__tests__/html/suggestedActions.rovingTabIndex.wraparound.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.scroll.html
+++ b/__tests__/html/suggestedActions.scroll.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.scroll.rtl.html
+++ b/__tests__/html/suggestedActions.scroll.rtl.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/suggestedActions.stacked.buttonTextWrap.html
+++ b/__tests__/html/suggestedActions.stacked.buttonTextWrap.html
@@ -12,7 +12,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         await host.windowSize(300, undefined, document.getElementById('webchat'));

--- a/__tests__/html/suggestedActions.styleOptions.html
+++ b/__tests__/html/suggestedActions.styleOptions.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/timestamp.attachmentSendTimeout.html
+++ b/__tests__/html/timestamp.attachmentSendTimeout.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         const workingDirectLine = WebChat.createDirectLine(options);

--- a/__tests__/html/timestamp.beforeYesterday.html
+++ b/__tests__/html/timestamp.beforeYesterday.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function mapObservable(observable, { next }) {
         return new Observable(observer => {

--- a/__tests__/html/timestamp.changeSendTimeout.html
+++ b/__tests__/html/timestamp.changeSendTimeout.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       function createDirectLineForTest(options) {
         const workingDirectLine = WebChat.createDirectLine(options);

--- a/__tests__/html/toast.accessibility.html
+++ b/__tests__/html/toast.accessibility.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore({}, ({ dispatch }) => next => action => {

--- a/__tests__/html/toast.customizeDebounceTimeout.html
+++ b/__tests__/html/toast.customizeDebounceTimeout.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/toast.html
+++ b/__tests__/html/toast.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore({}, ({ dispatch }) => next => action => {

--- a/__tests__/html/toast.showUpdateDismiss.html
+++ b/__tests__/html/toast.showUpdateDismiss.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/toast.twoVeryLongNotifications.html
+++ b/__tests__/html/toast.twoVeryLongNotifications.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/toast.undefined.html
+++ b/__tests__/html/toast.undefined.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useEffect },

--- a/__tests__/html/toaster.hideToaster.html
+++ b/__tests__/html/toaster.hideToaster.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/toaster.moveRecentToTop.html
+++ b/__tests__/html/toaster.moveRecentToTop.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/toaster.twoNotifications.closeOne.html
+++ b/__tests__/html/toaster.twoNotifications.closeOne.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/toaster.twoNotifications.expandCollapse.html
+++ b/__tests__/html/toaster.twoNotifications.expandCollapse.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/transcript.activityGrouping.html
+++ b/__tests__/html/transcript.activityGrouping.html
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useContext, useEffect, useMemo },

--- a/__tests__/html/transcript.activityStatus.intermediateSendFailed.html
+++ b/__tests__/html/transcript.activityStatus.intermediateSendFailed.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/transcript.legacyActivityMiddleware.passwordInput.html
+++ b/__tests__/html/transcript.legacyActivityMiddleware.passwordInput.html
@@ -49,7 +49,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback, useState },

--- a/__tests__/html/transcript.legacyActivityMiddleware.reactionButtons.html
+++ b/__tests__/html/transcript.legacyActivityMiddleware.reactionButtons.html
@@ -35,7 +35,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         React: { useCallback },

--- a/__tests__/html/transcript.navigation.adaptiveCard.focusInput.html
+++ b/__tests__/html/transcript.navigation.adaptiveCard.focusInput.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.behavior.proactive.adaptiveCard.html
+++ b/__tests__/html/transcript.navigation.behavior.proactive.adaptiveCard.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/transcript.navigation.behavior.proactive.message.html
+++ b/__tests__/html/transcript.navigation.behavior.proactive.message.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = await testHelpers.createDirectLineWithTranscript([

--- a/__tests__/html/transcript.navigation.defaultActiveDescendant.shiftTab.html
+++ b/__tests__/html/transcript.navigation.defaultActiveDescendant.shiftTab.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <button class="first-button" type="button">First button on the page</button>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.defaultActiveDescendant.tab.html
+++ b/__tests__/html/transcript.navigation.defaultActiveDescendant.tab.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <button class="first-button" type="button">First button on the page</button>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.escapeKey.html
+++ b/__tests__/html/transcript.navigation.escapeKey.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.byClick.html
+++ b/__tests__/html/transcript.navigation.focusActivity.byClick.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.byClick.onEdges.html
+++ b/__tests__/html/transcript.navigation.focusActivity.byClick.onEdges.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.focusCard.html
+++ b/__tests__/html/transcript.navigation.focusActivity.focusCard.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.saveFocus.html
+++ b/__tests__/html/transcript.navigation.focusActivity.saveFocus.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.assumptions.html
+++ b/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.assumptions.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.keyboard.html
+++ b/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.keyboard.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.mouse.html
+++ b/__tests__/html/transcript.navigation.focusActivity.scrollIntoView.mouse.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.focusAttachment.enterKey.html
+++ b/__tests__/html/transcript.navigation.focusAttachment.enterKey.html
@@ -13,7 +13,7 @@
     ></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.pageUpDown.html
+++ b/__tests__/html/transcript.navigation.pageUpDown.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.scrollIntoView.html
+++ b/__tests__/html/transcript.navigation.scrollIntoView.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.scrollIntoView.keyboard.html
+++ b/__tests__/html/transcript.navigation.scrollIntoView.keyboard.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       let counter = 0;
 

--- a/__tests__/html/transcript.navigation.scrollIntoView.mouse.html
+++ b/__tests__/html/transcript.navigation.scrollIntoView.mouse.html
@@ -8,7 +8,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       let counter = 0;
 

--- a/__tests__/html/transcript.navigation.upArrowOnTerminator.html
+++ b/__tests__/html/transcript.navigation.upArrowOnTerminator.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/transcript.navigation.useObserveTranscriptFocus.html
+++ b/__tests__/html/transcript.navigation.useObserveTranscriptFocus.html
@@ -10,7 +10,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script type="text/babel" data-presets="env,stage-3,react">
       const {
         WebChat: {

--- a/__tests__/html/transcript.navigation.visualKeyboardIndicator.html
+++ b/__tests__/html/transcript.navigation.visualKeyboardIndicator.html
@@ -21,7 +21,7 @@
   </head>
   <body>
     <button id="top-button">First button on the page</button>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/typingIndicator.liveRegion.fromName.html
+++ b/__tests__/html/typingIndicator.liveRegion.fromName.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = testHelpers.createDirectLineWithTranscript();

--- a/__tests__/html/typingIndicator.liveRegion.multiple.html
+++ b/__tests__/html/typingIndicator.liveRegion.multiple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/typingIndicator.liveRegion.simple.html
+++ b/__tests__/html/typingIndicator.liveRegion.simple.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const clock = lolex.install();

--- a/__tests__/html/updateActivity.sameActivityId.html
+++ b/__tests__/html/updateActivity.sameActivityId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const workingDirectLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/updateActivity.undefinedActivityId.html
+++ b/__tests__/html/updateActivity.undefinedActivityId.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const workingDirectLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/upload.image.html
+++ b/__tests__/html/upload.image.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         WebChat.renderWebChat(

--- a/__tests__/html/useFocus.main.html
+++ b/__tests__/html/useFocus.main.html
@@ -14,7 +14,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const renderWebChatWithHook = testHelpers.createRenderWebChatWithHook(

--- a/__tests__/html/useFocus.sendBox.html
+++ b/__tests__/html/useFocus.sendBox.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/useFocus.sendBoxWithoutKeyboard.html
+++ b/__tests__/html/useFocus.sendBoxWithoutKeyboard.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/useFocusSendBox.html
+++ b/__tests__/html/useFocusSendBox.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(
         async function () {

--- a/__tests__/html/useTextBoxSubmit.main.html
+++ b/__tests__/html/useTextBoxSubmit.main.html
@@ -14,7 +14,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const renderWebChatWithHook = testHelpers.createRenderWebChatWithHook(

--- a/__tests__/html/useTextBoxSubmit.sendBox.html
+++ b/__tests__/html/useTextBoxSubmit.sendBox.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/useTextBoxSubmit.sendBoxWithoutKeyboard.html
+++ b/__tests__/html/useTextBoxSubmit.sendBoxWithoutKeyboard.html
@@ -13,7 +13,7 @@
     </style>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });

--- a/__tests__/html/video.vimeo.sandbox.html
+++ b/__tests__/html/video.vimeo.sandbox.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();

--- a/__tests__/html/video.youtube.sandbox.html
+++ b/__tests__/html/video.youtube.sandbox.html
@@ -7,7 +7,7 @@
     <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
   </head>
   <body>
-    <div id="webchat"></div>
+    <main id="webchat"></main>
     <script>
       run(async function () {
         const store = testHelpers.createStore();


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4650.

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

-  Related to [#4650](https://github.com/microsoft/BotFramework-WebChat/issues/4650). Added automated accessibility check using [`axe-core`](https://npmjs.com/package/axe-core)
   -  HTML test: using `<main>` for the root container, by [@compulim](https://github.com/compulim), in PR [#4683](https://github.com/microsoft/BotFramework-WebChat/pull/4683)

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

In our HTML tests, replace `<div id="root">` with `<main id="root">`. This is one thing flagged by `axe-core`.

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

- Under `__tests__/html/`, replace-all `<div id="root"></div>` with `<main id="root"></main>`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
