### PR TITLE
Disable dark theme in until chat history has dark theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+-  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#4864](https://github.com/microsoft/BotFramework-WebChat/pull/4864)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)
+
 ### Added
 
 -  Resolves [#4853](https://github.com/microsoft/BotFramework-WebChat/issues/4853). Shorten URLs in link definitions UI, by [@compulim](https://github.com/compulim), in PR [#4860](https://github.com/microsoft/BotFramework-WebChat/pull/4860)

--- a/packages/component/src/Styles/StyleSet/Constants.ts
+++ b/packages/component/src/Styles/StyleSet/Constants.ts
@@ -1,7 +1,6 @@
 const DARK_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: dark)';
-const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
-
 const FORCED_COLORS_SELECTOR = '@media (forced-colors: active)';
+const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
 const NOT_FORCED_COLORS_SELECTOR = '@media (forced-colors: none)';
 
 export { DARK_THEME_SELECTOR, FORCED_COLORS_SELECTOR, LIGHT_THEME_SELECTOR, NOT_FORCED_COLORS_SELECTOR };

--- a/packages/component/src/Styles/StyleSet/Constants.ts
+++ b/packages/component/src/Styles/StyleSet/Constants.ts
@@ -1,8 +1,5 @@
-// TODO: Temporarily disable dark theme until all of Web Chat support dark theme.
-// const DARK_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: dark)';
-// const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
-const DARK_THEME_SELECTOR = '@media (forced-colors: none) and not (forced-colors: none)'; // Always return false
-const LIGHT_THEME_SELECTOR = '@media (forced-colors: none)';
+const DARK_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: dark)';
+const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
 
 const FORCED_COLORS_SELECTOR = '@media (forced-colors: active)';
 const NOT_FORCED_COLORS_SELECTOR = '@media (forced-colors: none)';

--- a/packages/component/src/Styles/StyleSet/Constants.ts
+++ b/packages/component/src/Styles/StyleSet/Constants.ts
@@ -1,6 +1,10 @@
-const DARK_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: dark)';
+// TODO: Temporarily disable dark theme until all of Web Chat support dark theme.
+// const DARK_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: dark)';
+// const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
+const DARK_THEME_SELECTOR = '@media (forced-colors: none) and not (forced-colors: none)'; // Always return false
+const LIGHT_THEME_SELECTOR = '@media (forced-colors: none)';
+
 const FORCED_COLORS_SELECTOR = '@media (forced-colors: active)';
-const LIGHT_THEME_SELECTOR = '@media (forced-colors: none) and (prefers-color-scheme: light)';
 const NOT_FORCED_COLORS_SELECTOR = '@media (forced-colors: none)';
 
 export { DARK_THEME_SELECTOR, FORCED_COLORS_SELECTOR, LIGHT_THEME_SELECTOR, NOT_FORCED_COLORS_SELECTOR };

--- a/packages/component/src/Styles/StyleSet/LinkDefinitions.ts
+++ b/packages/component/src/Styles/StyleSet/LinkDefinitions.ts
@@ -1,9 +1,8 @@
-import {
-  DARK_THEME_SELECTOR,
-  FORCED_COLORS_SELECTOR,
-  LIGHT_THEME_SELECTOR,
-  NOT_FORCED_COLORS_SELECTOR
-} from './Constants';
+import { FORCED_COLORS_SELECTOR, NOT_FORCED_COLORS_SELECTOR } from './Constants';
+
+// TODO: Temporarily disable dark theme until chat history support dark theme.
+const DARK_THEME_SELECTOR = '@media (forced-colors: none) and not (forced-colors: none)'; // Always return false
+const LIGHT_THEME_SELECTOR = '@media (forced-colors: none)';
 
 import CSSTokens from '../CSSTokens';
 

--- a/packages/component/src/Styles/StyleSet/ModalDialog.ts
+++ b/packages/component/src/Styles/StyleSet/ModalDialog.ts
@@ -1,9 +1,8 @@
-import {
-  DARK_THEME_SELECTOR,
-  FORCED_COLORS_SELECTOR,
-  LIGHT_THEME_SELECTOR,
-  NOT_FORCED_COLORS_SELECTOR
-} from './Constants';
+import { FORCED_COLORS_SELECTOR, NOT_FORCED_COLORS_SELECTOR } from './Constants';
+
+// TODO: Temporarily disable dark theme until we defined the link color and stuff for Markdown.
+const DARK_THEME_SELECTOR = '@media (forced-colors: none) and not (forced-colors: none)'; // Always return false
+const LIGHT_THEME_SELECTOR = '@media (forced-colors: none)';
 
 import CSSTokens from '../CSSTokens';
 


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4863.

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

### Fixed

-  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#4864](https://github.com/microsoft/BotFramework-WebChat/pull/4864)

## Description

Temporarily disable dark theme until chat history support dark theme.

Otherwise, link references will look weird.

![image](https://github.com/microsoft/BotFramework-WebChat/assets/1622400/e63bd270-ba09-4259-8b92-8a0c24fa3d92)

And link texts in modal dialog will also look weird.

![image](https://github.com/microsoft/BotFramework-WebChat/assets/1622400/38aa886e-0024-4549-8338-aab19ae9135c)

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

- `DARK_THEME_SELECTOR` will always falsy (select nothing)
- `LIGHT_THEME_SELECTOR` will be truthy if not in forced colors

## Specific Changes

- Updates `Constants` to disable dark theme selector

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
