### PR TITLE
Fix text missing after HTML tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 -  Fixes [#5294](https://github.com/microsoft/BotFramework-WebChat/issues/5294). Fixed copy button animation reset to "Copied" after hiding and showing Web Chat, in PR [#5295](https://github.com/microsoft/BotFramework-WebChat/pull/5295), by [@compulim](https://github.com/compulim)
 -  Fixes [#5147](https://github.com/microsoft/BotFramework-WebChat/issues/5147). Added `punycode` to our dependencies as `markdown-it` requires it but did not have it in their `package.json`, in PR [#5301](https://github.com/microsoft/BotFramework-WebChat/pull/5301), by [@compulim](https://github.com/compulim)
 -  Fixes [#5306](https://github.com/microsoft/BotFramework-WebChat/issues/5306). Title and subtitle in pre-chat message activity should wrap, in PR [#5307](https://github.com/microsoft/BotFramework-WebChat/pull/5307), by [@compulim](https://github.com/compulim)
+-  Fixes [#5319](https://github.com/microsoft/BotFramework-WebChat/issues/5319). Some Markdown text are not rendered after HTML tags, in PR [#5320](https://github.com/microsoft/BotFramework-WebChat/pull/5320), by [@compulim](https://github.com/compulim)
 
 # Removed
 

--- a/__tests__/hooks/useRenderMarkdownAsHTML.js
+++ b/__tests__/hooks/useRenderMarkdownAsHTML.js
@@ -16,7 +16,7 @@ test('renderMarkdown should use Markdown-It if not set in props', async () => {
       'webchat--css-xxxxx-xxxxx'
     )
   ).toBe(
-    '<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Hello, World!</p></div>\n'
+    '<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Hello, World!</p></div>'
   );
 });
 
@@ -33,7 +33,7 @@ test('renderMarkdown should use custom Markdown transform function from props', 
       'webchat--css-xxxxx-xxxxx'
     )
   ).toBe(
-    '<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>HELLO, WORLD!</p></div>\n'
+    '<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>HELLO, WORLD!</p></div>'
   );
 });
 
@@ -57,7 +57,7 @@ test('renderMarkdown should add accessibility text for external links', async ()
       )
     ).replace(CSS_HASH_PATTERN, 'webchat--css-xxxxx-xxxxx')
   ).toBe(
-    `<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Click \u200B<a href="https://aka.ms/" aria-label="here Opens in a new window; external." rel="noopener noreferrer" target="_blank">here<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="Opens in a new window; external." /></a>\u200B to find out more.</p></div>\n`
+    `<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Click \u200B<a href="https://aka.ms/" aria-label="here Opens in a new window; external." rel="noopener noreferrer" target="_blank">here<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="Opens in a new window; external." /></a>\u200B to find out more.</p></div>`
   );
 });
 
@@ -71,6 +71,6 @@ test('renderMarkdown should add accessibility text for external links with yue',
       )
     ).replace(CSS_HASH_PATTERN, 'webchat--css-xxxxx-xxxxx')
   ).toBe(
-    `<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Click \u200B<a href="https://aka.ms/" aria-label="here 喺新嘅視窗開啟外部連結。" rel="noopener noreferrer" target="_blank">here<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="喺新嘅視窗開啟外部連結。" /></a>\u200B to find out more.</p></div>\n`
+    `<div xmlns="http://www.w3.org/1999/xhtml" class="webchat__render-markdown webchat__render-markdown--message-activity webchat--css-xxxxx-xxxxx"><p>Click \u200B<a href="https://aka.ms/" aria-label="here 喺新嘅視窗開啟外部連結。" rel="noopener noreferrer" target="_blank">here<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="喺新嘅視窗開啟外部連結。" /></a>\u200B to find out more.</p></div>`
   );
 });

--- a/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
@@ -35,7 +35,10 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Hello, World!\n*$/u)
+        );
 
         const pushButton1 = document.querySelector('.ac-pushButton');
 
@@ -53,7 +56,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^Aloha!\n*$/u));
 
         const pushButton2 = document.querySelector('.ac-pushButton');
 

--- a/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
@@ -35,10 +35,7 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Hello, World!\n*$/u)
-        );
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
 
         const pushButton1 = document.querySelector('.ac-pushButton');
 
@@ -56,7 +53,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^Aloha!\n*$/u));
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
 
         const pushButton2 = document.querySelector('.ac-pushButton');
 

--- a/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.activeElementMod.html
@@ -35,7 +35,7 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!');
 
         const pushButton1 = document.querySelector('.ac-pushButton');
 
@@ -53,7 +53,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!');
 
         const pushButton2 = document.querySelector('.ac-pushButton');
 

--- a/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
@@ -45,7 +45,10 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Hello, World!\n*$/u)
+        );
 
         const textInput1 = document.querySelector('.ac-textInput');
 
@@ -62,7 +65,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^Aloha!\n*$/u));
 
         const textInput2 = document.querySelector('.ac-textInput');
 

--- a/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
@@ -45,10 +45,7 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Hello, World!\n*$/u)
-        );
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
 
         const textInput1 = document.querySelector('.ac-textInput');
 
@@ -65,7 +62,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^Aloha!\n*$/u));
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
 
         const textInput2 = document.querySelector('.ac-textInput');
 

--- a/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
+++ b/__tests__/html/accessibility.adaptiveCard.hack.persistValuesMod.html
@@ -45,7 +45,7 @@
 
         await pageConditions.numActivitiesShown(1);
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Hello, World!');
 
         const textInput1 = document.querySelector('.ac-textInput');
 
@@ -62,7 +62,7 @@
           type: 'message'
         });
 
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'Aloha!');
 
         const textInput2 = document.querySelector('.ac-textInput');
 

--- a/__tests__/html/markdownRenderHTML/false.adaptiveCards.html
+++ b/__tests__/html/markdownRenderHTML/false.adaptiveCards.html
@@ -59,7 +59,7 @@
 
         const markdownElement = firstActivityElement.querySelectorAll('.webchat__render-markdown')[1];
 
-        expect(markdownElement.textContent.startsWith('Header<p>This is some text')).toBe(true);
+        expect(markdownElement.innerHTML.startsWith('<h2>Header</h2>\n<p>&lt;p&gt;This is some text')).toBe(true);
 
         await host.snapshot();
       });

--- a/__tests__/html/markdownRenderHTML/false.citationModal.html
+++ b/__tests__/html/markdownRenderHTML/false.citationModal.html
@@ -97,7 +97,7 @@
 
         const markdownElement = document.querySelectorAll('dialog .webchat__render-markdown')[1];
 
-        expect(markdownElement.textContent.startsWith('Header<p>This is some text')).toBe(true);
+        expect(markdownElement.innerHTML.startsWith('<h2>Header</h2>\n<p>&lt;p&gt;This is some text')).toBe(true);
 
         await host.snapshot();
       });

--- a/__tests__/html/markdownRenderHTML/false.messageActivity.html
+++ b/__tests__/html/markdownRenderHTML/false.messageActivity.html
@@ -32,7 +32,7 @@
 
         const markdownElement = firstActivityElement.querySelector('.webchat__render-markdown');
 
-        expect(markdownElement.textContent.startsWith('Header<p>This is some text')).toBe(true);
+        expect(markdownElement.innerHTML.startsWith('<h2>Header</h2>\n<p>&lt;p&gt;This is some text')).toBe(true);
 
         await host.snapshot();
       });

--- a/__tests__/html/typing/activityOrder.html
+++ b/__tests__/html/typing/activityOrder.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,12 +102,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
         );
         await host.snapshot();
 
@@ -134,15 +134,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
         );
         await host.snapshot();
 
@@ -169,15 +166,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
         );
         await host.snapshot();
 
@@ -203,15 +197,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.*\n*$/u)
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html/typing/activityOrder.html
+++ b/__tests__/html/typing/activityOrder.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,12 +102,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
         );
         await host.snapshot();
 
@@ -134,12 +134,15 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox\n*$/u)
+        );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
         );
         await host.snapshot();
 
@@ -166,12 +169,15 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.\n*$/u)
         );
         await host.snapshot();
 
@@ -197,15 +203,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          expect.stringMatching(/^Amet consequat enim incididunt excepteur aliquip magna duis et tempor\.*\n*$/u)
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html/typing/activityOrder.html
+++ b/__tests__/html/typing/activityOrder.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,12 +102,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.'
         );
         await host.snapshot();
 
@@ -134,12 +134,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.'
         );
         await host.snapshot();
 
@@ -166,12 +166,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.'
         );
         await host.snapshot();
 
@@ -197,15 +197,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.\n'
+          'Amet consequat enim incididunt excepteur aliquip magna duis et tempor.'
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html/typing/chunk.html
+++ b/__tests__/html/typing/chunk.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,12 +102,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -132,12 +129,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -160,11 +154,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/chunk.html
+++ b/__tests__/html/typing/chunk.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,9 +102,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -129,9 +129,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -154,11 +154,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/chunk.html
+++ b/__tests__/html/typing/chunk.html
@@ -75,9 +75,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,9 +102,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -129,9 +132,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -154,11 +160,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/concludedLivestream.html
+++ b/__tests__/html/typing/concludedLivestream.html
@@ -69,7 +69,7 @@
         // THEN: Should display 1 message.
         await pageConditions.numActivitiesShown(1);
         expect(pageElements.typingIndicator()).toBeFalsy();
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 1 activity key.
@@ -102,7 +102,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 
@@ -131,7 +131,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 
@@ -160,7 +160,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/concludedLivestream.html
+++ b/__tests__/html/typing/concludedLivestream.html
@@ -69,7 +69,7 @@
         // THEN: Should display 1 message.
         await pageConditions.numActivitiesShown(1);
         expect(pageElements.typingIndicator()).toBeFalsy();
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 1 activity key.
@@ -102,7 +102,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 
@@ -131,7 +131,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 
@@ -160,7 +160,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/concludedLivestream.html
+++ b/__tests__/html/typing/concludedLivestream.html
@@ -69,7 +69,7 @@
         // THEN: Should display 1 message.
         await pageConditions.numActivitiesShown(1);
         expect(pageElements.typingIndicator()).toBeFalsy();
-        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[0]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 1 activity key.
@@ -102,7 +102,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 
@@ -131,7 +131,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 
@@ -160,7 +160,7 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/informative.html
+++ b/__tests__/html/typing/informative.html
@@ -58,12 +58,9 @@
         // THEN: Should render the informative message.
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Nisi elit quis nisi consectetur\.\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'Nisi elit quis nisi consectetur.\n');
 
         await pageConditions.numActivitiesShown(2);
         await host.snapshot();

--- a/__tests__/html/typing/informative.html
+++ b/__tests__/html/typing/informative.html
@@ -58,9 +58,12 @@
         // THEN: Should render the informative message.
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'Nisi elit quis nisi consectetur.\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Nisi elit quis nisi consectetur\.\n*$/u)
+        );
 
         await pageConditions.numActivitiesShown(2);
         await host.snapshot();

--- a/__tests__/html/typing/informative.html
+++ b/__tests__/html/typing/informative.html
@@ -58,9 +58,9 @@
         // THEN: Should render the informative message.
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'Nisi elit quis nisi consectetur.\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'Nisi elit quis nisi consectetur.');
 
         await pageConditions.numActivitiesShown(2);
         await host.snapshot();

--- a/__tests__/html/typing/layout.html
+++ b/__tests__/html/typing/layout.html
@@ -102,7 +102,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'informative message show up',
-          () => pageElements.activityContents()[0].textContent.trim() === 'Searching your document library…',
+          () => pageElements.activityContents()[0].textContent === 'Searching your document library…\n',
           1_000
         );
 
@@ -131,7 +131,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'interim activity show up',
-          () => pageElements.activityContents()[0].textContent.trim() === 'A quick brown fox',
+          () => pageElements.activityContents()[0].textContent === 'A quick brown fox\n',
           1_000
         );
 
@@ -159,7 +159,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'final activity show up',
-          () => pageElements.activityContents()[0].textContent.trim() === 'A quick brown fox jumped over the lazy dogs.',
+          () => pageElements.activityContents()[0].textContent === 'A quick brown fox jumped over the lazy dogs.\n',
           1_000
         );
 

--- a/__tests__/html/typing/layout.html
+++ b/__tests__/html/typing/layout.html
@@ -102,7 +102,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'informative message show up',
-          () => pageElements.activityContents()[0].textContent === 'Searching your document library…\n',
+          () => pageElements.activityContents()[0].textContent.trim() === 'Searching your document library…',
           1_000
         );
 
@@ -131,7 +131,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'interim activity show up',
-          () => pageElements.activityContents()[0].textContent === 'A quick brown fox\n',
+          () => pageElements.activityContents()[0].textContent.trim() === 'A quick brown fox',
           1_000
         );
 
@@ -159,7 +159,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'final activity show up',
-          () => pageElements.activityContents()[0].textContent === 'A quick brown fox jumped over the lazy dogs.\n',
+          () => pageElements.activityContents()[0].textContent.trim() === 'A quick brown fox jumped over the lazy dogs.',
           1_000
         );
 

--- a/__tests__/html/typing/layout.html
+++ b/__tests__/html/typing/layout.html
@@ -102,7 +102,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'informative message show up',
-          () => pageElements.activityContents()[0].textContent === 'Searching your document library…\n',
+          () => pageElements.activityContents()[0].textContent === 'Searching your document library…',
           1_000
         );
 
@@ -131,7 +131,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'interim activity show up',
-          () => pageElements.activityContents()[0].textContent === 'A quick brown fox\n',
+          () => pageElements.activityContents()[0].textContent === 'A quick brown fox',
           1_000
         );
 
@@ -159,7 +159,7 @@
         await pageConditions.numActivitiesShown(1);
         await pageConditions.became(
           'final activity show up',
-          () => pageElements.activityContents()[0].textContent === 'A quick brown fox jumped over the lazy dogs.\n',
+          () => pageElements.activityContents()[0].textContent === 'A quick brown fox jumped over the lazy dogs.',
           1_000
         );
 

--- a/__tests__/html/typing/outOfOrder.html
+++ b/__tests__/html/typing/outOfOrder.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -120,12 +120,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -162,12 +159,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -203,11 +197,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/outOfOrder.html
+++ b/__tests__/html/typing/outOfOrder.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -120,9 +120,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -159,9 +162,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -197,11 +203,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/outOfOrder.html
+++ b/__tests__/html/typing/outOfOrder.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -120,9 +120,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -159,9 +159,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -197,11 +197,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/outOfOrder.sequenceNumber.html
+++ b/__tests__/html/typing/outOfOrder.sequenceNumber.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -121,12 +121,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -164,12 +161,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys in correctly sorted order.
@@ -205,11 +199,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/outOfOrder.sequenceNumber.html
+++ b/__tests__/html/typing/outOfOrder.sequenceNumber.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -121,9 +121,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -161,9 +161,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys in correctly sorted order.
@@ -199,11 +199,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/outOfOrder.sequenceNumber.html
+++ b/__tests__/html/typing/outOfOrder.sequenceNumber.html
@@ -81,9 +81,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -121,9 +121,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys only.
@@ -161,9 +164,12 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox jumped over\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox jumped over\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 2 activity keys in correctly sorted order.
@@ -199,11 +205,11 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         await host.snapshot();
 

--- a/__tests__/html/typing/simultaneous.html
+++ b/__tests__/html/typing/simultaneous.html
@@ -73,9 +73,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,13 +102,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
-        expect(pageElements.activityContents()[2]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Falsches Üben\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -134,16 +131,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox\n*$/u)
-        );
-        expect(pageElements.activityContents()[2]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Falsches Üben\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -169,16 +160,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^A quick brown fox\n*$/u)
-        );
-        expect(pageElements.activityContents()[2]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Falsches Üben von Xylophonmusik\n*$/u)
-        );
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -203,16 +188,13 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
-        expect(pageElements.activityContents()[2]).toHaveProperty(
-          'textContent',
-          expect.stringMatching(/^Falsches Üben von Xylophonmusik\n*$/u)
-        );
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();
 
@@ -238,15 +220,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
+          'A quick brown fox jumped over the lazy dogs.\n'
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          expect.stringMatching(/^Falsches Üben von Xylophonmusik quält jeden größeren Zwerg\.\n*$/u)
+          'Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.\n'
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html/typing/simultaneous.html
+++ b/__tests__/html/typing/simultaneous.html
@@ -73,9 +73,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,10 +102,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -131,10 +131,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -160,10 +160,10 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik');
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -188,13 +188,13 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
+        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik');
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();
 
@@ -220,15 +220,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.'
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          'A quick brown fox jumped over the lazy dogs.'
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.\n'
+          'Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.'
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html/typing/simultaneous.html
+++ b/__tests__/html/typing/simultaneous.html
@@ -73,9 +73,9 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
         await host.snapshot();
 
         // THEN: Should have 2 activity keys.
@@ -102,10 +102,13 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', expect.stringMatching(/^A quick\n*$/u));
+        expect(pageElements.activityContents()[2]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Falsches Üben\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -131,10 +134,16 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox\n*$/u)
+        );
+        expect(pageElements.activityContents()[2]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Falsches Üben\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -160,10 +169,16 @@
         expect(pageElements.typingIndicator()).toBeFalsy();
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
-        expect(pageElements.activityContents()[1]).toHaveProperty('textContent', 'A quick brown fox\n');
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
+        expect(pageElements.activityContents()[1]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^A quick brown fox\n*$/u)
+        );
+        expect(pageElements.activityContents()[2]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Falsches Üben von Xylophonmusik\n*$/u)
+        );
         await host.snapshot();
 
         // THEN: Should have 3 activity keys only.
@@ -188,13 +203,16 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
-        expect(pageElements.activityContents()[2]).toHaveProperty('textContent', 'Falsches Üben von Xylophonmusik\n');
+        expect(pageElements.activityContents()[2]).toHaveProperty(
+          'textContent',
+          expect.stringMatching(/^Falsches Üben von Xylophonmusik\n*$/u)
+        );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();
 
@@ -220,15 +238,15 @@
         await pageConditions.numActivitiesShown(3);
         expect(pageElements.activityContents()[0]).toHaveProperty(
           'textContent',
-          'Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum.\n'
+          expect.stringMatching(/^Adipisicing cupidatat eu Lorem anim ut aute magna occaecat id cillum\.\n*$/u)
         );
         expect(pageElements.activityContents()[1]).toHaveProperty(
           'textContent',
-          'A quick brown fox jumped over the lazy dogs.\n'
+          expect.stringMatching(/^A quick brown fox jumped over the lazy dogs\.\n*$/u)
         );
         expect(pageElements.activityContents()[2]).toHaveProperty(
           'textContent',
-          'Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.\n'
+          expect.stringMatching(/^Falsches Üben von Xylophonmusik quält jeden größeren Zwerg\.\n*$/u)
         );
         expect(pageElements.typingIndicator()).toBeFalsy();
         await host.snapshot();

--- a/__tests__/html2/markdown/bug.br.html
+++ b/__tests__/html2/markdown/bug.br.html
@@ -36,7 +36,7 @@
 
         // THEN: Should render both "Line 1" and "Line 2".
         expect(document.getElementById('webchat').textContent).toEqual(
-          expect.stringMatching('<p>\n*Line 1\n*</p>\n*<br />\n*Line 2\n*</div>')
+          expect.stringMatching(/<p>\n*Line 1\n*<\/p>\n*<br \/>\n*Line 2\n*<\/div>/)
         );
       });
     </script>

--- a/__tests__/html2/markdown/bug.br.html
+++ b/__tests__/html2/markdown/bug.br.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.production.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js"></script>
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <main id="webchat"></main>
+    <script type="text/babel">
+      run(async function () {
+        const {
+          React,
+          ReactDOM: { render },
+          WebChat: {
+            Components: { BasicWebChat, Composer },
+            hooks: { useRenderMarkdownAsHTML },
+            ReactWebChat
+          }
+        } = window; // Imports in UMD fashion.
+
+        const { directLine, store } = testHelpers.createDirectLineEmulator();
+
+        const App = () => useRenderMarkdownAsHTML()('Line 1\n\n<br />\nLine 2');
+
+        render(
+          <Composer directLine={directLine} store={store}>
+            <App />
+          </Composer>,
+          document.getElementById('webchat')
+        );
+
+        // THEN: Should render both "Line 1" and "Line 2".
+        expect(document.getElementById('webchat').textContent).toEqual(
+          expect.stringMatching('<p>\n*Line 1\n*</p>\n*<br />\n*Line 2\n*</div>')
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html2/markdown/bug.br.html
+++ b/__tests__/html2/markdown/bug.br.html
@@ -36,7 +36,7 @@
 
         // THEN: Should render both "Line 1" and "Line 2".
         expect(document.getElementById('webchat').textContent).toEqual(
-          expect.stringMatching(/<p>\n*Line 1\n*<\/p>\n*<br \/>\n*Line 2\n*<\/div>/)
+          expect.stringMatching('<p>\n*Line 1\n*</p>\n*<br />\n*Line 2\n*</div>')
         );
       });
     </script>

--- a/packages/bundle/src/__tests__/renderMarkdown.spec.js
+++ b/packages/bundle/src/__tests__/renderMarkdown.spec.js
@@ -14,7 +14,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown('Same line.\nSame line.  \n2nd line.', styleOptions)).toBe(
-      '<p>Same line.\nSame line.<br />\n2nd line.</p>\n'
+      '<p>Same line.\nSame line.<br />\n2nd line.</p>'
     );
   });
 
@@ -22,7 +22,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown('Same Line.\n\rSame Line.\r\n2nd line.', styleOptions)).toBe(
-      '<p>Same Line.\nSame Line.</p>\n<p>2nd line.</p>\n'
+      '<p>Same Line.\nSame Line.</p>\n<p>2nd line.</p>'
     );
   });
 
@@ -30,7 +30,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: false };
 
     expect(renderMarkdown('Same Line.\r\nSame Line.\n\r2nd line.', styleOptions)).toBe(
-      '<p>Same Line.\nSame Line.</p>\n<p>2nd line.</p>\n'
+      '<p>Same Line.\nSame Line.</p>\n<p>2nd line.</p>'
     );
   });
 
@@ -38,7 +38,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown('**Message with Markdown**\r\nShould see bold text.', styleOptions)).toBe(
-      '<p><strong>Message with Markdown</strong></p>\n<p>Should see bold text.</p>\n'
+      '<p><strong>Message with Markdown</strong></p>\n<p>Should see bold text.</p>'
     );
   });
 
@@ -46,7 +46,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown(`\`\`\`\n${JSON.stringify({ hello: 'World!' }, null, 2)}\n\`\`\``, styleOptions)).toBe(
-      '<pre><code>{\n  "hello": "World!"\n}\n</code></pre>\n'
+      '<pre><code>{\n  "hello": "World!"\n}\n</code></pre>'
     );
   });
 
@@ -54,7 +54,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown('[example](https://sample.com){aria-label="Sample label"}', styleOptions)).toBe(
-      `<p>\u200B<a href="https://sample.com" aria-label="Sample label" rel="noopener noreferrer" target="_blank">example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" /></a>\u200B</p>\n`
+      `<p>\u200B<a href="https://sample.com" aria-label="Sample label" rel="noopener noreferrer" target="_blank">example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" /></a>\u200B</p>`
     );
   });
 
@@ -63,7 +63,7 @@ describe('renderMarkdown', () => {
     const options = { externalLinkAlt: 'Opens in a new window, external.' };
 
     expect(renderMarkdown('[example](https://sample.com){aria-label="Sample label"}', styleOptions, options)).toBe(
-      `<p>\u200B<a href="https://sample.com" aria-label="Sample label" rel="noopener noreferrer" target="_blank">example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="Opens in a new window, external." /></a>\u200B</p>\n`
+      `<p>\u200B<a href="https://sample.com" aria-label="Sample label" rel="noopener noreferrer" target="_blank">example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="webchat__render-markdown__external-link-icon" title="Opens in a new window, external." /></a>\u200B</p>`
     );
   });
 
@@ -71,7 +71,7 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown(`[example@test.com](sip:example@test.com)`, styleOptions)).toBe(
-      '<p>\u200B<a href="sip:example@test.com" rel="noopener noreferrer" target="_blank">example@test.com</a>\u200B</p>\n'
+      '<p>\u200B<a href="sip:example@test.com" rel="noopener noreferrer" target="_blank">example@test.com</a>\u200B</p>'
     );
   });
 
@@ -79,13 +79,13 @@ describe('renderMarkdown', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
     expect(renderMarkdown(`[(505)503-4455](tel:505-503-4455)`, styleOptions)).toBe(
-      '<p>\u200B<a href="tel:505-503-4455" rel="noopener noreferrer" target="_blank">(505)503-4455</a>\u200B</p>\n'
+      '<p>\u200B<a href="tel:505-503-4455" rel="noopener noreferrer" target="_blank">(505)503-4455</a>\u200B</p>'
     );
   });
 
   it('should render strikethrough text correctly', () => {
     const styleOptions = { markdownRespectCRLF: true };
 
-    expect(renderMarkdown(`~~strike text~~`, styleOptions)).toBe('<p><s>strike text</s></p>\n');
+    expect(renderMarkdown(`~~strike text~~`, styleOptions)).toBe('<p><s>strike text</s></p>');
   });
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.ariaLabel.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.ariaLabel.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "ariaLabel" option with "Hello, World!"', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" aria-label="Hello, World!">Example</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" aria-label="Hello, World!">Example</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -51,6 +51,6 @@ describe('When passing "ariaLabel" option with false', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
+      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.ariaLabel.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.ariaLabel.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,36 +12,36 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "ariaLabel" option with "Hello, World!"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { ariaLabel: 'Hello, World!' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have "aria-label" attribute set to "Hello, World!"', () =>
     expect(actual.querySelector('a').getAttribute('aria-label')).toBe('Hello, World!'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" aria-label="Hello, World!">Example</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "ariaLabel" option with false', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { ariaLabel: false };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString('<a href="https://example.com" aria-label="Hello, World!">Example</a>'),
+      parseDocumentFragmentFromString('<a href="https://example.com" aria-label="Hello, World!">Example</a>'),
       () => decoration
     );
   });
@@ -47,7 +50,7 @@ describe('When passing "ariaLabel" option with false', () => {
     expect(actual.querySelector('a').hasAttribute('aria-label')).toBe(false));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.asButton.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.asButton.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "asButton" option with true', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example</button></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example</button></p>'
     ));
 
   test('should match baseline', () =>
@@ -48,7 +48,7 @@ describe('When passing "asButton" option with true and "iconClassName" with "my-
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" /></button></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" /></button></p>'
     ));
 
   test('should match baseline', () =>
@@ -74,7 +74,7 @@ describe('When passing "asButton" option with true and "title" with "Hello, Worl
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><button title="Hello, World!" type="button" value="https://example.com">Example</button></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><button title="Hello, World!" type="button" value="https://example.com">Example</button></p>'
     ));
 
   test('should match baseline', () =>
@@ -100,7 +100,7 @@ describe('When passing "asButton" option with true and "className" with "my-link
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><button class="my-link" type="button" value="https://example.com">Example</button></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><button class="my-link" type="button" value="https://example.com">Example</button></p>'
     ));
 
   test('should match baseline', () =>
@@ -126,7 +126,7 @@ describe('When passing "asButton" option with true and "aria-label" with "Hello,
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><button aria-label="Hello, World!" type="button" value="https://example.com">Example</button></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><button aria-label="Hello, World!" type="button" value="https://example.com">Example</button></p>'
     ));
 
   test('should match baseline', () =>

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.asButton.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.asButton.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,59 +12,59 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "asButton" option with true', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should replace with <button type="button">', () =>
     expect(actual.querySelector('button').getAttribute('type')).toBe('button'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example</button></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "asButton" option with true and "iconClassName" with "my-icon"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true, iconClassName: 'my-icon' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should replace with <button type="button">', () =>
     expect(actual.querySelector('button').getAttribute('type')).toBe('button'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><button type="button" value="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" /></button></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "asButton" option with true and "title" with "Hello, World!"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true, title: 'Hello, World!' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should replace with <button type="button" title="Hello, World!">', () => {
@@ -70,24 +73,24 @@ describe('When passing "asButton" option with true and "title" with "Hello, Worl
   });
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><button title="Hello, World!" type="button" value="https://example.com">Example</button></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "asButton" option with true and "className" with "my-link"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true, className: 'my-link' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should replace with <button type="button" class="my-link">', () => {
@@ -96,24 +99,24 @@ describe('When passing "asButton" option with true and "className" with "my-link
   });
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><button class="my-link" type="button" value="https://example.com">Example</button></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "asButton" option with true and "aria-label" with "Hello, World!"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true, ariaLabel: 'Hello, World!' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should replace with <button type="button" aria-label="Hello, World!">', () => {
@@ -122,14 +125,14 @@ describe('When passing "asButton" option with true and "aria-label" with "Hello,
   });
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><button aria-label="Hello, World!" type="button" value="https://example.com">Example</button></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.className.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.className.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "className" option with "my-link"', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" class="my-link">Example</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" class="my-link">Example</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -51,6 +51,6 @@ describe('When passing "className" option with false', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
+      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.className.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.className.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,36 +12,36 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "className" option with "my-link"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { className: 'my-link' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have "className" attribute set to "my-link"', () =>
     expect(actual.querySelector('a').classList.contains('my-link')).toBe(true));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" class="my-link">Example</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "className" option with false', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { className: false };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString('<a href="https://example.com" class="my-link">Example</a>'),
+      parseDocumentFragmentFromString('<a href="https://example.com" class="my-link">Example</a>'),
       () => decoration
     );
   });
@@ -47,7 +50,7 @@ describe('When passing "className" option with false', () => {
     expect(actual.querySelector('a').hasAttribute('class')).toBe(false));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.iconClassName.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.iconClassName.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,11 +12,11 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "iconAlt" option with "Hello, World!" and "iconClassName" with "my-icon"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { iconAlt: 'Hello, World!', iconClassName: 'my-icon' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have icon image with "alt" attribute set to empty string', () =>
@@ -31,14 +34,14 @@ describe('When passing "iconAlt" option with "Hello, World!" and "iconClassName"
     expect(actual.querySelector('img').getAttribute('title')).toBe('Hello, World!'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" title="Hello, World!" /></a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.iconClassName.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.iconClassName.spec.ts
@@ -35,7 +35,7 @@ describe('When passing "iconAlt" option with "Hello, World!" and "iconClassName"
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" title="Hello, World!" /></a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com">Example<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" class="my-icon" title="Hello, World!" /></a></p>'
     ));
 
   test('should match baseline', () =>

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.rel.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.rel.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,36 +12,36 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "rel" option with "noopener noreferer"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { rel: 'noopener noreferer' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have "rel" attribute set to "noopener noreferer"', () =>
     expect(actual.querySelector('a').getAttribute('rel')).toBe('noopener noreferer'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" rel="noopener noreferer">Example</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "rel" option with false', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { rel: false };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString('<a href="https://example.com" rel="noopener noreferer">Example</a>'),
+      parseDocumentFragmentFromString('<a href="https://example.com" rel="noopener noreferer">Example</a>'),
       () => decoration
     );
   });
@@ -46,7 +49,7 @@ describe('When passing "rel" option with false', () => {
   test('should have "rel" attribute removed', () => expect(actual.querySelector('a').hasAttribute('rel')).toBe(false));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.rel.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.rel.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "rel" option with "noopener noreferer"', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" rel="noopener noreferer">Example</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" rel="noopener noreferer">Example</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -50,6 +50,6 @@ describe('When passing "rel" option with false', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
+      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.selector.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.selector.spec.ts
@@ -27,7 +27,7 @@ describe('When passing "ariaLabel" option with "Hello, World!" for a specific an
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -58,7 +58,7 @@ describe('When passing "ariaLabel" option with "Hello, World!" for a specific an
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>'
     ));
 
   test('should match baseline', () =>

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.selector.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.selector.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,12 +12,12 @@ const BASE_MARKDOWN = '[Hello, World!](https://example.com/1)\n\n[Aloha!](https:
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "ariaLabel" option with "Hello, World!" for a specific anchor based on "href"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { ariaLabel: 'Hello, World!' };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString(BASE_HTML),
+      parseDocumentFragmentFromString(BASE_HTML),
       href => href === 'https://example.com/1' && decoration
     );
   });
@@ -23,14 +26,14 @@ describe('When passing "ariaLabel" option with "Hello, World!" for a specific an
     expect(actual.querySelector('a').getAttribute('aria-label')).toBe('Hello, World!'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(
           new MarkdownIt()
             .use(betterLink, (_, textContent) => textContent === 'Hello, World!' && decoration)
             .render(BASE_MARKDOWN)
@@ -40,12 +43,12 @@ describe('When passing "ariaLabel" option with "Hello, World!" for a specific an
 });
 
 describe('When passing "ariaLabel" option with "Hello, World!" for a specific anchor based on "textContent"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { ariaLabel: 'Hello, World!' };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString(BASE_HTML),
+      parseDocumentFragmentFromString(BASE_HTML),
       (_, textContent) => textContent === 'Hello, World!' && decoration
     );
   });
@@ -54,14 +57,14 @@ describe('When passing "ariaLabel" option with "Hello, World!" for a specific an
     expect(actual.querySelector('a').getAttribute('aria-label')).toBe('Hello, World!'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/1" aria-label="Hello, World!">Hello, World!</a></p>\n<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com/2">Aloha!</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(
           new MarkdownIt()
             .use(betterLink, (_, textContent) => textContent === 'Hello, World!' && decoration)
             .render(BASE_MARKDOWN)

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.target.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.target.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,36 +12,36 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "target" option with "noopener noreferer"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { target: 'noopener noreferer' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have "target" attribute set to "noopener noreferer"', () =>
     expect(actual.querySelector('a').getAttribute('target')).toBe('noopener noreferer'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" target="noopener noreferer">Example</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "target" option with false', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { target: false };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString('<a href="https://example.com" target="noopener noreferer">Example</a>'),
+      parseDocumentFragmentFromString('<a href="https://example.com" target="noopener noreferer">Example</a>'),
       () => decoration
     );
   });
@@ -47,7 +50,7 @@ describe('When passing "target" option with false', () => {
     expect(actual.querySelector('a').hasAttribute('target')).toBe(false));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.target.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.target.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "target" option with "noopener noreferer"', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" target="noopener noreferer">Example</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" target="noopener noreferer">Example</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -51,6 +51,6 @@ describe('When passing "target" option with false', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
+      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.title.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.title.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,36 +12,36 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "title" option with "Hello, World!"', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { title: 'Hello, World!' };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should have "title" attribute set to "Hello, World!"', () =>
     expect(actual.querySelector('a').getAttribute('title')).toBe('Hello, World!'));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" title="Hello, World!">Example</a></p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "title" option with false', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { title: false };
 
   beforeEach(() => {
     actual = betterLinkDocumentMod(
-      parseDocumentFromString('<a href="https://example.com" title="Hello, World!">Example</a>'),
+      parseDocumentFragmentFromString('<a href="https://example.com" title="Hello, World!">Example</a>'),
       () => decoration
     );
   });
@@ -47,7 +50,7 @@ describe('When passing "title" option with false', () => {
     expect(actual.querySelector('a').hasAttribute('title')).toBe(false));
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.title.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.title.spec.ts
@@ -24,7 +24,7 @@ describe('When passing "title" option with "Hello, World!"', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" title="Hello, World!">Example</a></p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml"><a href="https://example.com" title="Hello, World!">Example</a></p>'
     ));
 
   test('should match baseline', () =>
@@ -51,6 +51,6 @@ describe('When passing "title" option with false', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>\n'
+      '<a xmlns="http://www.w3.org/1999/xhtml" href="https://example.com">Example</a>'
     ));
 });

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.ts
@@ -52,11 +52,11 @@ function setOrRemoveAttribute(element: Element, attributeName: string, setter: A
   }
 }
 
-export default function betterLinkDocumentMod(
-  document: Document,
+export default function betterLinkDocumentMod<T extends Document | DocumentFragment>(
+  documentFragment: T,
   decorator: (href: string, textContent: string) => BetterLinkDocumentModDecoration | false | undefined
-): Document {
-  for (const anchor of [...iterateNodeList(document.querySelectorAll('a'))]) {
+): T {
+  for (const anchor of [...iterateNodeList(documentFragment.querySelectorAll('a'))]) {
     const decoration = decorator(anchor.getAttribute('href'), anchor.textContent);
 
     if (!decoration) {
@@ -109,5 +109,5 @@ export default function betterLinkDocumentMod(
     }
   }
 
-  return document;
+  return documentFragment;
 }

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.wrapZeroWidthSpace.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.wrapZeroWidthSpace.spec.ts
@@ -21,7 +21,7 @@ describe('When passing "wrapZeroWidthSpace" option with true', () => {
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<a href="https://example.com">Example</a>\u200b</p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<a href="https://example.com">Example</a>\u200b</p>'
     ));
 
   test('should match baseline', () =>
@@ -42,7 +42,7 @@ describe('When passing "wrapZeroWidthSpace" option with true and "asButton" opti
 
   test('should match snapshot', () =>
     expect(serializeDocumentFragmentIntoString(actual)).toBe(
-      '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<button type="button" value="https://example.com">Example</button>\u200b</p>\n'
+      '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<button type="button" value="https://example.com">Example</button>\u200b</p>'
     ));
 
   test('should match baseline', () =>

--- a/packages/bundle/src/markdown/private/betterLinkDocumentMod.wrapZeroWidthSpace.spec.ts
+++ b/packages/bundle/src/markdown/private/betterLinkDocumentMod.wrapZeroWidthSpace.spec.ts
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import MarkdownIt from 'markdown-it';
 import betterLink from '../markdownItPlugins/betterLink';
 import betterLinkDocumentMod, { type BetterLinkDocumentModDecoration } from './betterLinkDocumentMod';
@@ -9,43 +12,43 @@ const BASE_MARKDOWN = '[Example](https://example.com)';
 const BASE_HTML = new MarkdownIt().render(BASE_MARKDOWN);
 
 describe('When passing "wrapZeroWidthSpace" option with true', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { wrapZeroWidthSpace: true };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<a href="https://example.com">Example</a>\u200b</p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });
 
 describe('When passing "wrapZeroWidthSpace" option with true and "asButton" option with true', () => {
-  let actual: Document;
+  let actual: DocumentFragment;
   const decoration: BetterLinkDocumentModDecoration = { asButton: true, wrapZeroWidthSpace: true };
 
   beforeEach(() => {
-    actual = betterLinkDocumentMod(parseDocumentFromString(BASE_HTML), () => decoration);
+    actual = betterLinkDocumentMod(parseDocumentFragmentFromString(BASE_HTML), () => decoration);
   });
 
   test('should match snapshot', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
       '<p xmlns="http://www.w3.org/1999/xhtml">\u200b<button type="button" value="https://example.com">Example</button>\u200b</p>\n'
     ));
 
   test('should match baseline', () =>
-    expect(serializeDocumentIntoString(actual)).toBe(
-      serializeDocumentIntoString(
-        parseDocumentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
+    expect(serializeDocumentFragmentIntoString(actual)).toBe(
+      serializeDocumentFragmentIntoString(
+        parseDocumentFragmentFromString(new MarkdownIt().use(betterLink, () => decoration).render(BASE_MARKDOWN))
       )
     ));
 });

--- a/packages/bundle/src/markdown/renderMarkdown.ts
+++ b/packages/bundle/src/markdown/renderMarkdown.ts
@@ -2,7 +2,10 @@ import { onErrorResumeNext } from 'botframework-webchat-core';
 import MarkdownIt from 'markdown-it';
 import sanitizeHTML from 'sanitize-html';
 
-import { parseDocumentFromString, serializeDocumentIntoString } from 'botframework-webchat-component/internal';
+import {
+  parseDocumentFragmentFromString,
+  serializeDocumentFragmentIntoString
+} from 'botframework-webchat-component/internal';
 import ariaLabel, { post as ariaLabelPost, pre as ariaLabelPre } from './markdownItPlugins/ariaLabel';
 import { pre as respectCRLFPre } from './markdownItPlugins/respectCRLF';
 import betterLinkDocumentMod, { BetterLinkDocumentModDecoration } from './private/betterLinkDocumentMod';
@@ -148,11 +151,11 @@ export default function render(
   //       Particularly, apply them at `useRenderMarkdownAsHTML` instead of inside the default `renderMarkdown`.
   //       If web devs want to bring their own Markdown engine, they don't need to rebuild "better link" and sanitization themselves.
 
-  const documentAfterMarkdown = parseDocumentFromString(htmlAfterMarkdown);
+  const documentFragmentAfterMarkdown = parseDocumentFragmentFromString(htmlAfterMarkdown);
 
-  betterLinkDocumentMod(documentAfterMarkdown, decorate);
+  betterLinkDocumentMod(documentFragmentAfterMarkdown, decorate);
 
-  const htmlAfterBetterLink = serializeDocumentIntoString(documentAfterMarkdown);
+  const htmlAfterBetterLink = serializeDocumentFragmentIntoString(documentFragmentAfterMarkdown);
 
   const htmlAfterSanitization = sanitizeHTML(htmlAfterBetterLink, SANITIZE_HTML_OPTIONS);
 

--- a/packages/component/src/Utils/parseDocumentFragmentFromString.ts
+++ b/packages/component/src/Utils/parseDocumentFragmentFromString.ts
@@ -1,8 +1,9 @@
 export default function parseDocumentFragmentFromString(html: string): DocumentFragment {
   const parser = new DOMParser();
-  const fragment = new DocumentFragment();
+  const parsedDocument = parser.parseFromString(html, 'text/html');
+  const fragment = parsedDocument.createDocumentFragment();
 
-  fragment.append(...parser.parseFromString(html, 'text/html').body.childNodes);
+  fragment.append(...parsedDocument.body.childNodes);
 
   return fragment;
 }

--- a/packages/component/src/Utils/parseDocumentFragmentFromString.ts
+++ b/packages/component/src/Utils/parseDocumentFragmentFromString.ts
@@ -1,0 +1,8 @@
+export default function parseDocumentFragmentFromString(html: string): DocumentFragment {
+  const parser = new DOMParser();
+  const fragment = new DocumentFragment();
+
+  fragment.append(...parser.parseFromString(html, 'text/html').body.childNodes);
+
+  return fragment;
+}

--- a/packages/component/src/Utils/parseDocumentFromString.ts
+++ b/packages/component/src/Utils/parseDocumentFromString.ts
@@ -1,5 +1,0 @@
-export default function parseDocumentFromString(html: string): Document {
-  const parser = new DOMParser();
-
-  return parser.parseFromString(html, 'text/html');
-}

--- a/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
+++ b/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
@@ -6,5 +6,5 @@ export default function serializeDocumentFragmentIntoString(documentFragment: Do
     elementHTML.push(serializer.serializeToString(element));
   }
 
-  return `${elementHTML.join('\n')}\n`;
+  return `${elementHTML.join('\n')}\n`.replace(/\n{2,}/gu, '\n');
 }

--- a/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
+++ b/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
@@ -1,10 +1,3 @@
 export default function serializeDocumentFragmentIntoString(documentFragment: DocumentFragment): string {
-  const serializer = new XMLSerializer();
-  const elementHTML: string[] = [];
-
-  for (const element of documentFragment.childNodes) {
-    elementHTML.push(serializer.serializeToString(element));
-  }
-
-  return `${elementHTML.join('\n')}\n`.replace(/\n{2,}/gu, '\n');
+  return new XMLSerializer().serializeToString(documentFragment).trim();
 }

--- a/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
+++ b/packages/component/src/Utils/serializeDocumentFragmentIntoString.ts
@@ -1,8 +1,8 @@
-export default function serializeDocumentIntoString(document: Document): string {
+export default function serializeDocumentFragmentIntoString(documentFragment: DocumentFragment): string {
   const serializer = new XMLSerializer();
   const elementHTML: string[] = [];
 
-  for (const element of document.body.childNodes) {
+  for (const element of documentFragment.childNodes) {
     elementHTML.push(serializer.serializeToString(element));
   }
 

--- a/packages/component/src/Utils/serializeDocumentIntoString.ts
+++ b/packages/component/src/Utils/serializeDocumentIntoString.ts
@@ -2,7 +2,7 @@ export default function serializeDocumentIntoString(document: Document): string 
   const serializer = new XMLSerializer();
   const elementHTML: string[] = [];
 
-  for (const element of document.body.children) {
+  for (const element of document.body.childNodes) {
     elementHTML.push(serializer.serializeToString(element));
   }
 

--- a/packages/component/src/hooks/useRenderMarkdownAsHTML.ts
+++ b/packages/component/src/hooks/useRenderMarkdownAsHTML.ts
@@ -53,7 +53,7 @@ export default function useRenderMarkdownAsHTML(
 
         containerClassName && rootElement.classList.add(...containerClassName.split(' ').filter(Boolean));
 
-        rootElement.append(...documentAfterSanitization.body.children);
+        rootElement.append(...documentAfterSanitization.body.childNodes);
         documentAfterSanitization.body.append(rootElement);
 
         return serializeDocumentIntoString(documentAfterSanitization);

--- a/packages/component/src/hooks/useRenderMarkdownAsHTML.ts
+++ b/packages/component/src/hooks/useRenderMarkdownAsHTML.ts
@@ -2,8 +2,8 @@ import { cx } from '@emotion/css';
 import { hooks, StrictStyleOptions } from 'botframework-webchat-api';
 import { useMemo } from 'react';
 
-import parseDocumentFromString from '../Utils/parseDocumentFromString';
-import serializeDocumentIntoString from '../Utils/serializeDocumentIntoString';
+import parseDocumentFragmentFromString from '../Utils/parseDocumentFragmentFromString';
+import serializeDocumentFragmentIntoString from '../Utils/serializeDocumentFragmentIntoString';
 import useWebChatUIContext from './internal/useWebChatUIContext';
 import useStyleSet from './useStyleSet';
 
@@ -47,16 +47,16 @@ export default function useRenderMarkdownAsHTML(
       (markdown => {
         const htmlAfterSanitization = renderMarkdown(markdown, styleOptions, { containerClassName, externalLinkAlt });
 
-        const documentAfterSanitization = parseDocumentFromString(htmlAfterSanitization);
+        const documentFragmentAfterSanitization = parseDocumentFragmentFromString(htmlAfterSanitization);
 
-        const rootElement = documentAfterSanitization.createElement('div');
+        const rootElement = document.createElement('div');
 
         containerClassName && rootElement.classList.add(...containerClassName.split(' ').filter(Boolean));
 
-        rootElement.append(...documentAfterSanitization.body.childNodes);
-        documentAfterSanitization.body.append(rootElement);
+        rootElement.append(...documentFragmentAfterSanitization.childNodes);
+        documentFragmentAfterSanitization.append(rootElement);
 
-        return serializeDocumentIntoString(documentAfterSanitization);
+        return serializeDocumentFragmentIntoString(documentFragmentAfterSanitization);
       }),
     [containerClassName, externalLinkAlt, renderMarkdown, styleOptions]
   );

--- a/packages/component/src/internal.ts
+++ b/packages/component/src/internal.ts
@@ -1,6 +1,6 @@
-import parseDocumentFromString from './Utils/parseDocumentFromString';
-import serializeDocumentIntoString from './Utils/serializeDocumentIntoString';
-import { useLiveRegion } from './providers/LiveRegionTwin/index';
+import parseDocumentFragmentFromString from './Utils/parseDocumentFragmentFromString';
+import serializeDocumentFragmentIntoString from './Utils/serializeDocumentFragmentIntoString';
 import useInjectStyles from './hooks/internal/useInjectStyles';
+import { useLiveRegion } from './providers/LiveRegionTwin/index';
 
-export { parseDocumentFromString, serializeDocumentIntoString, useInjectStyles, useLiveRegion };
+export { parseDocumentFragmentFromString, serializeDocumentFragmentIntoString, useInjectStyles, useLiveRegion };


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5319.

## Changelog Entry

### Fixed

-  Fixes [#5319](https://github.com/microsoft/BotFramework-WebChat/issues/5319). Some Markdown text are not rendered after HTML tags, in PR [#5320](https://github.com/microsoft/BotFramework-WebChat/pull/5320), by [@compulim](https://github.com/compulim)

## Description

Our HTML parsing and serialization logic only handle `.children` but not `.childNodes`. Thus, it is omitting text nodes.

When dealing with certain types of Markdown, the text may not be wrapped in `<p>`. For example,

```md
Line 1

<br />
Line 2
```

Will be converted to HTML and "Line 2" is not wrapped in `<p>`:

```html
<p>Line 1</p><br />Line 2
```

## Specific Changes

- Updates `serializeDocumentIntoString` and `useRenderMarkdownAsHTML` to handle text nodes

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
