### PR TITLE
Design proposal: Starter Prompts

### DIFF
--- a/docs/STARTER_PROMPTS.md
+++ b/docs/STARTER_PROMPTS.md
@@ -1,0 +1,53 @@
+# Starter Prompts
+
+Starter prompts are a special message that would send during greeting. It can consist of:
+
+-  An optional image
+-  An optional name of the bot
+-  An optional description about the bot (supports Markdown)
+-  Up to 6 buttons with predefined message to assist customers to jumpstart the conversation
+   -  An optional icon for each button
+   -  A title for each button (plain text, required)
+   -  The message to send or put in the send box when clicked (plain text, required)
+
+```json
+{
+   "type": "event",
+   "name": "StarterPrompts", // Should we name this "greeting" event? And should it be camelCase, PascalCase, kebab-case?
+   "entities": [
+      {
+         "@context": "https://schema.org",
+         "@id": "",
+         "@type": "Message",
+         "type": "https://schema.org/Message",
+
+         "sender": {
+            "@type": "Person",
+            "description": "I can help you with anything around you. Just let me know.",
+            "image": "https://.../bot.svg", // Could be data URI of an image.
+            "name": "Secretary Bot"
+         },
+         "potentialActions": [
+            {
+               "@type": "SendAction",
+               "image": "https://.../clock.svg", // Could be data URI of an image.
+               "name": "Check time",
+               "object": {
+                  "@type": "Message",
+                  "text": "What time is it now?"
+               }
+            },
+            {
+               "@type": "SendAction",
+               "image": "https://.../cloud.svg", // Could be data URI of an image.
+               "name": "Check weather",
+               "object": {
+                  "@type": "Message",
+                  "text": "Do I need to bring an umbrella?"
+               }
+            }
+         ]
+      }
+   ]
+}
+```


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description

Adding design doc of the "Starter Prompts" feature.

## Design

Starter prompts helps end-users to jumpstart a conversation by providing what the bot could help and a list of canned message that end-user can try out.

## Specific Changes

- Added `docs/STARTER_PROMPTS.md`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
