### PR TITLE
Bundle ShikiJS for Webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 -  Fixes [#5319](https://github.com/microsoft/BotFramework-WebChat/issues/5319). Some Markdown text are not rendered after HTML tags, in PR [#5320](https://github.com/microsoft/BotFramework-WebChat/pull/5320), by [@compulim](https://github.com/compulim)
 -  Fixes [#5323](https://github.com/microsoft/BotFramework-WebChat/issues/5323). Removed unused CSS class from carousel component, eliminating unintended styling, in PR [#5325](https://github.com/microsoft/BotFramework-WebChat/pull/5325), by [@OEvgeny](https://github.com/OEvgeny)
 -  Resolved CSS class name conflicts between component and fluent packages to prevent styling issues, in PR [#5326](https://github.com/microsoft/BotFramework-WebChat/pull/5326), in PR [#5327](https://github.com/microsoft/BotFramework-WebChat/pull/5327), by [@OEvgeny](https://github.com/OEvgeny)
+-  Fixed [#5350](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5350). Bundled `shiki` in component package, in PR [#5349](https://github.com/microsoft/BotFramework-WebChat/pull5349), by [@compulim](https://github.com/compulim)
 
 # Removed
 

--- a/packages/component/src/Attachment/Text/private/shiki.ts
+++ b/packages/component/src/Attachment/Text/private/shiki.ts
@@ -1,14 +1,14 @@
 // `shiki/core` entry does not include any themes or languages or the wasm binary.
-import { createHighlighterCore, type ThemeRegistrationRaw } from 'shiki/core';
-import { createJavaScriptRegexEngine } from 'shiki/engine-javascript.mjs';
+import { createHighlighterCore, type ThemeRegistrationRaw } from 'shiki/dist/core.mjs';
+import { createJavaScriptRegexEngine } from 'shiki/dist/engine-javascript.mjs';
 
 // directly import the theme and language modules, only the ones you imported will be bundled.
-import themeGitHubDark from 'shiki/themes/github-dark-default.mjs';
-import themeGitHubLight from 'shiki/themes/github-light-default.mjs';
+import themeGitHubDark from 'shiki/dist/themes/github-dark-default.mjs';
+import themeGitHubLight from 'shiki/dist/themes/github-light-default.mjs';
 
-import languageJavaScript from 'shiki/langs/js.mjs';
-import languagePython from 'shiki/langs/py.mjs';
-import languageTypeScript from 'shiki/langs/ts.mjs';
+import languageJavaScript from 'shiki/dist/langs/js.mjs';
+import languagePython from 'shiki/dist/langs/py.mjs';
+import languageTypeScript from 'shiki/dist/langs/ts.mjs';
 
 function addjustTheme(theme: ThemeRegistrationRaw): ThemeRegistrationRaw {
   return {

--- a/packages/component/src/Attachment/Text/private/shiki.ts
+++ b/packages/component/src/Attachment/Text/private/shiki.ts
@@ -1,14 +1,14 @@
 // `shiki/core` entry does not include any themes or languages or the wasm binary.
-import { createHighlighterCore, type ThemeRegistrationRaw } from 'shiki/dist/core.mjs';
-import { createJavaScriptRegexEngine } from 'shiki/dist/engine-javascript.mjs';
+import { createHighlighterCore, type ThemeRegistrationRaw } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine-javascript.mjs';
 
 // directly import the theme and language modules, only the ones you imported will be bundled.
-import themeGitHubDark from 'shiki/dist/themes/github-dark-default.mjs';
-import themeGitHubLight from 'shiki/dist/themes/github-light-default.mjs';
+import themeGitHubDark from 'shiki/themes/github-dark-default.mjs';
+import themeGitHubLight from 'shiki/themes/github-light-default.mjs';
 
-import languageJavaScript from 'shiki/dist/langs/js.mjs';
-import languagePython from 'shiki/dist/langs/py.mjs';
-import languageTypeScript from 'shiki/dist/langs/ts.mjs';
+import languageJavaScript from 'shiki/langs/js.mjs';
+import languagePython from 'shiki/langs/py.mjs';
+import languageTypeScript from 'shiki/langs/ts.mjs';
 
 function addjustTheme(theme: ThemeRegistrationRaw): ThemeRegistrationRaw {
   return {

--- a/packages/component/tsup.config.ts
+++ b/packages/component/tsup.config.ts
@@ -6,19 +6,24 @@ import { decoratorStyleContent as decoratorStyleContentPlaceholder } from './src
 
 const config: typeof baseConfig = {
   ...baseConfig,
-  loader: {
-    ...baseConfig.loader,
-    '.css': 'local-css'
+  entry: {
+    'botframework-webchat-component': './src/index.ts',
+    'botframework-webchat-component.internal': './src/internal.ts',
+    'botframework-webchat-component.decorator': './src/decorator/index.ts'
   },
   esbuildPlugins: [
     injectCSSPlugin({ stylesPlaceholder: componentStyleContentPlaceholder }),
     injectCSSPlugin({ stylesPlaceholder: decoratorStyleContentPlaceholder })
   ],
-  entry: {
-    'botframework-webchat-component': './src/index.ts',
-    'botframework-webchat-component.internal': './src/internal.ts',
-    'botframework-webchat-component.decorator': './src/decorator/index.ts'
-  }
+  loader: {
+    ...baseConfig.loader,
+    '.css': 'local-css'
+  },
+  noExternal: [
+    // Belows are the dependency chain related to "regex" where it is named export-only and does not work on Webpack 4/PPUX (CJS cannot import named export).
+    // Webpack 4: "Can't import the named export 'rewrite' from non EcmaScript module (only default export is available)"
+    'shiki', // shiki -> @shikijs/core -> @shikijs/engine-javascript -> regex
+  ]
 };
 
 export default defineConfig([


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixed #5350.

## Changelog Entry

### Fixed

-  Fixed [#5350](https://github.com/microsoft/BotFramework-WebChat/issues/pull/5350). Bundled `shiki` in component package, in PR [#5349](https://github.com/microsoft/BotFramework-WebChat/pull5349), by [@compulim](https://github.com/compulim) 

## Description

`regex` only has named export. However, Webpack 4 cannot import named export in CommonJS mode.

We need to temporarily bundle `shiki`, `@shikijs/*`, `oniguruma-to-js` and `regex` in `botframework-webchat-component`.

It is okay to keep named import in `src/Attachment/Text/private/shiki.ts` as we will be bundling code directly.

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

- Bundle `shiki` and its dependency chain in `botframework-webchat-component` by marking `shiki` as `noExternal`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
