### PR TITLE
Bump to 4.18.1-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.18.0",
+  "version": "4.18.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-webchat-root",
-      "version": "4.18.0",
+      "version": "4.18.1-0",
       "license": "MIT",
       "dependencies": {
         "react": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-webchat-root",
-  "version": "4.18.0",
+  "version": "4.18.1-0",
   "private": true,
   "files": [
     "lib/**/*"

--- a/packages/embed/servicingPlan.json
+++ b/packages/embed/servicingPlan.json
@@ -547,6 +547,24 @@
       "private": true,
       "versionFamily": "4"
     },
+    "4.18": {
+      "redirects": [
+        [
+          "*",
+          "4.18.0"
+        ]
+      ]
+    },
+    "4.18.0": {
+      "assets": [
+        [
+          "https://cdn.botframework.com/botframework-webchat/4.18.0/webchat-es5.js",
+          "sha384-RuyQM7i2h9QDvJTm5quFymi0qfuWyIZocRdsgUaPIhlZnAM/Qz1/YnUxH55Dt9Rd"
+        ]
+      ],
+      "private": true,
+      "versionFamily": "4"
+    },
     "hosted": {
       "assets": [
         [


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #5239.

## Changelog Entry

(Bumping to 4.18.1-0)

## Description

After release of 4.18.0, bumping to 4.18.1-0.

## Specific Changes

- `npm version --no-git-tag-version 4.18.1-0`
- Add 4.18.0 to `servicingPlan.json`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
