### PR TITLE
Perf: improve useMemoized callback execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 -  Fixes [#5175](https://github.com/microsoft/BotFramework-WebChat/issues/5175). `PrecompiledGlobalize.js` is emitted instead of `.cjs`, by [@compulim](https://github.com/compulim) in PR [#5181](https://github.com/microsoft/BotFramework-WebChat/pull/5181)
 -  Improved performance for `BasicTranscript`, in PR [5183](https://github.com/microsoft/BotFramework-WebChat/pull/5183), by [@OEvgeny](https://github.com/OEvgeny)
 -  Fixed potential memory usage issues caused by `useActivitiesWithRenderer`, in PR [5183](https://github.com/microsoft/BotFramework-WebChat/pull/5183), by [@OEvgeny](https://github.com/OEvgeny)
+-  Improved performance for `useMemoized`, in PR [5190](https://github.com/microsoft/BotFramework-WebChat/pull/5190), by [@OEvgeny](https://github.com/OEvgeny)
 
 ### Changed
 

--- a/packages/component/src/hooks/internal/useMemoized.ts
+++ b/packages/component/src/hooks/internal/useMemoized.ts
@@ -39,7 +39,7 @@ export default function useMemoized<TFinal, TArgs>(fn: Fn<TArgs, TFinal>, deps: 
         const lookupCached = ({ args: cachedArgs }: { args: TArgs[] }) =>
           args.length === cachedArgs.length && args.every((arg, index) => Object.is(arg, cachedArgs[+index]));
 
-        const cached = nextCache.find(lookupCached) ?? cache.find(lookupCached);
+        const cached = cache.find(lookupCached) ?? nextCache.find(lookupCached);
         if (cached) {
           cached.args = args;
           nextCache.push(cached);

--- a/packages/component/src/hooks/internal/useMemoized.ts
+++ b/packages/component/src/hooks/internal/useMemoized.ts
@@ -49,14 +49,14 @@ export default function useMemoized<TFinal, TArgs>(fn: Fn<TArgs, TFinal>, deps: 
           return cached.result;
         }
 
-        const newCached = {
+        const nextCached = {
           args,
           result: fn(...args)
         };
-        nextCache.push(newCached);
-        cache.push(newCached);
+        nextCache.push(nextCached);
+        cache.push(nextCached);
 
-        return newCached.result;
+        return nextCached.result;
       };
 
       return memoizedFn;


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog Entry

- Improved performance for `useMemoized`, in PR [5190](https://github.com/microsoft/BotFramework-WebChat/pull/5190), by [@OEvgeny](https://github.com/OEvgeny)

## Description

This PR reduces time spent in the memoized function created by `useMemoized` by 3-18 times. As this function is one of the primitives we use to improve performance, we should keep it as fast and simple as possible.

## Design

The main idea is to reduce unnecessary object allocations and reuse existing objects where possible.

Changes are:
- use a single lookup instead of combined array lookup
- reuse cached object if found
- do not create unnecessary objects
- explicit branching for cached / non-cached conditions

## Specific Changes

- Updated `memoizedFn` implementation

## -

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
