### PR TITLE
document typo: Fixed broken renderMarkdown link in HOOKS documentation

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -881,7 +881,7 @@ renderMarkdown('Hello, World!') === '<p>Hello, World!</p>\n';
 ```
 <!-- prettier-ignore-end -->
 
-The Markdown engine can be reconfigured by passing `renderMarkdown` prop to Web Chat. The default engine is a customized [Markdown-It](https://npmjs.com/package/markdown-it) with [HTML sanitizer](https://npmjs.com/package/sanitize-html) and [support `aria-label` attribute](https://npmjs.com/package/markdown-it-attrs). The customization can be found in [bundle/src/renderMarkdown.js](https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/bundle/src/renderMarkdown.js).
+The Markdown engine can be reconfigured by passing `renderMarkdown` prop to Web Chat. The default engine is a customized [Markdown-It](https://npmjs.com/package/markdown-it) with [HTML sanitizer](https://npmjs.com/package/sanitize-html) and [support `aria-label` attribute](https://npmjs.com/package/markdown-it-attrs). The customization can be found in [bundle/src/markdown/renderMarkdown.ts](https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/bundle/src/markdown/renderMarkdown.ts).
 
 ## `useRenderToast`
 


### PR DESCRIPTION
When referencing the documentation type for the `useRenderMarkdownAsHTML` hook, I noticed a broken link; The PR updates the renderMarkdown description and link to point to the renderMarkdown.ts file.

> Fixes #

## Changelog Entry
Change does not affect product, just documentation.  Happy to add if needed, but didn't think it was

## Description
Before:

* Go to `docs/HOOKS.md`
* Navigate to `useRenderMarkdownAsHTML` section
* Click on `bundle/src/renderMarkdown.js`
* Link gives a 404

After:
* Go to `docs/HOOKS.md`
* Navigate to `useRenderMarkdownAsHTML` section
* Click on `bundle/src/markdown/renderMarkdown.ts
* Navigated to renderMarkdown file.

## Design

n/a

## Specific Changes

* Fixes broken renderMarkdown link in HOOKS documentation

-  [ ] I have added tests and executed them locally - n/a
-  [ ] I have updated `CHANGELOG.md` - n/a
-  [ ] I have updated documentation - n/a

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
