### PR TITLE
Revert Redux store type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4865](https://github.com/microsoft/BotFramework-WebChat/issues/4865). Fixed <kbd>CTRL</kbd> + <kbd>Z</kbd> should undo correctly, by [@compulim](https://github.com/compulim), in PR [#4861](https://github.com/microsoft/BotFramework-WebChat/issues/pull/4861)
 -  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#4864](https://github.com/microsoft/BotFramework-WebChat/pull/4864)
 -  Fixes [#4866](https://github.com/microsoft/BotFramework-WebChat/issues/4866). Citation modal show fill screen width on mobile device and various fit-and-finish, by [@compulim](https://github.com/compulim), in PR [#4867](https://github.com/microsoft/BotFramework-WebChat/pull/4867)
+-  Fixes [#4878](https://github.com/microsoft/BotFramework-WebChat/issues/4878). `createStore` should return type of `Redux.Store`, by [@compulim](https://github.com/compulim), in PR [#4877](https://github.com/microsoft/BotFramework-WebChat/pull/4877)
 
 ### Added
 

--- a/packages/core/src/createStore.ts
+++ b/packages/core/src/createStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore as createReduxStore } from 'redux';
+import { applyMiddleware, createStore as createReduxStore, type Store } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import createSagaMiddleware from 'redux-saga';
 
@@ -28,8 +28,6 @@ type CreateStoreOptions = {
    */
   ponyfill?: Partial<GlobalScopePonyfill>;
 };
-
-type Store = ReturnType<typeof createReduxStore>;
 
 function createEnhancerAndSagaMiddleware(getStore, ...middlewares) {
   const sagaMiddleware = createSagaMiddleware({


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4878.

## Changelog Entry

### Fixed

-  Fixes [#4878](https://github.com/microsoft/BotFramework-WebChat/issues/4878). `createStore` should return type of `Redux.Store`, by [@compulim](https://github.com/compulim), in PR [#4877](https://github.com/microsoft/BotFramework-WebChat/pull/4877)

## Description

We did not bump `redux`, it is still `4.2.1`. So the signature from 4.15.9 should continue to work.

## Design

### 4.15.9

```ts
import { type Store } from 'redux'

export type WebChatStore = Store;
```

### 4.15.10-0

```ts
import { createStore } from 'redux'

export type WebChatStore = ReturnType<typeof createStore>;
```

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- Modify `createStore.tsx` to export `type Store` from `redux`, instead of `ReturnType<typeof createStore>`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
