### PR TITLE
Fix handler function and wildcard route issues in k.direct-line-token sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#4864](https://github.com/microsoft/BotFramework-WebChat/pull/4864)
 -  Fixes [#4866](https://github.com/microsoft/BotFramework-WebChat/issues/4866). Citation modal show fill screen width on mobile device and various fit-and-finish, by [@compulim](https://github.com/compulim), in PR [#4867](https://github.com/microsoft/BotFramework-WebChat/pull/4867)
 -  Fixes [#4878](https://github.com/microsoft/BotFramework-WebChat/issues/4878). `createStore` should return type of `Redux.Store`, by [@compulim](https://github.com/compulim), in PR [#4877](https://github.com/microsoft/BotFramework-WebChat/pull/4877)
+-  Fixes [#4871](https://github.com/microsoft/BotFramework-WebChat/issues/4871). Updated handler functions in both [`javascript/bot`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/bot) and [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) to include the missing third parameter or use async/await. By @ramfattah, in PR [#4884](https://github.com/microsoft/BotFramework-WebChat/pull/4884)
+-  Fixes [#4872](https://github.com/microsoft/BotFramework-WebChat/issues/4872). Modified the wildcard route in [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) to ensure it's correctly formatted for Restify. By @ramfattah, in PR [#4884](https://github.com/microsoft/BotFramework-WebChat/pull/4884)
+
 
 ### Added
 

--- a/samples/01.getting-started/k.direct-line-token/javascript/bot/package-lock.json
+++ b/samples/01.getting-started/k.direct-line-token/javascript/bot/package-lock.json
@@ -4102,7 +4102,8 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xml2js": {
       "version": "0.5.0",

--- a/samples/01.getting-started/k.direct-line-token/javascript/bot/src/index.js
+++ b/samples/01.getting-started/k.direct-line-token/javascript/bot/src/index.js
@@ -19,10 +19,12 @@ const adapter = createBotAdapter();
 const bot = createBot();
 const server = createServer();
 
-server.post('/api/messages', (req, res) => {
-  adapter.processActivity(req, res, context => bot.run(context));
+server.post('/api/messages', async (req, res) => {
+  await adapter.processActivity(req, res, async context => {
+    await bot.run(context);
+  });
 });
 
 server.listen(PORT, () => {
-  console.log(`Bot is now listening to port ${PORT}`);
+  console.log(`Bot is now listening to port http://localhost:${PORT}`);
 });

--- a/samples/01.getting-started/k.direct-line-token/javascript/web/src/index.js
+++ b/samples/01.getting-started/k.direct-line-token/javascript/web/src/index.js
@@ -31,7 +31,7 @@ server.post('/api/messages', require('./routes/botMessages'));
 // We will use the REST API server to serve static web content to simplify deployment for demonstration purposes.
 STATIC_FILES &&
   server.get(
-    '/**/*',
+    '/*',
     restify.plugins.serveStatic({
       default: 'index.html',
       directory: join(__dirname, '..', '..', '..', STATIC_FILES)
@@ -41,5 +41,5 @@ STATIC_FILES &&
 server.listen(PORT, () => {
   STATIC_FILES && console.log(`Will serve static content from ${STATIC_FILES}`);
 
-  console.log(`Rest API server is listening to port ${PORT}`);
+  console.log(`Rest API server is listening to port http://localhost:${PORT}`);
 });

--- a/samples/01.getting-started/k.direct-line-token/javascript/web/src/routes/botMessages.js
+++ b/samples/01.getting-started/k.direct-line-token/javascript/web/src/routes/botMessages.js
@@ -11,18 +11,20 @@ if (PROXY_BOT_URL) {
 
   console.log(`Will redirect /api/messages to ${new URL('api/messages', PROXY_BOT_URL).href}`);
 
-  module.exports = (req, res) => {
+  module.exports = (req, res, next) => {
     proxy.web(req, res, { target: PROXY_BOT_URL });
+    next();
   };
 } else {
   let warningShown;
 
-  module.exports = (_, res) => {
+  module.exports = (_, res, next) => {
     if (!warningShown) {
       warningShown = true;
       console.warn('PROXY_BOT_URL is not set, we are not reverse-proxying /api/messages.');
     }
 
     res.send(502);
+    next();
   };
 }


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4871 & #4872

## Changelog Entry
Fixed  #4871. Updated handler functions in both [`javascript/bot`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/bot) and [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) to include the missing third parameter or use async/await. By @ramfattah, in PR #4884

Fixed #4872. Modified the wildcard route in [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) to ensure it's correctly formatted for Restify. By @ramfattah, in PR #4884

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description
In this PR, I've addressed two primary issues in the [k.direct-line-token/javascript](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript) sample. The first is in regards to the handler functions in both the [`javascript/bot`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/bot) and [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) directories, where the missing third parameter was causing request handling issues. 

The second issue was related to the wildcard route in the [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web) directory, which was not formatted correctly for Restify. Both these changes aim to enhance the stability and reliability of the sample.

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Design
The design approach was to ensure that the server routes and handlers function seamlessly. This involved:

* Making the handler functions asynchronous to handle requests effectively.
* Adjusting the wildcard route to be in line with Restify's expectations.

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- In samples [`javascript/bot`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/bot) and [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web), I updated the post request handler to be asynchronous
- In [`javascript/web`](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/01.getting-started/k.direct-line-token/javascript/web), I modified the wildcard route for serving static files
- Enhanced the server listening log to include the full local URL
    ```js 
    `Bot is now listening to port http://localhost:${PORT}`
    ```


<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [ ] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
