### PR TITLE
Focus should not blur briefly after tapping on a suggested action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
--  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/pull/XXX)
+-  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#5097](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5097)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb)
+-  Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb)
+
+### Fixed
+
+-  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/pull/XXX)
 
 ### Changed
 

--- a/__tests__/html/accessibility.suggestedActions.sendFocusImmediately.html
+++ b/__tests__/html/accessibility.suggestedActions.sendFocusImmediately.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <main id="webchat"></main>
+    <script>
+      run(async function () {
+        WebChat.renderWebChat(
+          {
+            directLine: testHelpers.createDirectLineWithTranscript([
+              {
+                from: {
+                  id: 'bot',
+                  role: 'bot'
+                },
+                suggestedActions: {
+                  actions: [
+                    {
+                      type: 'imBack',
+                      value: 'What can I say?'
+                    },
+                    {
+                      type: 'imBack',
+                      value: 'What is the weather?'
+                    }
+                  ]
+                },
+                textFormat: 'markdown',
+                timestamp: new Date(2000, 0, 1, 12, 34, 56, 789).toISOString(),
+                type: 'message'
+              }
+            ]),
+            store: testHelpers.createStore(),
+            styleOptions: {
+              suggestedActionLayout: 'stacked'
+            }
+          },
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+        await pageConditions.suggestedActionsShown();
+
+        // THEN: Suggested actions container in stacked layout should be of `role="toolbar"` with `aria-orientation="vertical"`
+        const [firstSuggestedAction] = pageElements.suggestedActions();
+
+        let elementBeforeClick;
+
+        pageElements.sendBoxTextBox().focus = () => {
+          elementBeforeClick = document.activeElement;
+        };
+
+        await host.click(firstSuggestedAction);
+
+        expect(elementBeforeClick).not.toBe(document.body);
+        expect(elementBeforeClick).toBe(firstSuggestedAction);
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html/accessibility.suggestedActions.sendFocusImmediately.js
+++ b/__tests__/html/accessibility.suggestedActions.sendFocusImmediately.js
@@ -1,0 +1,7 @@
+/** @jest-environment ./packages/test/harness/src/host/jest/WebDriverEnvironment.js */
+
+describe('accessibility requirement', () => {
+  describe('after clicking on suggested action', () => {
+    test('should send the focus to send box immediately', () => runHTML('accessibility.suggestedActions.sendFocusImmediately.html'));
+  });
+});

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -43,6 +43,7 @@
         "concurrently": "^8.2.2",
         "core-js": "^3.34.0",
         "node-dev": "^8.0.0",
+        "type-fest": "^4.14.0",
         "typescript": "^5.3.2"
       },
       "peerDependencies": {
@@ -4641,6 +4642,18 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
+    "node_modules/type-fest": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
@@ -8199,6 +8212,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
       "dev": true
     },
     "typescript": {

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -90,6 +90,7 @@
     "concurrently": "^8.2.2",
     "core-js": "^3.34.0",
     "node-dev": "^8.0.0",
+    "type-fest": "^4.14.0",
     "typescript": "^5.3.2"
   },
   "dependencies": {

--- a/packages/component/src/SendBox/SuggestedAction.tsx
+++ b/packages/component/src/SendBox/SuggestedAction.tsx
@@ -1,20 +1,20 @@
 import { hooks } from 'botframework-webchat-api';
+import type { DirectLineCardAction } from 'botframework-webchat-core';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { MouseEventHandler, useCallback, VFC } from 'react';
-import type { DirectLineCardAction } from 'botframework-webchat-core';
 
-import AccessibleButton from '../Utils/AccessibleButton';
 import connectToWebChat from '../connectToWebChat';
-import useFocus from '../hooks/useFocus';
-import useFocusAccessKeyEffect from '../Utils/AccessKeySink/useFocusAccessKeyEffect';
 import useFocusVisible from '../hooks/internal/useFocusVisible';
-import useItemRef from '../providers/RovingTabIndex/useItemRef';
 import useLocalizeAccessKey from '../hooks/internal/useLocalizeAccessKey';
-import useScrollToEnd from '../hooks/useScrollToEnd';
-import useStyleSet from '../hooks/useStyleSet';
 import useStyleToEmotionObject from '../hooks/internal/useStyleToEmotionObject';
 import useSuggestedActionsAccessKey from '../hooks/internal/useSuggestedActionsAccessKey';
+import useFocus from '../hooks/useFocus';
+import useScrollToEnd from '../hooks/useScrollToEnd';
+import useStyleSet from '../hooks/useStyleSet';
+import useItemRef from '../providers/RovingTabIndex/useItemRef';
+import AccessibleButton from '../Utils/AccessibleButton';
+import useFocusAccessKeyEffect from '../Utils/AccessKeySink/useFocusAccessKeyEffect';
 
 const { useDirection, useDisabled, usePerformCardAction, useStyleOptions, useSuggestedActions } = hooks;
 
@@ -90,15 +90,21 @@ const SuggestedAction: VFC<SuggestedActionProps> = ({
 
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
     ({ target }) => {
-      // TODO: [P3] #XXX We should not destruct DirectLineCardAction into React props and pass them in. It makes typings difficult.
-      //       Instead, we should pass a "cardAction" props.
-      performCardAction({ displayText, text, type, value } as DirectLineCardAction, { target });
+      (async function () {
+        // We need to focus to the send box before we are performing this card action.
+        // The will make sure the focus is always on Web Chat.
+        // Otherwise, the focus may momentarily send to `document.body` and screen reader will be confused.
+        await focus('sendBoxWithoutKeyboard');
 
-      // Since "openUrl" action do not submit, the suggested action buttons do not hide after click.
-      type === 'openUrl' && setSuggestedActions([]);
+        // TODO: [P3] #XXX We should not destruct DirectLineCardAction into React props and pass them in. It makes typings difficult.
+        //       Instead, we should pass a "cardAction" props.
+        performCardAction({ displayText, text, type, value } as DirectLineCardAction, { target });
 
-      focus('sendBoxWithoutKeyboard');
-      scrollToEnd();
+        // Since "openUrl" action do not submit, the suggested action buttons do not hide after click.
+        type === 'openUrl' && setSuggestedActions([]);
+
+        scrollToEnd();
+      })();
     },
     [displayText, focus, performCardAction, scrollToEnd, setSuggestedActions, text, type, value]
   );

--- a/packages/component/src/hooks/internal/WebChatUIContext.js
+++ b/packages/component/src/hooks/internal/WebChatUIContext.js
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-const context = createContext();
-
-export default context;

--- a/packages/component/src/hooks/internal/WebChatUIContext.ts
+++ b/packages/component/src/hooks/internal/WebChatUIContext.ts
@@ -1,0 +1,13 @@
+import { createContext, type MutableRefObject } from 'react';
+
+import { type FocusSendBoxInit } from '../../types/internal/FocusSendBoxInit';
+import { type FocusTranscriptInit } from '../../types/internal/FocusTranscriptInit';
+
+export type ContextType = {
+  focusSendBoxCallbacksRef: MutableRefObject<((init: FocusSendBoxInit) => Promise<void>)[]>;
+  focusTranscriptCallbacksRef: MutableRefObject<((init: FocusTranscriptInit) => Promise<void>)[]>;
+};
+
+const context = createContext<ContextType>(undefined as ContextType);
+
+export default context;

--- a/packages/component/src/hooks/internal/createWaitUntilable.spec.ts
+++ b/packages/component/src/hooks/internal/createWaitUntilable.spec.ts
@@ -1,0 +1,98 @@
+import createWaitUntilable, { type WaitUntilable } from './createWaitUntilable';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (error: unknown) => void;
+  resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  const deferred: Partial<Deferred<T>> = {};
+
+  deferred.promise = new Promise<T>((resolve, reject) => {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  });
+
+  return deferred as Deferred<T>;
+}
+
+function hasResolve(promise): Promise<boolean> {
+  // eslint-disable-next-line no-restricted-globals
+  return Promise.race([promise.then(() => true), new Promise(resolve => setTimeout(() => resolve(false), 0))]);
+}
+
+describe('with no waitUntil()', () => {
+  let getPromise: () => Promise<void>;
+  let promise: Promise<void>;
+
+  beforeEach(() => {
+    [, getPromise] = createWaitUntilable({});
+
+    promise = getPromise();
+  });
+
+  test('should resolve initially', () => expect(hasResolve(promise)).resolves.toBe(true));
+});
+
+describe('With a single waitUntil()', () => {
+  let event: WaitUntilable<{}>;
+  let getPromise: () => Promise<void>;
+  let promise: Promise<void>;
+  let deferred: Deferred<void>;
+
+  beforeEach(() => {
+    [event, getPromise] = createWaitUntilable({});
+
+    deferred = createDeferred();
+    event.waitUntil(deferred.promise);
+    promise = getPromise();
+  });
+
+  test('should not resolve initially', () => expect(hasResolve(promise)).resolves.toBe(false));
+
+  describe('after waitUntil() has resolved', () => {
+    beforeEach(() => deferred.resolve());
+
+    test('should resolve', () => expect(hasResolve(promise)).resolves.toBe(true));
+  });
+});
+
+describe('With nested waitUntil()', () => {
+  let event: WaitUntilable<{}>;
+  let getPromise: () => Promise<void>;
+  let promise: Promise<void>;
+  let deferred1: Deferred<void>;
+  let deferred2: Deferred<void>;
+
+  beforeEach(() => {
+    [event, getPromise] = createWaitUntilable({});
+
+    deferred1 = createDeferred();
+    deferred2 = createDeferred();
+
+    event.waitUntil(
+      (async () => {
+        await deferred1.promise;
+
+        event.waitUntil(deferred2.promise);
+      })()
+    );
+
+    promise = getPromise();
+  });
+
+  test('should not resolve initially', () => expect(hasResolve(promise)).resolves.toBe(false));
+
+  describe('after first waitUntil() is resolved', () => {
+    beforeEach(() => deferred1.resolve());
+
+    test('should not resolve', () => expect(hasResolve(promise)).resolves.toBe(false));
+
+    describe('after second waitUntil() is resolved', () => {
+      beforeEach(() => deferred2.resolve());
+
+      test('should resolve', () => expect(hasResolve(promise)).resolves.toBe(true));
+    });
+  });
+});

--- a/packages/component/src/hooks/internal/createWaitUntilable.ts
+++ b/packages/component/src/hooks/internal/createWaitUntilable.ts
@@ -1,0 +1,35 @@
+export type WaitUntilable<T> = T & { waitUntil: (promise: Promise<void>) => void };
+
+export default function createWaitUntilable<T extends object>(
+  object: T
+): readonly [WaitUntilable<T>, () => Promise<void>] {
+  const allPromises: Promise<void>[] = [];
+
+  return Object.freeze([
+    {
+      ...object,
+      waitUntil(promise: Promise<void>) {
+        allPromises.push(promise);
+      }
+    },
+    async () => {
+      // Implements the logic of ExtendableEvent.waitUntil.
+      // When calling waitUntil(), new promises can be added by calling waitUntil() again.
+      // It should wait until no new promises are added.
+
+      // From excerpt of https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil:
+      // "The waitUntil() method must be initially called within the event callback, but after that it can be called multiple times, until all the promises passed to it settle."
+      for (let numPromise = 0; ; numPromise = allPromises.length) {
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.all(allPromises).then(() => {
+          // Intentionally left blank.
+        });
+
+        // Wait until all promise changes are settled.
+        if (numPromise === allPromises.length) {
+          break;
+        }
+      }
+    }
+  ]);
+}

--- a/packages/component/src/hooks/useFocus.ts
+++ b/packages/component/src/hooks/useFocus.ts
@@ -1,19 +1,26 @@
 import { useCallback } from 'react';
 
+import createWaitUntilable from './internal/createWaitUntilable';
 import useWebChatUIContext from './internal/useWebChatUIContext';
 
-export default function useFocus(): (where?: 'main' | 'sendBox' | 'sendBoxWithoutKeyboard') => void {
+export default function useFocus(): (where?: 'main' | 'sendBox' | 'sendBoxWithoutKeyboard') => Promise<void> {
   const { focusSendBoxCallbacksRef, focusTranscriptCallbacksRef } = useWebChatUIContext();
 
   return useCallback(
-    where => {
-      if (where === 'sendBoxWithoutKeyboard') {
-        return focusSendBoxCallbacksRef.current.forEach(callback => callback({ noKeyboard: true }));
+    async where => {
+      if (where === 'sendBox' || where === 'sendBoxWithoutKeyboard') {
+        const [options, getPromise] = createWaitUntilable({ noKeyboard: where === 'sendBoxWithoutKeyboard' });
+
+        focusSendBoxCallbacksRef.current.forEach(callback => callback(options));
+
+        await getPromise();
+      } else {
+        const [, getPromise] = createWaitUntilable({});
+
+        focusTranscriptCallbacksRef.current.forEach(callback => callback());
+
+        await getPromise();
       }
-
-      const { current } = where === 'sendBox' ? focusSendBoxCallbacksRef : focusTranscriptCallbacksRef;
-
-      current.forEach(callback => callback());
     },
     [focusSendBoxCallbacksRef, focusTranscriptCallbacksRef]
   );

--- a/packages/component/src/types/internal/FocusSendBoxInit.ts
+++ b/packages/component/src/types/internal/FocusSendBoxInit.ts
@@ -1,0 +1,3 @@
+import { type WaitUntilable } from '../../hooks/internal/createWaitUntilable';
+
+export type FocusSendBoxInit = WaitUntilable<{ noKeyboard: boolean }>;

--- a/packages/component/src/types/internal/FocusTranscriptInit.ts
+++ b/packages/component/src/types/internal/FocusTranscriptInit.ts
@@ -1,0 +1,4 @@
+import { type EmptyObject } from 'type-fest';
+import { type WaitUntilable } from '../../hooks/internal/createWaitUntilable';
+
+export type FocusTranscriptInit = WaitUntilable<EmptyObject>;


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5050.

## Changelog Entry

### Fixed

-  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#5097](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5097)

## Description

After tapping on a suggested action, the focus is blurred briefly before sending to the send box.

This pull request resolves the issue by sending the focus to the send box, wait for focus send complete, then, send the card action and remove the suggested action.

## Design

Today:

1. Tap on the send box
2. Remove suggested actions
   1. Suggested actions will be unmounted
   2. Focus is blurred
3. Focus on the send box (without virtual keyboard)
   1. Set send box to read-only
   2. Idle (`setTimeout(..., 0)`)
   3. Focus on send box
   4. Set send box to read-write

There are 2 parts we need to modify:

- Move point 3 before point 2
   - Focus on the send box before removing suggested action
- Make sure point 3 is completed before executing point 2

However, iOS 17 does not support `navigator.virtualKeyboard` API. We have to use the `readonly` attribute trick to focus on the send box while preventing the keyboard to show up. This will keep the focus on the send box without showing the virtual keyboard.

To ensure point 3 is awaitable, we are extending by following the `ExtendableEvent.waitUntil` pattern.

## Specific Changes

-  Modify `SuggestedAction.tsx` to move the focus before sending and unmounting suggested action
-  Modify `TextBox.tsx` to add `waitUntil()` to signal the completion of focus change
-  Added `type-fest` as development dependencies to `component` package

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
