### PR TITLE
Ignore ENTER while in text composition mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - Improved focus management for scroll to end button
 - Fixed [#5439](https://github.com/microsoft/BotFramework-WebChat/issues/5439). Fixed batched livestream activities are not recognized in the same session, in PR [#5440](https://github.com/microsoft/BotFramework-WebChat/pull/5440), by [@compulim](https://github.com/compulim)
 - Fixed [#5452](https://github.com/microsoft/BotFramework-WebChat/issues/5452). With Fluent/Copilot theme, the typing indicator padding should not be squashed, in PR [#5453](https://github.com/microsoft/BotFramework-WebChat/pull/5453), by [@compulim](https://github.com/compulim)
+- Fixed [#5461](https://github.com/microsoft/BotFramework-WebChat/issues/5461). On macOS and Fluent skinpack applied, using Japanese IME to input some Japanese text should not send them immediately, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX), by [@compulim](https://github.com/compulim)
 
 # Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - Improved focus management for scroll to end button
 - Fixed [#5439](https://github.com/microsoft/BotFramework-WebChat/issues/5439). Fixed batched livestream activities are not recognized in the same session, in PR [#5440](https://github.com/microsoft/BotFramework-WebChat/pull/5440), by [@compulim](https://github.com/compulim)
 - Fixed [#5452](https://github.com/microsoft/BotFramework-WebChat/issues/5452). With Fluent/Copilot theme, the typing indicator padding should not be squashed, in PR [#5453](https://github.com/microsoft/BotFramework-WebChat/pull/5453), by [@compulim](https://github.com/compulim)
-- Fixed [#5461](https://github.com/microsoft/BotFramework-WebChat/issues/5461). On macOS and Fluent skinpack applied, using Japanese IME to input some Japanese text should not send them immediately, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX), by [@compulim](https://github.com/compulim)
+- Fixed [#5461](https://github.com/microsoft/BotFramework-WebChat/issues/5461). On macOS and Fluent skinpack applied, using Japanese IME to input some Japanese text should not send them immediately, in PR [#5462](https://github.com/microsoft/BotFramework-WebChat/pull/5462), by [@compulim](https://github.com/compulim)
 
 # Removed
 

--- a/packages/fluent-theme/src/components/sendBox/TextArea.tsx
+++ b/packages/fluent-theme/src/components/sendBox/TextArea.tsx
@@ -1,6 +1,13 @@
 import { hooks } from 'botframework-webchat-api';
 import cx from 'classnames';
-import React, { forwardRef, Fragment, useCallback, type FormEventHandler, type KeyboardEventHandler } from 'react';
+import React, {
+  forwardRef,
+  Fragment,
+  useCallback,
+  useRef,
+  type FormEventHandler,
+  type KeyboardEventHandler
+} from 'react';
 import { useStyles } from '../../styles';
 import styles from './TextArea.module.css';
 
@@ -30,13 +37,22 @@ const TextArea = forwardRef<
 >((props, ref) => {
   const [uiState] = useUIState();
   const classNames = useStyles(styles);
+  const isInCompositionRef = useRef<boolean>(false);
 
   const disabled = uiState === 'disabled';
+
+  const handleCompositionEnd = useCallback(() => {
+    isInCompositionRef.current = false;
+  }, [isInCompositionRef]);
+
+  const handleCompositionStart = useCallback(() => {
+    isInCompositionRef.current = true;
+  }, [isInCompositionRef]);
 
   const handleKeyDown = useCallback<KeyboardEventHandler<HTMLTextAreaElement>>(event => {
     // Shift+Enter adds a new line
     // Enter requests related form submission
-    if (!event.shiftKey && event.key === 'Enter') {
+    if (!event.shiftKey && event.key === 'Enter' && !isInCompositionRef.current) {
       event.preventDefault();
 
       if ('form' in event.target && event.target.form instanceof HTMLFormElement) {
@@ -84,6 +100,8 @@ const TextArea = forwardRef<
               classNames['sendbox__text-area-shared']
             )}
             data-testid={props['data-testid']}
+            onCompositionEnd={handleCompositionEnd}
+            onCompositionStart={handleCompositionStart}
             onInput={props.onInput}
             onKeyDown={handleKeyDown}
             placeholder={props.placeholder}


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5461.

## Changelog Entry

### Fixed

- Fixed [#5461](https://github.com/microsoft/BotFramework-WebChat/issues/5461). On macOS and Fluent skinpack applied, using Japanese IME to input some Japanese text should not send them immediately, in PR [#5462](https://github.com/microsoft/BotFramework-WebChat/pull/5462), by [@compulim](https://github.com/compulim)

## Description

<kbd>ENTER</kbd> should not send messages if it is in IME text composition mode.

## Design

When browser say they are in text composition mode, it means the IME mini-dialog pops up.

While in text composition mode, <kbd>ENTER</kbd> key should not be handled by the browser.

On Windows, when IME mini-dialog pops up, all keys are filtered and will not send to the browser.

On macOS, keys are not (completely) filtered.

In the send box of our Fluent skin pack, it use a multiline textbox (`<textarea>`) and send on <kbd>ENTER</kbd> (new line on <kbd>SHIFT</kbd> + <kbd>ENTER</kbd>). As macOS did not filter out <kbd>ENTER</kbd>, we mistakenly send out the message.

We could not write tests as the behavior works outside of browser and emulating `compositionstart` event didn't work.

## Specific Changes

- Disable send out the message when <kbd>ENTER</kbd> is pressed during `compositionstart` until `compositionend`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
