### PR TITLE
Keyboard help screen to use HTML description list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#5097](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5097)
+-  Fixes [#5111](https://github.com/microsoft/BotFramework-WebChat/issues/5111). Fixed keyboard help screen to use HTML description list, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/pull/XXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -  Fixes [#5050](https://github.com/microsoft/BotFramework-WebChat/issues/5050). Fixed focus should not blur briefly after tapping on a suggested action, by [@compulim](https://github.com/compulim), in PR [#5097](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5097)
--  Fixes [#5111](https://github.com/microsoft/BotFramework-WebChat/issues/5111). Fixed keyboard help screen to use HTML description list, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/issues/pull/XXX)
+-  Fixes [#5111](https://github.com/microsoft/BotFramework-WebChat/issues/5111). Fixed keyboard help screen to use HTML description list, by [@compulim](https://github.com/compulim), in PR [#5116](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5116)
 
 ### Changed
 

--- a/packages/component/src/Styles/StyleSet/KeyboardHelp.ts
+++ b/packages/component/src/Styles/StyleSet/KeyboardHelp.ts
@@ -183,10 +183,12 @@ export default function createKeyboardHelpStyleSet({ paddingRegular, primaryFont
       },
 
       '& .webchat__keyboard-help__notes': {
-        marginBottom: paddingRegular
+        marginBottom: paddingRegular,
+        marginTop: 0
       },
 
       '& .webchat__keyboard-help__notes-header': {
+        fontWeight: 'bold',
         margin: 0
       },
 

--- a/packages/component/src/Transcript/KeyboardHelp.tsx
+++ b/packages/component/src/Transcript/KeyboardHelp.tsx
@@ -5,9 +5,9 @@ import React, { useCallback, useState } from 'react';
 
 import type { FC } from 'react';
 
+import useUniqueId from '../hooks/internal/useUniqueId';
 import useFocus from '../hooks/useFocus';
 import useStyleSet from '../hooks/useStyleSet';
-import useUniqueId from '../hooks/internal/useUniqueId';
 
 const { useLocalizer } = hooks;
 
@@ -17,16 +17,16 @@ type NotesBodyProps = {
 };
 
 const Notes: FC<NotesBodyProps> = ({ header, text }) => (
-  <section className="webchat__keyboard-help__notes">
-    <h4 className="webchat__keyboard-help__notes-header">{header}</h4>
+  <dl className="webchat__keyboard-help__notes">
+    <dt className="webchat__keyboard-help__notes-header">{header}</dt>
     {text.split('\n').map((line, index) => (
       // We are splitting lines into paragraphs, index as key is legitimate here.
       // eslint-disable-next-line react/no-array-index-key
-      <p className="webchat__keyboard-help__notes-text" key={index}>
+      <dd className="webchat__keyboard-help__notes-text" key={index}>
         {line}
-      </p>
+      </dd>
     ))}
-  </section>
+  </dl>
 );
 
 Notes.propTypes = {


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5111.

## Changelog Entry

### Fixed

-  Fixes [#5111](https://github.com/microsoft/BotFramework-WebChat/issues/5111). Fixed keyboard help screen to use HTML description list, by [@compulim](https://github.com/compulim), in PR [#5116](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5116)

## Description

Based on customer feedback, the keyboard help screen should use HTML description list (`<dl>`) to allow screen readers to have programmatic to the information.

## Design

This pull request is purely schematic changes. No tests code should be modified.

Tag changes:

- `<section>` -> `<dl>`
- `<h4>` -> `<dt>`
- `<p>` -> `<dd>`

## Specific Changes

-  Update keyboard help screen to use HTML description list

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
