### PR TITLE
Fix rebase scripts for lockfile v3 with npm workspaces

### DIFF
--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -23,39 +23,6 @@ async function readAllStdin() {
   });
 }
 
-function rebaseV1Inline(name, dependency, baseURL) {
-  const { resolved: actual, version: versionFromDependency } = dependency;
-  let version = versionFromDependency;
-  const npmPrefix = 'npm:';
-
-  if (versionFromDependency.startsWith(npmPrefix)) {
-    const lastAt = versionFromDependency.lastIndexOf('@');
-
-    // eslint-disable-next-line no-magic-numbers
-    name = versionFromDependency.slice(npmPrefix.length, lastAt);
-    version = versionFromDependency.slice(lastAt + 1);
-  }
-
-  const [singleName] = name.split('/').reverse();
-
-  const { href: expected } = new URL(`${name}/-/${singleName}-${version}.tgz`, 'https://registry.npmjs.org/');
-  const { href: rebased } = new URL(`${name}/-/${singleName}-${version}.tgz`, baseURL);
-
-  if (expected !== actual) {
-    throw new Error(`v1: Expecting "resolved" field to be "${expected}", actual is "${actual}".`);
-  }
-
-  dependency.resolved = rebased;
-
-  rebaseV1InlineAll(dependency, baseURL);
-}
-
-function rebaseV1InlineAll({ dependencies }, baseURL) {
-  for (const [name, dependency] of Object.entries(dependencies || {})) {
-    rebaseV1Inline(name, dependency, baseURL);
-  }
-}
-
 function rebaseV2Inline(path, dependency, baseURL) {
   if (dependency.link || !dependency.resolved) {
     return;
@@ -76,7 +43,7 @@ function rebaseV2Inline(path, dependency, baseURL) {
   dependency.resolved = rebased;
 }
 
-function rebaseV2InlineAll(packages, baseURL) {
+function rebaseV3InlineAll(packages, baseURL) {
   for (const [path, dependency] of Object.entries(packages || {})) {
     // "path" is falsy if it is iterating the current package.
     path && rebaseV2Inline(path, dependency, baseURL);
@@ -92,11 +59,12 @@ async function main() {
 
   const packageLockJSON = JSON.parse(await readAllStdin());
 
-  // v1
-  rebaseV1InlineAll(packageLockJSON, baseURL);
+  if (packageLockJSON.lockfileVersion !== 3) {
+    throw new Error('Only works with v3 lockfile.');
+  }
 
-  // v2
-  rebaseV2InlineAll(packageLockJSON.packages, baseURL);
+  // v3
+  rebaseV3InlineAll(packageLockJSON.packages, baseURL);
 
   const json = JSON.stringify(packageLockJSON, null, 2);
 

--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -57,6 +57,10 @@ function rebaseV1InlineAll({ dependencies }, baseURL) {
 }
 
 function rebaseV2Inline(path, dependency, baseURL) {
+  if (dependency.link || !dependency.resolved) {
+    return;
+  }
+
   const { name: nameFromDependency, resolved: actual, version } = dependency;
   const name = nameFromDependency || path.split('node_modules/').reverse()[0];
 

--- a/scripts/rebasePackageLock.mjs
+++ b/scripts/rebasePackageLock.mjs
@@ -23,7 +23,7 @@ async function readAllStdin() {
   });
 }
 
-function rebaseV2Inline(path, dependency, baseURL) {
+function rebaseV3Inline(path, dependency, baseURL) {
   if (dependency.link || !dependency.resolved) {
     return;
   }
@@ -46,7 +46,7 @@ function rebaseV2Inline(path, dependency, baseURL) {
 function rebaseV3InlineAll(packages, baseURL) {
   for (const [path, dependency] of Object.entries(packages || {})) {
     // "path" is falsy if it is iterating the current package.
-    path && rebaseV2Inline(path, dependency, baseURL);
+    path && rebaseV3Inline(path, dependency, baseURL);
   }
 }
 


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #4847.

## Changelog Entry

(No changelog for build tools update.)

## Description

npm workspaces use `resolved` field for workspaces (as a relative value).

For package in workspace, lockfile v3 also included them in without `resolved` field.

We need to skip rebase both cases because they represent packages in the workspace.

## Specific Changes

- Updated `scripts/rebasePackageLock.mjs`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
