### PR TITLE
Embed `uuid` package for Webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
       - [`typescript@5.7.3`](https://npmjs.com/package/typescript/)
       - [`webpack-cli@6.0.1`](https://npmjs.com/package/webpack-cli/)
       - [`webpack@5.98.0`](https://npmjs.com/package/webpack/)
+- Fixed [#5446](https://github.com/microsoft/BotFramework-WebChat/issues/5446). Embedded `uuid` so `microsoft-cognitiveservices-speech-sdk` do not need to use dynamic loading, as this could fail in Webpack 4 environment, in PR [#5445](https://github.com/microsoft/BotFramework-WebChat/pull/5445), by [@compulim](https://github.com/compulim)
 
 ### Fixed
 

--- a/packages/bundle/tsup.config.ts
+++ b/packages/bundle/tsup.config.ts
@@ -46,7 +46,11 @@ const config: typeof baseConfig = {
     'web-speech-cognitive-services',
     // Belows are the dependency chain related to "regex" where it is named export-only and does not work on Webpack 4/PPUX (CJS cannot import named export).
     // Webpack 4: "Can't import the named export 'rewrite' from non EcmaScript module (only default export is available)"
-    'shiki' // shiki -> @shikijs/core -> @shikijs/engine-javascript -> regex
+    'shiki', // shiki -> @shikijs/core -> @shikijs/engine-javascript -> regex
+    // Issues related to Webpack 4 when it tries to statically analyze dependencies.
+    // The way `microsoft-cognitiveservices-speech-sdk` imported the `uuid` package (in their `Guid.js`) is causing esbuild/tsup to proxy require() into __require() for dynamic loading.
+    // Webpack 4 cannot statically analyze the code and failed.
+    'uuid'
   ]
 };
 

--- a/packages/bundle/tsup.config.ts
+++ b/packages/bundle/tsup.config.ts
@@ -49,7 +49,7 @@ const config: typeof baseConfig = {
     'shiki', // shiki -> @shikijs/core -> @shikijs/engine-javascript -> regex
     // Issues related to Webpack 4 when it tries to statically analyze dependencies.
     // The way `microsoft-cognitiveservices-speech-sdk` imported the `uuid` package (in their `Guid.js`) is causing esbuild/tsup to proxy require() into __require() for dynamic loading.
-    // Webpack 4 cannot statically analyze the code and failed.
+    // Webpack 4 cannot statically analyze the code and failed with error "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted".
     'uuid'
   ]
 };


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5446.

## Changelog Entry

### Changed

- Fixed [#5446](https://github.com/microsoft/BotFramework-WebChat/issues/5446). Embedded `uuid` so `microsoft-cognitiveservices-speech-sdk` do not need to use dynamic loading, as this could fail in Webpack 4 environment, in PR [#5445](https://github.com/microsoft/BotFramework-WebChat/pull/5445), by [@compulim](https://github.com/compulim)

## Description

Issues related to Webpack 4 when it tries to statically analyze dependencies.

The way `microsoft-cognitiveservices-speech-sdk` imported the `uuid` package (in their `Guid.js`) is causing esbuild/tsup to create a proxy for `require()` for dynamic loading.

![image](https://github.com/user-attachments/assets/bcc2325d-bfba-4df2-9c3b-2569fc0cc33c)

When this `__require()` appears in Web Chat, Webpack 4 will fail to statically analyze dependencies and complain "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted."

We need to embed `uuid` inside Web Chat temporarily for now. We need to add automated test for Webpack 4 later.

## Specific Changes

-  Added `uuid` to `tsup/noExternal`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
