### PR TITLE
Bump to 4.15.8 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.15.8] - 2023-06-06
+
 ### Breaking changes
 
 -  When `activity.channelData['webchat:fallback-text']` is present but empty, it will no longer applies `aria-hidden` to the activity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.8-0",
+  "version": "4.15.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.8-0",
+      "version": "4.15.8",
       "license": "MIT",
       "dependencies": {
         "react": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.8-0",
+  "version": "4.15.8",
   "private": true,
   "files": [
     "lib/**/*"


### PR DESCRIPTION
> Related to #4738.

## Changelog Entry

(No changelog for version bump)

## Description

Bump to `4.15.8` to prepare for release.

## Specific Changes

- `npm version 4.15.8 --no-git-tag-version`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
