### PR TITLE
Adding styleOptions to support file type restriction and single file upload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "edge",
+      "type": "msedge",
       "request": "launch",
       "name": "Launch Microsoft Edge",
       "url": "http://localhost:5000/samples/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb)
+
 ### Changed
 
 -  Moved pull request validation pipeline to GitHub Actions, by [@compulim](https://github.com/compulim), in PR [#4976](https://github.com/microsoft/BotFramework-WebChat/pull/4976)

--- a/__tests__/html/attachment.allowedFileTypes.html
+++ b/__tests__/html/attachment.allowedFileTypes.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <main id="webchat"></main>
+    <script>
+      run(async function () {
+        const directLine = WebChat.createDirectLine({ token: await testHelpers.token.fetchDirectLineToken() });
+        const store = testHelpers.createStore();
+
+        WebChat.renderWebChat(
+          {
+            directLine,
+            store: testHelpers.createStore(),
+            styleOptions: {
+              uploadFileTypes: 'image/*',
+              uploadMultiple: false
+            }
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+        
+        // Validate the <input> element has the correct file types
+        const input = document.querySelector('input[type="file"]');
+        expect(input).toHaveProperty('accept', 'image/*');
+        expect(input).toHaveProperty('multiple', false);
+        
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/attachment.allowedFileTypes.html
+++ b/__tests__/html/attachment.allowedFileTypes.html
@@ -28,9 +28,9 @@
         await pageConditions.uiConnected();
         
         // Validate the <input> element has the correct file types
-        const input = pageElements.uploadButton()
-        expect(input).toHaveProperty('accept', 'image/*');
-        expect(input).toHaveProperty('multiple', false);
+        const uploadButton = pageElements.uploadButton()
+        expect(uploadButton).toHaveProperty('accept', 'image/*');
+        expect(uploadButton).toHaveProperty('multiple', false);
         
       });
     </script>

--- a/__tests__/html/attachment.allowedFileTypes.html
+++ b/__tests__/html/attachment.allowedFileTypes.html
@@ -18,7 +18,7 @@
             directLine,
             store: testHelpers.createStore(),
             styleOptions: {
-              uploadFileTypes: 'image/*',
+              uploadAccept: 'image/*',
               uploadMultiple: false
             }
           },
@@ -28,7 +28,7 @@
         await pageConditions.uiConnected();
         
         // Validate the <input> element has the correct file types
-        const input = document.querySelector('input[type="file"]');
+        const input = pageElements.uploadButton()
         expect(input).toHaveProperty('accept', 'image/*');
         expect(input).toHaveProperty('multiple', false);
         

--- a/__tests__/html/attachment.allowedFileTypes.js
+++ b/__tests__/html/attachment.allowedFileTypes.js
@@ -1,0 +1,6 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('Attachment', () => {
+  test('with allowed file types', () =>
+    runHTML('attachment.allowedFileTypes.html'));
+});

--- a/packages/api/src/StyleOptions.ts
+++ b/packages/api/src/StyleOptions.ts
@@ -258,11 +258,16 @@ type StyleOptions = {
   hideUploadButton?: boolean;
   microphoneButtonColorOnDictate?: string;
   sendBoxBackground?: string;
+
   /**
-   * The file type that the attachment button should accept.
+   * The comma-delimited file types that the upload button should accept.
    * @example 'image/*,.pdf'
    */
-  attachmentAccept?: string;
+  uploadFileTypes?: string;
+  /**
+   * If true, the upload button will accept multiple files.
+   */
+  uploadMultiple?: boolean;
 
   /** Send box button: Icon color, defaults to subtle */
   sendBoxButtonColor?: string;

--- a/packages/api/src/StyleOptions.ts
+++ b/packages/api/src/StyleOptions.ts
@@ -261,11 +261,13 @@ type StyleOptions = {
 
   /**
    * The comma-delimited file types that the upload button should accept.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept
    * @example 'image/*,.pdf'
    */
-  uploadFileTypes?: string;
+  uploadAccept?: string;
   /**
    * If true, the upload button will accept multiple files.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple
    */
   uploadMultiple?: boolean;
 

--- a/packages/api/src/StyleOptions.ts
+++ b/packages/api/src/StyleOptions.ts
@@ -258,6 +258,11 @@ type StyleOptions = {
   hideUploadButton?: boolean;
   microphoneButtonColorOnDictate?: string;
   sendBoxBackground?: string;
+  /**
+   * The file type that the attachment button should accept.
+   * @example 'image/*,.pdf'
+   */
+  attachmentAccept?: string;
 
   /** Send box button: Icon color, defaults to subtle */
   sendBoxButtonColor?: string;

--- a/packages/api/src/defaultStyleOptions.ts
+++ b/packages/api/src/defaultStyleOptions.ts
@@ -96,7 +96,7 @@ const DEFAULT_OPTIONS: Required<StyleOptions> = {
   microphoneButtonColorOnDictate: '#F33',
   sendBoxBackground: 'White',
   uploadAccept: undefined,
-  uploadMultiple: undefined,
+  uploadMultiple: true,
 
   // Send box buttons
   sendBoxButtonColor: undefined,

--- a/packages/api/src/defaultStyleOptions.ts
+++ b/packages/api/src/defaultStyleOptions.ts
@@ -95,6 +95,7 @@ const DEFAULT_OPTIONS: Required<StyleOptions> = {
   hideUploadButton: false,
   microphoneButtonColorOnDictate: '#F33',
   sendBoxBackground: 'White',
+  attachmentAccept: '*',
 
   // Send box buttons
   sendBoxButtonColor: undefined,

--- a/packages/api/src/defaultStyleOptions.ts
+++ b/packages/api/src/defaultStyleOptions.ts
@@ -95,7 +95,8 @@ const DEFAULT_OPTIONS: Required<StyleOptions> = {
   hideUploadButton: false,
   microphoneButtonColorOnDictate: '#F33',
   sendBoxBackground: 'White',
-  attachmentAccept: '*',
+  uploadFileTypes: '*',
+  uploadMultiple: true,
 
   // Send box buttons
   sendBoxButtonColor: undefined,

--- a/packages/api/src/defaultStyleOptions.ts
+++ b/packages/api/src/defaultStyleOptions.ts
@@ -95,8 +95,8 @@ const DEFAULT_OPTIONS: Required<StyleOptions> = {
   hideUploadButton: false,
   microphoneButtonColorOnDictate: '#F33',
   sendBoxBackground: 'White',
-  uploadFileTypes: '*',
-  uploadMultiple: true,
+  uploadAccept: undefined,
+  uploadMultiple: undefined,
 
   // Send box buttons
   sendBoxButtonColor: undefined,

--- a/packages/component/src/SendBox/UploadButton.tsx
+++ b/packages/component/src/SendBox/UploadButton.tsx
@@ -3,13 +3,14 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { FC, useCallback, useRef } from 'react';
 
-import AttachmentIcon from './Assets/AttachmentIcon';
-import connectToWebChat from '../connectToWebChat';
+import { useStyleOptions } from 'botframework-webchat-api/lib/hooks';
 import downscaleImageToDataURL from '../Utils/downscaleImageToDataURL/index';
-import IconButton from './IconButton';
+import connectToWebChat from '../connectToWebChat';
+import useStyleToEmotionObject from '../hooks/internal/useStyleToEmotionObject';
 import useSendFiles from '../hooks/useSendFiles';
 import useStyleSet from '../hooks/useStyleSet';
-import useStyleToEmotionObject from '../hooks/internal/useStyleToEmotionObject';
+import AttachmentIcon from './Assets/AttachmentIcon';
+import IconButton from './IconButton';
 
 const { useDisabled, useLocalizer } = hooks;
 
@@ -95,6 +96,7 @@ type UploadButtonProps = {
 
 const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   const [{ uploadButton: uploadButtonStyleSet }] = useStyleSet();
+  const [{ attachmentAccept }] = useStyleOptions();
   const [disabled] = useDisabled();
   const inputRef = useRef<HTMLInputElement>();
   const localize = useLocalizer();
@@ -122,6 +124,7 @@ const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   return (
     <div className={classNames(rootClassName, 'webchat__upload-button', uploadButtonStyleSet + '', className)}>
       <input
+        accept={attachmentAccept}
         aria-disabled={disabled}
         aria-hidden="true"
         className="webchat__upload-button--file-input"

--- a/packages/component/src/SendBox/UploadButton.tsx
+++ b/packages/component/src/SendBox/UploadButton.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { FC, useCallback, useRef } from 'react';
 
-import { useStyleOptions } from 'botframework-webchat-api/lib/hooks';
 import downscaleImageToDataURL from '../Utils/downscaleImageToDataURL/index';
 import connectToWebChat from '../connectToWebChat';
 import useStyleToEmotionObject from '../hooks/internal/useStyleToEmotionObject';
@@ -12,7 +11,7 @@ import useStyleSet from '../hooks/useStyleSet';
 import AttachmentIcon from './Assets/AttachmentIcon';
 import IconButton from './IconButton';
 
-const { useDisabled, useLocalizer } = hooks;
+const { useDisabled, useLocalizer, useStyleOptions } = hooks;
 
 const ROOT_STYLE = {
   '&.webchat__upload-button': {
@@ -96,7 +95,7 @@ type UploadButtonProps = {
 
 const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   const [{ uploadButton: uploadButtonStyleSet }] = useStyleSet();
-  const [{ uploadFileTypes, uploadMultiple }] = useStyleOptions();
+  const [{ uploadAccept, uploadMultiple }] = useStyleOptions();
   const [disabled] = useDisabled();
   const inputRef = useRef<HTMLInputElement>();
   const localize = useLocalizer();
@@ -124,7 +123,7 @@ const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   return (
     <div className={classNames(rootClassName, 'webchat__upload-button', uploadButtonStyleSet + '', className)}>
       <input
-        accept={uploadFileTypes}
+        accept={uploadAccept}
         aria-disabled={disabled}
         aria-hidden="true"
         className="webchat__upload-button--file-input"

--- a/packages/component/src/SendBox/UploadButton.tsx
+++ b/packages/component/src/SendBox/UploadButton.tsx
@@ -96,7 +96,7 @@ type UploadButtonProps = {
 
 const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   const [{ uploadButton: uploadButtonStyleSet }] = useStyleSet();
-  const [{ attachmentAccept }] = useStyleOptions();
+  const [{ uploadFileTypes, uploadMultiple }] = useStyleOptions();
   const [disabled] = useDisabled();
   const inputRef = useRef<HTMLInputElement>();
   const localize = useLocalizer();
@@ -124,11 +124,11 @@ const UploadButton: FC<UploadButtonProps> = ({ className }) => {
   return (
     <div className={classNames(rootClassName, 'webchat__upload-button', uploadButtonStyleSet + '', className)}>
       <input
-        accept={attachmentAccept}
+        accept={uploadFileTypes}
         aria-disabled={disabled}
         aria-hidden="true"
         className="webchat__upload-button--file-input"
-        multiple={true}
+        multiple={uploadMultiple}
         onChange={disabled ? undefined : handleFileChange}
         onClick={disabled ? PREVENT_DEFAULT_HANDLER : undefined}
         readOnly={disabled}

--- a/packages/test/page-object/src/globals/pageElements/index.js
+++ b/packages/test/page-object/src/globals/pageElements/index.js
@@ -19,6 +19,7 @@ import transcript from './transcript';
 import transcriptLiveRegion from './transcriptLiveRegion';
 import transcriptScrollable from './transcriptScrollable';
 import transcriptTerminator from './transcriptTerminator';
+import uploadButton from './uploadButton';
 
 export {
   activeActivity,
@@ -41,5 +42,6 @@ export {
   transcript,
   transcriptLiveRegion,
   transcriptScrollable,
-  transcriptTerminator
+  transcriptTerminator,
+  uploadButton
 };


### PR DESCRIPTION
Adds support for restricting the file types that can be uploaded and only allowing a single file.



<!-- Please provide the issue number here if any -->

> Fixes #5081 

## Changelog Entry

### Added

- Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb)

## Description

![image](https://github.com/microsoft/BotFramework-WebChat/assets/77851615/324b3925-4054-47a8-b447-7eb1acaa1800)

![webchat-images](https://github.com/microsoft/BotFramework-WebChat/assets/77851615/55eaf773-0a22-4aa5-b831-90d5a106533b)

## Design

Sample implementation:
```html
<script>
  window.WebChat.renderWebChat(
    {
      styleOptions: {
        uploadAccept: 'image/*',
        uploadMultiple: false
      }
    },
    document.getElementById('webchat')
  );
</script>
```

## Specific Changes

- Added `uploadAccept` style option to allow restricted file types
- Added `uploadMultiple` style option to allow single file uploading


<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [X] I have added tests and executed them locally
-  [X] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] Internationalization reviewed (strings, unit formatting)
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] Security reviewed (no data URIs, check for nonce leak)
-  [x] Tests reviewed (coverage, legitimacy)
