### PR TITLE
4.16.0 and native chevron of accordion in citation should be hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.16.0] - 2023-11-16
 
-### Breaking changes.
+### Breaking changes
 
 -  Starting from 4.16.0, Internet Explorer is no longer supported
    -  After more than a year of the Internet Explorer 11 officially retirement, we decided to stop supporting Internet Explorer. This will help us to bring new features to Web Chat
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -  Fixes [#4863](https://github.com/microsoft/BotFramework-WebChat/issues/4863). Disable dark theme for link references until chat history has dark theme support, by [@compulim](https://github.com/compulim), in PR [#4864](https://github.com/microsoft/BotFramework-WebChat/pull/4864)
 -  Fixes [#4866](https://github.com/microsoft/BotFramework-WebChat/issues/4866). Citation modal show fill screen width on mobile device and various fit-and-finish, by [@compulim](https://github.com/compulim), in PR [#4867](https://github.com/microsoft/BotFramework-WebChat/pull/4867)
 -  Fixes [#4878](https://github.com/microsoft/BotFramework-WebChat/issues/4878). `createStore` should return type of `Redux.Store`, by [@compulim](https://github.com/compulim), in PR [#4877](https://github.com/microsoft/BotFramework-WebChat/pull/4877)
+-  Fixes [#4957](https://github.com/microsoft/BotFramework-WebChat/issues/4957). Native chevron of the accordion in citation should be hidden, by [@compulim](https://github.com/compulim), in PR [#4958](https://github.com/microsoft/BotFramework-WebChat/pull/4958)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [4.15.10] - 2023-11-16
+## [4.16.0] - 2023-11-16
 
-### Breaking changes
+### Breaking changes.
 
+-  Starting from 4.16.0, Internet Explorer is no longer supported
+   -  After more than a year of the Internet Explorer 11 officially retirement, we decided to stop supporting Internet Explorer. This will help us to bring new features to Web Chat
+   -  4.15.9 is the last version which supports Internet Explorer in limited fashion
 -  `useTextBoxValue` setter will no longer replace emoticon with emoji, in PR [#4861](https://github.com/microsoft/BotFramework-WebChat/issues/pull/4861)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.10",
+  "version": "4.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.15.10",
+      "version": "4.16.0",
       "license": "MIT",
       "dependencies": {
         "react": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.15.10",
+  "version": "4.16.0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/component/src/Styles/StyleSet/LinkDefinitions.ts
+++ b/packages/component/src/Styles/StyleSet/LinkDefinitions.ts
@@ -28,6 +28,10 @@ export default function createLinkDefinitionsStyleSet() {
         }
       },
 
+      '.webchat__link-definitions__header::-webkit-details-marker': {
+        display: 'none'
+      },
+
       '&:not([open]) .webchat__link-definitions__header-chevron': {
         marginBottom: '-0.1em',
         transform: 'rotate(-180deg)'


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #4957.

## Changelog Entry

-  Fixes [#4957](https://github.com/microsoft/BotFramework-WebChat/issues/4957). Native chevron of the accordion in citation should be hidden, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX)

## Description

Native chevron of accordion in citation should be hidden.

## Specific Changes

- Bumps to 4.16.0 and bids farewell to Internet Explorer
- Hid native chevron of accordion in citation via `::-webkit-details-marker`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] Browser and platform compatibilities reviewed
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
