### PR TITLE
Fix `rebasePackageLock.mjs` to support NPM alias

### DIFF
--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -24,8 +24,18 @@ async function readAllStdin() {
 }
 
 function rebaseV1Inline(name, dependency, baseURL) {
-  const { resolved: actual, version } = dependency;
-  const singleName = name.split('/').reverse()[0];
+  const { resolved: actual, version: versionFromDependency } = dependency;
+  let version = versionFromDependency;
+
+  if (versionFromDependency.startsWith('npm:')) {
+    const lastAt = versionFromDependency.lastIndexOf('@');
+
+    // eslint-disable-next-line no-magic-numbers
+    name = versionFromDependency.slice(4, lastAt);
+    version = versionFromDependency.slice(lastAt + 1);
+  }
+
+  const [singleName] = name.split('/').reverse();
 
   const { href: expected } = new URL(`${name}/-/${singleName}-${version}.tgz`, 'https://registry.npmjs.org/');
   const { href: rebased } = new URL(`${name}/-/${singleName}-${version}.tgz`, baseURL);
@@ -46,8 +56,16 @@ function rebaseV1InlineAll({ dependencies }, baseURL) {
 }
 
 function rebaseV2Inline(path, dependency, baseURL) {
-  const { resolved: actual, version } = dependency;
-  const name = path.split('node_modules/').reverse()[0];
+  const { name: nameFromDependency, resolved: actual, version: versionFromDependency } = dependency;
+  const name = nameFromDependency || path.split('node_modules/').reverse()[0];
+  let version = versionFromDependency;
+
+  if (versionFromDependency.startsWith('npm:')) {
+    const lastAt = versionFromDependency.lastIndexOf('@');
+
+    // eslint-disable-next-line no-magic-numbers
+    version = versionFromDependency.slice(lastAt + 1);
+  }
 
   const singleName = name.split('/').reverse()[0];
 

--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -56,16 +56,8 @@ function rebaseV1InlineAll({ dependencies }, baseURL) {
 }
 
 function rebaseV2Inline(path, dependency, baseURL) {
-  const { name: nameFromDependency, resolved: actual, version: versionFromDependency } = dependency;
+  const { name: nameFromDependency, resolved: actual, version } = dependency;
   const name = nameFromDependency || path.split('node_modules/').reverse()[0];
-  let version = versionFromDependency;
-
-  if (versionFromDependency.startsWith('npm:')) {
-    const lastAt = versionFromDependency.lastIndexOf('@');
-
-    // eslint-disable-next-line no-magic-numbers
-    version = versionFromDependency.slice(lastAt + 1);
-  }
 
   const singleName = name.split('/').reverse()[0];
 

--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -26,12 +26,13 @@ async function readAllStdin() {
 function rebaseV1Inline(name, dependency, baseURL) {
   const { resolved: actual, version: versionFromDependency } = dependency;
   let version = versionFromDependency;
+  const npmPrefix = 'npm:';
 
-  if (versionFromDependency.startsWith('npm:')) {
+  if (versionFromDependency.startsWith(npmPrefix)) {
     const lastAt = versionFromDependency.lastIndexOf('@');
 
     // eslint-disable-next-line no-magic-numbers
-    name = versionFromDependency.slice(4, lastAt);
+    name = versionFromDependency.slice(npmPrefix.length, lastAt);
     version = versionFromDependency.slice(lastAt + 1);
   }
 


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog Entry

(No CHANGELOG for tooling update)

## Description

Update `rebasePackageLock.mjs` to support NPM alias.

Following are `package-lock.json` samples that failed previous versions of the script.

### Lockfile v1

```json
"node_modules/@isaacs/cliui": {
  "version": "8.0.2",
  "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
  "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
  "dev": true,
  "dependencies": {
    "string-width": "^5.1.2",
    "string-width-cjs": "npm:string-width@^4.2.0",
    "strip-ansi": "^7.0.1",
    "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
    "wrap-ansi": "^8.1.0",
    "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
  },
  "engines": {}
},
```

```json
"string-width-cjs": {
  "version": "npm:string-width@4.2.3",
  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
  "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
  "dev": true,
  "requires": {
    "emoji-regex": "^8.0.0",
    "is-fullwidth-code-point": "^3.0.0",
    "strip-ansi": "^6.0.1"
  },
  "dependencies": {}
},
```

### Lockfile v2

```json
"@isaacs/cliui": {
  "version": "8.0.2",
  "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
  "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
  "dev": true,
  "requires": {
    "string-width": "^5.1.2",
    "string-width-cjs": "npm:string-width@^4.2.0",
    "strip-ansi": "^7.0.1",
    "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
    "wrap-ansi": "^8.1.0",
    "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
  },
  "engines": {}
}
```

```json
"node_modules/string-width-cjs": {
  "name": "string-width",
  "version": "4.2.3",
  "resolved": "https://fuselabs.pkgs.visualstudio.com/_packaging/FuseNPM/npm/registry/string-width/-/string-width-4.2.3.tgz",
  "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
  "dev": true,
  "dependencies": {},
  "engines": {}
},
```

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

- Updated `rebasePackageLock.mjs` to support NPM alias

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
