### PR TITLE
Fix tsup for Webpack 4

### DIFF
--- a/packages/api/decorator.js
+++ b/packages/api/decorator.js
@@ -1,3 +1,3 @@
 // This is required for Webpack 4 which does not support named exports.
 // eslint-disable-next-line no-undef
-module.exports = require('./dist/botframework-webchat-api.decorator');
+module.exports = require('./dist/botframework-webchat-api.decorator.js');

--- a/packages/api/internal.js
+++ b/packages/api/internal.js
@@ -1,3 +1,3 @@
 // This is required for Webpack 4 which does not support named exports.
 // eslint-disable-next-line no-undef
-module.exports = require('./dist/botframework-webchat-api.internal');
+module.exports = require('./dist/botframework-webchat-api.internal.js');

--- a/packages/api/tsup.config.ts
+++ b/packages/api/tsup.config.ts
@@ -1,13 +1,24 @@
 import { defineConfig } from 'tsup';
 import baseConfig from '../../tsup.base.config';
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-webchat-api': './src/index.ts',
     'botframework-webchat-api.internal': './src/internal.ts',
     'botframework-webchat-api.decorator': './src/decorator/index.ts'
+  }
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm',
+    noExternal: ['globalize']
   },
-  noExternal: ['globalize'],
-  format: ['esm', 'cjs']
-});
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/base/tsup.config.ts
+++ b/packages/base/tsup.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from 'tsup';
 import baseConfig from '../../tsup.base.config';
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-webchat-base': './src/index.ts',
     'botframework-webchat-base.utils': './src/utils/index.ts'
+  }
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
   },
-  format: ['esm', 'cjs']
-});
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/base/utils.js
+++ b/packages/base/utils.js
@@ -1,3 +1,3 @@
 // This is required for Webpack 4 which does not support named exports.
 // eslint-disable-next-line no-undef
-module.exports = require('./dist/botframework-webchat-base.utils');
+module.exports = require('./dist/botframework-webchat-base.utils.js');

--- a/packages/bundle/tsup.config.ts
+++ b/packages/bundle/tsup.config.ts
@@ -13,7 +13,7 @@ const resolveCognitiveServicesToES2015 = {
   }
 };
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-webchat': './src/index.ts',
@@ -34,6 +34,17 @@ export default defineConfig({
     'memoize-one',
     'microsoft-cognitiveservices-speech-sdk',
     'web-speech-cognitive-services'
-  ],
-  format: ['esm', 'cjs']
-});
+  ]
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
+  },
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/component/decorator.js
+++ b/packages/component/decorator.js
@@ -1,3 +1,3 @@
 // This is required for Webpack 4 which does not support named exports.
 // eslint-disable-next-line no-undef
-module.exports = require('./lib/decorator/index');
+module.exports = require('./dist/botframework-webchat-component.decorator.js');

--- a/packages/component/internal.js
+++ b/packages/component/internal.js
@@ -1,3 +1,3 @@
 // This is required for Webpack 4 which does not support named exports.
 // eslint-disable-next-line no-undef
-module.exports = require('./lib/internal');
+module.exports = require('./dist/botframework-webchat-component.internal.js');

--- a/packages/component/tsup.config.ts
+++ b/packages/component/tsup.config.ts
@@ -1,10 +1,10 @@
+import { injectCSSPlugin } from 'botframework-webchat-styles/build';
 import { defineConfig } from 'tsup';
 import baseConfig from '../../tsup.base.config';
 import { componentStyleContent as componentStyleContentPlaceholder } from './src/Styles/createStyles';
 import { decoratorStyleContent as decoratorStyleContentPlaceholder } from './src/decorator/private/createStyles';
-import { injectCSSPlugin } from 'botframework-webchat-styles/build';
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   loader: {
     ...baseConfig.loader,
@@ -18,6 +18,17 @@ export default defineConfig({
     'botframework-webchat-component': './src/index.ts',
     'botframework-webchat-component.internal': './src/internal.ts',
     'botframework-webchat-component.decorator': './src/decorator/index.ts'
+  }
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
   },
-  format: ['esm', 'cjs']
-});
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,10 +1,21 @@
 import { defineConfig } from 'tsup';
 import baseConfig from '../../tsup.base.config';
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-webchat-core': './src/index.ts'
+  }
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
   },
-  format: ['esm', 'cjs']
-});
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/directlinespeech/tsup.config.ts
+++ b/packages/directlinespeech/tsup.config.ts
@@ -13,7 +13,7 @@ const resolveCognitiveServicesToES2015 = {
   }
 };
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-directlinespeech-sdk': './src/index.js'
@@ -29,4 +29,16 @@ export default defineConfig({
   esbuildPlugins: [resolveCognitiveServicesToES2015],
   // We need to internalize event-target-shim because it appear as transient packages with a different version.
   noExternal: ['event-target-shim']
-});
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
+  },
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/packages/fluent-theme/tsup.config.ts
+++ b/packages/fluent-theme/tsup.config.ts
@@ -44,7 +44,8 @@ export default defineConfig([
       '.css': 'local-css'
     },
     esbuildPlugins: [...(baseConfig.esbuildPlugins || []), injectCSSPlugin({ stylesPlaceholder: fluentStyleContentPlaceholder })],
-    format: ['cjs']
+    format: ['cjs'],
+    target: [...baseConfig.target, 'es2019']
   },
   {
     ...baseConfig,

--- a/packages/styles/tsup.config.ts
+++ b/packages/styles/tsup.config.ts
@@ -1,12 +1,23 @@
 import { defineConfig } from 'tsup';
 import baseConfig from '../../tsup.base.config';
 
-export default defineConfig({
+const config: typeof baseConfig = {
   ...baseConfig,
   entry: {
     'botframework-webchat-styles': './src/index.ts',
     'botframework-webchat-styles.build': './src/build/index.ts',
     'botframework-webchat-styles.react': './src/react/index.ts'
+  }
+};
+
+export default defineConfig([
+  {
+    ...config,
+    format: 'esm'
   },
-  format: ['esm', 'cjs']
-});
+  {
+    ...config,
+    format: 'cjs',
+    target: [...config.target, 'es2019']
+  }
+]);

--- a/tsup.base.config.ts
+++ b/tsup.base.config.ts
@@ -1,11 +1,13 @@
-import { defineConfig, type Options } from 'tsup';
+import { type Options } from 'tsup';
 import { babelPlugin, defaultPredicate, type Predicate } from './esbuildBabelPluginIstanbul';
+
+type Target = Exclude<Options['target'], Array<unknown> | undefined>;
 
 const env = process.env.NODE_ENV || 'development';
 const { npm_package_version } = process.env;
 const istanbulPredicate: Predicate = args => defaultPredicate(args) && !/\.worker\.[cm]?[jt]s$/u.test(args.path);
 
-export default defineConfig({
+const baseConfig: Options & { target: Target[] } = {
   dts: true,
   env: {
     build_tool: 'tsup',
@@ -52,5 +54,7 @@ export default defineConfig({
   minify: env === 'production',
   platform: 'browser',
   sourcemap: true,
-  target: ['chrome100', 'firefox100', 'safari15']
-}) as Options;
+  target: ['chrome100', 'firefox100', 'safari15'] satisfies Target[]
+};
+
+export default baseConfig;


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description

There are some limitations on vanilla Webpack 4 without `babel-loader`:

- Cannot load ESM and it imports CJS
   - We need `noExternal: 'globalize'` only for ESM
   - We don't need for CJS as it won't ESM -> CJS
- Webpack 4 does not understand ES2020, need to target ES2019
   - It does not understand `??` operator
- No named imports, requires barrel file for interoperability
   - We made some mistakes in our barrel file
   - It need to point to `.js`, otherwise, Webpack 4 may point to `.mjs` which will require Babel

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

<!-- Please list the changes in a concise manner. -->

## -

-

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] I have added tests and executed them locally
-  [ ] I have updated `CHANGELOG.md`
-  [ ] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
