### PR TITLE
Fix: dropzone doesn't receive drop event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 -  Fixed math parsing that could cause Web Chat to hang when processing certain LaTeX expressions, in PR [#5377](https://github.com/microsoft/BotFramework-WebChat/pull/5377), by [@OEvgeny](https://github.com/OEvgeny)
 -  Fixed long math formula should be scrollable, in PR [#5380](https://github.com/microsoft/BotFramework-WebChat/pull/5380), by [@compulim](https://github.com/compulim)
 -  Fixed [#4948](https://github.com/microsoft/BotFramework-WebChat/issues/4948). Microphone should stop after initial silence, in PR [#5385](https://github.com/microsoft/BotFramework-WebChat/pull/5385)
--  Fixed [#5390](https://github.com/microsoft/BotFramework-WebChat/issues/5390). Fixed drop zone remaining visible when file is dropped outside of the zone, in PR [#5394](https://github.com/microsoft/BotFramework-WebChat/pull/5394), by [@OEvgeny](https://github.com/OEvgeny)
+-  Fixed [#5390](https://github.com/microsoft/BotFramework-WebChat/issues/5390). Fixed drop zone remaining visible when file is dropped outside of the zone, in PR [#5394](https://github.com/microsoft/BotFramework-WebChat/pull/5394), in PR [#5415](https://github.com/microsoft/BotFramework-WebChat/pull/5415), by [@OEvgeny](https://github.com/OEvgeny)
 
 # Removed
 

--- a/__tests__/html/fluentTheme/dragAndDrop.upload.html
+++ b/__tests__/html/fluentTheme/dragAndDrop.upload.html
@@ -95,6 +95,18 @@
         // THEN: Should render the drop zone.
         await host.snapshot();
 
+        // WHEN: Dragging a file over the document.
+        const dragOverDocumentEvent = new DragEvent('dragover', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer
+        });
+
+        document.dispatchEvent(dragOverDocumentEvent);
+        
+        // THEN: The default browser behavior should be prevented.
+        await pageConditions.became('DragOver event preventDefault is called', () => dragOverDocumentEvent.defaultPrevented, 1000);
+
         // WHEN: Dropping out of the drop zone.
         const dropEvent1 = new DragEvent('drop', {
           bubbles: true,

--- a/packages/fluent-theme/src/components/dropZone/DropZone.tsx
+++ b/packages/fluent-theme/src/components/dropZone/DropZone.tsx
@@ -6,8 +6,8 @@ import React, {
   useEffect,
   useRef,
   useState,
-  type DragEventHandler,
-  type DragEvent as ReactDragEvent
+  type DragEvent as ReactDragEvent,
+  type DragEventHandler
 } from 'react';
 import { useRefFrom } from 'use-ref-from';
 
@@ -19,7 +19,13 @@ import { useStyles } from '../../styles';
 const { useLocalizer } = hooks;
 
 const handleDragOver = (event: ReactDragEvent<unknown> | DragEvent) => {
-  // This is for preventing the browser from opening the dropped file in a new tab.
+  // Prevent default dragover behavior to enable drop event triggering.
+  // Browsers require this to fire subsequent drop events - without it,
+  // they would handle the drop directly (e.g., open files in new tabs).
+  // This is needed regardless of whether we prevent default drop behavior,
+  // as it ensures our dropzone receives the drop event first. If we allow
+  // default drop handling (by not calling preventDefault there), the browser
+  // will still process the drop after our event handlers complete.
   event.preventDefault();
 };
 
@@ -86,17 +92,17 @@ const DropZone = (props: { readonly onFilesAdded: (files: File[]) => void }) => 
       }
     };
 
+    document.addEventListener('dragend', handleDragEnd);
     document.addEventListener('dragenter', handleDragEnter);
     document.addEventListener('dragleave', handleDragLeave);
-    document.addEventListener('dragend', handleDragEnd);
     document.addEventListener('drop', handleDocumentDrop);
 
     return () => {
+      document.removeEventListener('dragend', handleDragEnd);
       document.removeEventListener('dragenter', handleDragEnter);
       document.removeEventListener('dragleave', handleDragLeave);
-      document.removeEventListener('dragend', handleDragEnd);
-      document.removeEventListener('drop', handleDocumentDrop);
       document.removeEventListener('dragover', handleDragOver);
+      document.removeEventListener('drop', handleDocumentDrop);
     };
   }, [setDropZoneState]);
 

--- a/packages/fluent-theme/src/components/dropZone/DropZone.tsx
+++ b/packages/fluent-theme/src/components/dropZone/DropZone.tsx
@@ -1,6 +1,14 @@
 import { hooks } from 'botframework-webchat-component';
 import cx from 'classnames';
-import React, { memo, useCallback, useEffect, useRef, useState, type DragEventHandler } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEventHandler,
+  type DragEvent as ReactDragEvent
+} from 'react';
 import { useRefFrom } from 'use-ref-from';
 
 import { AddDocumentIcon } from '../../icons';
@@ -10,7 +18,7 @@ import { useStyles } from '../../styles';
 
 const { useLocalizer } = hooks;
 
-const handleDragOver: DragEventHandler<HTMLDivElement> = event => {
+const handleDragOver = (event: ReactDragEvent<unknown> | DragEvent) => {
   // This is for preventing the browser from opening the dropped file in a new tab.
   event.preventDefault();
 };
@@ -47,6 +55,8 @@ const DropZone = (props: { readonly onFilesAdded: (files: File[]) => void }) => 
     let entranceCounter = 0;
 
     const handleDragEnter = (event: DragEvent) => {
+      document.addEventListener('dragover', handleDragOver);
+
       entranceCounter++;
 
       if (isFilesTransferEvent(event)) {
@@ -63,7 +73,10 @@ const DropZone = (props: { readonly onFilesAdded: (files: File[]) => void }) => 
     const handleDragLeave = () => --entranceCounter <= 0 && setDropZoneState(false);
 
     const handleDragEnd = () => {
+      document.removeEventListener('dragover', handleDragOver);
+
       entranceCounter = 0;
+
       setDropZoneState(false);
     };
 
@@ -83,6 +96,7 @@ const DropZone = (props: { readonly onFilesAdded: (files: File[]) => void }) => 
       document.removeEventListener('dragleave', handleDragLeave);
       document.removeEventListener('dragend', handleDragEnd);
       document.removeEventListener('drop', handleDocumentDrop);
+      document.removeEventListener('dragover', handleDragOver);
     };
   }, [setDropZoneState]);
 


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog

-  Fixed [#5390](https://github.com/microsoft/BotFramework-WebChat/issues/5390). Fixed drop zone remaining visible when file is dropped outside of the zone, in PR [#5394](https://github.com/microsoft/BotFramework-WebChat/pull/5394), in PR [#5415](https://github.com/microsoft/BotFramework-WebChat/pull/5415), by [@OEvgeny](https://github.com/OEvgeny)

## Description

While the previous fix (#5394) addressed the visibility issue in certain cases, this PR further improves the drop zone behavior by ensuring it correctly receives outside drop events and handles them appropriately.

## Design

1. Added dragover event listener which prevents default browser behavior only when dragged inside the window to prevent unnecessary global event handlers
2. Added detailed documentation explaining the relationship between dragover and drop events

## Specific Changes

- Added dynamic dragover event listener management
- Enhanced type definition for dragover event handler to support both React and native events
- Improved comment explaining browser drag and drop behavior
- Reorder listeners

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] Internationalization reviewed (strings, unit formatting)
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] Security reviewed (no data URIs, check for nonce leak)
-  [x] Tests reviewed (coverage, legitimacy)
