### PR TITLE
Fix npm start and samples

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -58,10 +58,8 @@
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
     "start": "concurrently --kill-others --prefix-colors \"auto\" \"npm:start:*\"",
-    "start:babel": "npm run build:babel -- --skip-initial-build --watch",
     "start:devserver": "node ./scripts/devServer.mjs",
-    "start:tsup": "npm run build:tsup -- --watch",
-    "start:typescript": "npm run build:typescript -- --watch"
+    "start:tsup": "npm run build:tsup -- --watch"
   },
   "localDependencies": {
     "botframework-directlinespeech-sdk": "production",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,9 +57,7 @@
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
     "start": "concurrently --kill-others --prefix-colors \"auto\" \"npm:start:*\"",
-    "start:babel": "npm run build:babel -- --skip-initial-build --watch",
-    "start:tsup": "npm run build:tsup -- --watch",
-    "start:typescript": "npm run build:typescript -- --watch"
+    "start:tsup": "npm run build:tsup -- --watch"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -72,8 +72,7 @@
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
     "start": "concurrently --kill-others --prefix-colors \"auto\" \"npm:start:*\"",
-    "start:tsup": "npm run build:tsup -- --watch",
-    "start:typescript": "npm run build:typescript -- --watch"
+    "start:tsup": "npm run build:tsup -- --watch"
   },
   "devDependencies": {
     "@jridgewell/sourcemap-codec": "^1.4.15",

--- a/samples/05.custom-components/f.password-input/index.html
+++ b/samples/05.custom-components/f.password-input/index.html
@@ -76,7 +76,7 @@
         'use strict';
 
         const {
-          hooks: { useRenderActivityStatus, useSendPostBack },
+          hooks: { useCreateActivityStatusRenderer, useSendPostBack },
           ReactWebChat
         } = window.WebChat;
 
@@ -85,7 +85,7 @@
         const PasswordInputActivity = ({ activity, nextVisibleActivity }) => {
           const [twoFACode, setTwoFACode] = useState('');
           const [submitted, setSubmitted] = useState(false);
-          const renderActivityStatus = useRenderActivityStatus({ activity, nextVisibleActivity });
+          const renderActivityStatus = useCreateActivityStatusRenderer()({ activity, sendState: 'sent' });
           const sendPostBack = useSendPostBack();
 
           const handleCodeChange = useCallback(
@@ -111,6 +111,7 @@
                 <label className="passwordInput__box">
                   <span className="passwordInput__label">Please input your 2FA code</span>
                   <input
+                    autoComplete="off"
                     autoFocus={true}
                     className="passwordInput__input"
                     disabled={submitted}
@@ -120,7 +121,7 @@
                   />
                 </label>
               </form>
-              {renderActivityStatus()}
+              {renderActivityStatus({ hideTimestamp: false })}
             </div>
           );
         };


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Related to #5176.

## Changelog Entry

(No changelog for toolchain and sample updates.)

## Description

Fix `npm start` by removing obsoleted `npm run start:babel` and various scripts.

## Specific Changes

- Remove `start:babel` and `start:typescript`
- Fix "password input" sample

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
