### PR TITLE
Clean up middleware signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - If you customized `renderMarkdown` with a custom HTML sanitizer, please move the HTML sanitizer to the new HTML content transformer middleware
 - `useGroupActivities` hook is being deprecated in favor of the `useGroupActivitiesByName` hook. The hook will be removed on or after 2027-05-04
 - `useSuggestedActions()` hook is being deprecated in favor of the `useSuggestedActionsHooks().useSuggestedActions()` hook. The hook will be removed on or after 2027-05-30
+- The following middleware should be created using their respective factory functions:
+   - `activityBorderDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
+   - `activityGroupingDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
+   - `sendBoxMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
+   - `sendBoxToolbarMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
 
 ### Added
 
@@ -329,7 +334,8 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - `useSendMessage` hook is updated to support sending attachments with a message
    - `useSendBoxAttachments` hook is added to get/set attachments in the send box
 - Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb), in PR [#5048](https://github.com/microsoft/BotFramework-WebChat/pull/5048)
-- Added `sendBoxMiddleware` and `sendBoxToolbarMiddleware`, by [@compulim](https://github.com/compulim), in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120)
+- Added `sendBoxMiddleware` and `sendBoxToolbarMiddleware`, by [@compulim](https://github.com/compulim), in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120) and [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
+   - Instead of passing barebone middleware, use the `createSendBoxMiddleware` and `createSendBoxToolbarMiddleware` correspondingly, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
 - (Experimental) Added `botframework-webchat-fluent-theme` package for applying Fluent UI theme to Web Chat, by [@compulim](https://github.com/compulim) and [@OEvgeny](https://github.com/OEvgeny)
    - Initial commit, in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120)
    - Inherits Fluent CSS palette if available, in PR [#5122](https://github.com/microsoft/BotFramework-WebChat/pull/5122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - If you customized `renderMarkdown` with a custom HTML sanitizer, please move the HTML sanitizer to the new HTML content transformer middleware
 - `useGroupActivities` hook is being deprecated in favor of the `useGroupActivitiesByName` hook. The hook will be removed on or after 2027-05-04
 - `useSuggestedActions()` hook is being deprecated in favor of the `useSuggestedActionsHooks().useSuggestedActions()` hook. The hook will be removed on or after 2027-05-30
-- The following middleware should be created using their respective factory functions:
+- The following middleware should be created using their respective factory function:
    - `activityBorderDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
    - `activityGroupingDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
    - `sendBoxMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
@@ -335,7 +335,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
    - `useSendBoxAttachments` hook is added to get/set attachments in the send box
 - Resolves [#5081](https://github.com/microsoft/BotFramework-WebChat/issues/5081). Added `uploadAccept` and `uploadMultiple` style options, by [@ms-jb](https://github.com/ms-jb), in PR [#5048](https://github.com/microsoft/BotFramework-WebChat/pull/5048)
 - Added `sendBoxMiddleware` and `sendBoxToolbarMiddleware`, by [@compulim](https://github.com/compulim), in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120) and [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
-   - Instead of passing barebone middleware, use the `createSendBoxMiddleware` and `createSendBoxToolbarMiddleware` correspondingly, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
+   - Instead of passing barebone middleware, use the `createSendBoxMiddleware()` and `createSendBoxToolbarMiddleware()` factory function correspondingly, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
 - (Experimental) Added `botframework-webchat-fluent-theme` package for applying Fluent UI theme to Web Chat, by [@compulim](https://github.com/compulim) and [@OEvgeny](https://github.com/OEvgeny)
    - Initial commit, in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120)
    - Inherits Fluent CSS palette if available, in PR [#5122](https://github.com/microsoft/BotFramework-WebChat/pull/5122)

--- a/__tests__/html/fluentTheme/withCustomDecorator.html
+++ b/__tests__/html/fluentTheme/withCustomDecorator.html
@@ -28,7 +28,7 @@
           React,
           ReactDOM: { render },
           WebChat: {
-            decorator: { DecoratorComposer },
+            decorator: { createActivityBorderMiddleware, DecoratorComposer },
             FluentThemeProvider,
             ReactWebChat
           }
@@ -43,12 +43,12 @@
         }
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity border' &&
-            (next => request => (request.livestreamingState === 'completing' ? Flair : next(request))),
-          init =>
-            init === 'activity border' &&
-            (next => request => (request.livestreamingState === 'preparing' ? Loader : next(request)))
+          createActivityBorderMiddleware(
+            next => request => (request.livestreamingState === 'completing' ? Flair : next(request))
+          ),
+          createActivityBorderMiddleware(
+            next => request => (request.livestreamingState === 'preparing' ? Loader : next(request))
+          )
         ];
 
         const { directLine, store } = testHelpers.createDirectLineEmulator();

--- a/__tests__/html/sendBoxMiddleware/warnIfInvalid.html
+++ b/__tests__/html/sendBoxMiddleware/warnIfInvalid.html
@@ -18,7 +18,7 @@
         await pageConditions.uiConnected();
 
         // THEN: It should warn about the invalid middleware.
-        await pageConditions.warnMessageLogged('"sendBoxMiddleware" prop is invalid.');
+        await pageConditions.warnMessageLogged('must be an array of function');
 
         // THEN: It should render the default send box.
         await host.snapshot();

--- a/__tests__/html/sendBoxToolbarMiddleware/warnIfInvalid.html
+++ b/__tests__/html/sendBoxToolbarMiddleware/warnIfInvalid.html
@@ -18,7 +18,7 @@
         await pageConditions.uiConnected();
 
         // THEN: It should warn about the invalid middleware.
-        await pageConditions.warnMessageLogged('"sendBoxToolbarMiddleware" prop is invalid.');
+        await pageConditions.warnMessageLogged('must be an array of function');
 
         // THEN: It should render the default send box.
         await host.snapshot();

--- a/__tests__/html2/feedbackForm/behavior.resetByEscapeKey.html
+++ b/__tests__/html2/feedbackForm/behavior.resetByEscapeKey.html
@@ -94,7 +94,9 @@
         // WHEN: Feedback form is opened.
         document.querySelector(`[data-testid="${testIds.sendBoxTextBox}"]`).focus();
         await host.sendShiftTab(3);
-        await host.sendKeys('UP', 'ENTER', 'RIGHT', 'SPACE');
+
+        // WHEN: Select the activity, then press right arrow key to select the dislike button (radio button).
+        await host.sendKeys('UP', 'ENTER', 'RIGHT');
 
         // THEN: The dislike button should be pressed.
         expect(Array.from(pageElements.allByTestId(testIds.feedbackButton)).map(element => element.checked)).toEqual([

--- a/__tests__/html2/feedbackForm/feedback.form.activity.html
+++ b/__tests__/html2/feedbackForm/feedback.form.activity.html
@@ -102,8 +102,6 @@
           1000
         );
 
-        return;
-
         await host.sendKeys('Test feedback');
 
         await host.snapshot('local');

--- a/__tests__/html2/feedbackForm/feedback.form.activity.html
+++ b/__tests__/html2/feedbackForm/feedback.form.activity.html
@@ -93,14 +93,16 @@
         // THEN: Should match snapshot.
         await host.snapshot('local');
 
-        // WHEN: Click on dislike button to re-open feedback form
-        await host.sendKeys('RIGHT', 'SPACE');
+        // WHEN: Press right arrow key to select the dislike button (radio button).
+        await host.sendKeys('RIGHT');
 
         await pageConditions.became(
           'feedback form is open',
           () => document.activeElement === pageElements.byTestId('feedback sendbox'),
           1000
         );
+
+        return;
 
         await host.sendKeys('Test feedback');
 

--- a/__tests__/html2/grouping/customGrouping.html
+++ b/__tests__/html2/grouping/customGrouping.html
@@ -32,7 +32,10 @@
 
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -62,22 +65,20 @@
             : undefined;
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/disableAll.html
+++ b/__tests__/html2/grouping/disableAll.html
@@ -16,7 +16,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -24,22 +27,20 @@
         const { directLine, store } = testHelpers.createDirectLineEmulator({ ponyfill: clock });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/disableSender.html
+++ b/__tests__/html2/grouping/disableSender.html
@@ -16,7 +16,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -24,22 +27,20 @@
         const { directLine, store } = testHelpers.createDirectLineEmulator({ ponyfill: clock });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/disableStatus.html
+++ b/__tests__/html2/grouping/disableStatus.html
@@ -16,7 +16,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -24,22 +27,20 @@
         const { directLine, store } = testHelpers.createDirectLineEmulator({ ponyfill: clock });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/disableStatus.perSender.html
+++ b/__tests__/html2/grouping/disableStatus.perSender.html
@@ -16,7 +16,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -24,22 +27,20 @@
         const { directLine, store } = testHelpers.createDirectLineEmulator({ ponyfill: clock });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/extraneousGroup.html
+++ b/__tests__/html2/grouping/extraneousGroup.html
@@ -28,7 +28,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -50,22 +53,20 @@
         });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/fluentTheme.html
+++ b/__tests__/html2/grouping/fluentTheme.html
@@ -35,7 +35,11 @@
           const {
             React: { createElement },
             ReactDOM: { render },
-            WebChat: { FluentThemeProvider, ReactWebChat }
+            WebChat: {
+              decorator: { createActivityGroupingMiddleware },
+              FluentThemeProvider,
+              ReactWebChat
+            }
           } = window; // Imports in UMD fashion.
 
           const clock = lolex.createClock();
@@ -59,22 +63,20 @@
               : undefined;
 
           const decoratorMiddleware = [
-            init =>
-              init === 'activity grouping' &&
-              (next => request => {
-                const DownstreamComponent = next(request);
+            createActivityGroupingMiddleware(next => request => {
+              const DownstreamComponent = next(request);
 
-                if (request.groupingName) {
-                  return ({ activities, children }) =>
-                    createElement(
-                      'div',
-                      { className: `grouping grouping--${request.groupingName}` },
-                      DownstreamComponent ? createElement(DownstreamComponent, { activities }, children) : children
-                    );
-                }
+              if (request.groupingName) {
+                return ({ activities, children }) =>
+                  createElement(
+                    'div',
+                    { className: `grouping grouping--${request.groupingName}` },
+                    DownstreamComponent ? createElement(DownstreamComponent, { activities }, children) : children
+                  );
+              }
 
-                return DownstreamComponent;
-              })
+              return DownstreamComponent;
+            })
           ];
 
           render(

--- a/__tests__/html2/grouping/groupingBorder.html
+++ b/__tests__/html2/grouping/groupingBorder.html
@@ -16,7 +16,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -24,22 +27,20 @@
         const { directLine, store } = testHelpers.createDirectLineEmulator({ ponyfill: clock });
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/grouping/noSuchGroup.html
+++ b/__tests__/html2/grouping/noSuchGroup.html
@@ -30,7 +30,10 @@
       run(async function () {
         const {
           React: { createElement },
-          WebChat: { renderWebChat }
+          WebChat: {
+            decorator: { createActivityGroupingMiddleware },
+            renderWebChat
+          }
         } = window; // Imports in UMD fashion.
 
         const clock = lolex.createClock();
@@ -41,22 +44,20 @@
         const groupActivitiesMiddleware = () => next => request => ({});
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity grouping' &&
-            (next => request => {
-              const DownstreamComponent = next(request);
+          createActivityGroupingMiddleware(next => request => {
+            const DownstreamComponent = next(request);
 
-              if (request.groupingName) {
-                return ({ activities, children }) =>
-                  createElement(
-                    'div',
-                    { className: `grouping grouping--${request.groupingName}` },
-                    createElement(DownstreamComponent, { activities }, children)
-                  );
-              }
+            if (request.groupingName) {
+              return ({ activities, children }) =>
+                createElement(
+                  'div',
+                  { className: `grouping grouping--${request.groupingName}` },
+                  createElement(DownstreamComponent, { activities }, children)
+                );
+            }
 
-              return DownstreamComponent;
-            })
+            return DownstreamComponent;
+          })
         ];
 
         renderWebChat(

--- a/__tests__/html2/livestream/layout.html
+++ b/__tests__/html2/livestream/layout.html
@@ -33,7 +33,7 @@
           React,
           ReactDOM: { render },
           WebChat: {
-            decorator: { DecoratorComposer },
+            decorator: { createActivityBorderMiddleware, DecoratorComposer },
             FluentThemeProvider,
             ReactWebChat
           }
@@ -52,15 +52,15 @@
         }
 
         const decoratorMiddleware = [
-          init =>
-            init === 'activity border' &&
-            (next => request => (request.livestreamingState === 'completing' ? Flair : next(request))),
-          init =>
-            init === 'activity border' &&
-            (next => request => (request.livestreamingState === 'preparing' ? Loader : next(request))),
-          init =>
-            init === 'activity border' &&
-            (next => request => (request.livestreamingState === 'ongoing' ? FlairOngoing : next(request)))
+          createActivityBorderMiddleware(
+            next => request => (request.livestreamingState === 'completing' ? Flair : next(request))
+          ),
+          createActivityBorderMiddleware(
+            next => request => (request.livestreamingState === 'preparing' ? Loader : next(request))
+          ),
+          createActivityBorderMiddleware(
+            next => request => (request.livestreamingState === 'ongoing' ? FlairOngoing : next(request))
+          )
         ];
 
         const { directLine, store } = testHelpers.createDirectLineEmulator();

--- a/packages/api/src/decorator.ts
+++ b/packages/api/src/decorator.ts
@@ -1,11 +1,7 @@
 // Decorator general
 
 export { default as DecoratorComposer } from './decorator/DecoratorComposer';
-export {
-  type DecoratorMiddleware,
-  type DecoratorMiddlewareInit,
-  type DecoratorMiddlewareTypes
-} from './decorator/types';
+export { activityBorderMiddleware, activityGroupingMiddleware, type DecoratorMiddleware } from './decorator/types';
 
 // ActivityBorderDecorator
 

--- a/packages/api/src/decorator.ts
+++ b/packages/api/src/decorator.ts
@@ -1,12 +1,21 @@
 // Decorator general
 
 export { default as DecoratorComposer } from './decorator/DecoratorComposer';
-export { activityBorderMiddleware, activityGroupingMiddleware, type DecoratorMiddleware } from './decorator/types';
+export { type DecoratorMiddleware } from './decorator/types';
 
 // ActivityBorderDecorator
 
-export { default as ActivityBorderDecorator } from './decorator/ActivityBorder/ActivityBorderDecorator';
+export {
+  default as ActivityBorderDecorator,
+  createActivityBorderMiddleware,
+  type ActivityBorderDecoratorMiddlewareProps,
+  type ActivityBorderDecoratorMiddlewareRequest,
+  type ActivityBorderDecoratorProps
+} from './decorator/ActivityBorder/ActivityBorderDecorator';
 
 // ActivityGroupingDecorator
 
-export { default as ActivityGroupingDecorator } from './decorator/ActivityGrouping/ActivityGroupingDecorator';
+export {
+  default as ActivityGroupingDecorator,
+  createActivityGroupingMiddleware
+} from './decorator/ActivityGrouping/ActivityGroupingDecorator';

--- a/packages/api/src/decorator.ts
+++ b/packages/api/src/decorator.ts
@@ -8,8 +8,6 @@ export { type DecoratorMiddleware } from './decorator/types';
 export {
   default as ActivityBorderDecorator,
   createActivityBorderMiddleware,
-  type ActivityBorderDecoratorMiddlewareProps,
-  type ActivityBorderDecoratorMiddlewareRequest,
   type ActivityBorderDecoratorProps
 } from './decorator/ActivityBorder/ActivityBorderDecorator';
 

--- a/packages/api/src/decorator/ActivityBorder/ActivityBorderDecorator.tsx
+++ b/packages/api/src/decorator/ActivityBorder/ActivityBorderDecorator.tsx
@@ -1,10 +1,10 @@
 import { getActivityLivestreamingMetadata, type WebChatActivity } from 'botframework-webchat-core';
 import React, { memo, useMemo, type ReactNode } from 'react';
+
 import PassthroughFallback from '../private/PassthroughFallback';
 import {
   ActivityBorderDecoratorMiddlewareProxy,
   createActivityBorderMiddleware,
-  type ActivityBorderDecoratorMiddlewareProps,
   type ActivityBorderDecoratorMiddlewareRequest
 } from './private/ActivityBorderDecoratorMiddleware';
 
@@ -25,6 +25,7 @@ function ActivityBorderDecorator({ activity, children }: ActivityBorderDecorator
     const { type } = getActivityLivestreamingMetadata(activity) || {};
 
     return {
+      from: supportedActivityRoles.includes(activity?.from?.role) ? activity?.from?.role : undefined,
       livestreamingState:
         type === 'final activity'
           ? 'completing'
@@ -34,8 +35,7 @@ function ActivityBorderDecorator({ activity, children }: ActivityBorderDecorator
               ? 'ongoing'
               : type === 'contentless'
                 ? undefined // No bubble is shown for "contentless" livestream, should not decorate.
-                : undefined,
-      from: supportedActivityRoles.includes(activity?.from?.role) ? activity?.from?.role : undefined
+                : undefined
     };
   }, [activity]);
 
@@ -47,9 +47,4 @@ function ActivityBorderDecorator({ activity, children }: ActivityBorderDecorator
 }
 
 export default memo(ActivityBorderDecorator);
-export {
-  createActivityBorderMiddleware,
-  type ActivityBorderDecoratorMiddlewareProps,
-  type ActivityBorderDecoratorMiddlewareRequest,
-  type ActivityBorderDecoratorProps
-};
+export { createActivityBorderMiddleware, type ActivityBorderDecoratorProps };

--- a/packages/api/src/decorator/ActivityBorder/ActivityBorderDecorator.tsx
+++ b/packages/api/src/decorator/ActivityBorder/ActivityBorderDecorator.tsx
@@ -3,6 +3,8 @@ import React, { memo, useMemo, type ReactNode } from 'react';
 import PassthroughFallback from '../private/PassthroughFallback';
 import {
   ActivityBorderDecoratorMiddlewareProxy,
+  createActivityBorderMiddleware,
+  type ActivityBorderDecoratorMiddlewareProps,
   type ActivityBorderDecoratorMiddlewareRequest
 } from './private/ActivityBorderDecoratorMiddleware';
 
@@ -45,4 +47,9 @@ function ActivityBorderDecorator({ activity, children }: ActivityBorderDecorator
 }
 
 export default memo(ActivityBorderDecorator);
-export { type ActivityBorderDecoratorProps };
+export {
+  createActivityBorderMiddleware,
+  type ActivityBorderDecoratorMiddlewareProps,
+  type ActivityBorderDecoratorMiddlewareRequest,
+  type ActivityBorderDecoratorProps
+};

--- a/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
@@ -29,7 +29,7 @@ type Request = Readonly<{
 
 type Props = Readonly<{ children?: ReactNode | undefined }>;
 
-const template = templateMiddleware<Request, Props>('ActivityBorderDecoratorMiddleware');
+const template = templateMiddleware<Request, Props>('activity border');
 
 const {
   createMiddleware: createActivityBorderMiddleware,

--- a/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
@@ -1,5 +1,10 @@
 import type { EmptyObject } from 'type-fest';
-import templateMiddleware from '../../private/templateMiddleware';
+import templateMiddleware, {
+  type InferInit,
+  type InferMiddleware,
+  type InferProps,
+  type InferRequest
+} from '../../private/templateMiddleware';
 import { type activityBorderDecoratorTypeName } from '../types';
 
 type Request = Readonly<{
@@ -26,19 +31,21 @@ type Request = Readonly<{
 
 type Props = EmptyObject;
 
+const template = templateMiddleware<typeof activityBorderDecoratorTypeName, Request, Props>(
+  'ActivityBorderDecoratorMiddleware'
+);
+
 const {
   initMiddleware: initActivityBorderDecoratorMiddleware,
   Provider: ActivityBorderDecoratorMiddlewareProvider,
   Proxy: ActivityBorderDecoratorMiddlewareProxy,
-  // False positive, `types` is used for its typing.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  types
-} = templateMiddleware<typeof activityBorderDecoratorTypeName, Request, Props>('ActivityBorderDecoratorMiddleware');
+  '~types': _types
+} = template;
 
-type ActivityBorderDecoratorMiddleware = typeof types.middleware;
-type ActivityBorderDecoratorMiddlewareInit = typeof types.init;
-type ActivityBorderDecoratorMiddlewareProps = typeof types.props;
-type ActivityBorderDecoratorMiddlewareRequest = typeof types.request;
+type ActivityBorderDecoratorMiddleware = InferMiddleware<typeof template>;
+type ActivityBorderDecoratorMiddlewareInit = InferInit<typeof template>;
+type ActivityBorderDecoratorMiddlewareProps = InferProps<typeof template>;
+type ActivityBorderDecoratorMiddlewareRequest = InferRequest<typeof template>;
 
 export {
   ActivityBorderDecoratorMiddlewareProvider,

--- a/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityBorder/private/ActivityBorderDecoratorMiddleware.ts
@@ -1,11 +1,9 @@
-import type { EmptyObject } from 'type-fest';
+import { type ReactNode } from 'react';
 import templateMiddleware, {
-  type InferInit,
   type InferMiddleware,
   type InferProps,
   type InferRequest
-} from '../../private/templateMiddleware';
-import { type activityBorderDecoratorTypeName } from '../types';
+} from '../../../middleware/private/templateMiddleware';
 
 type Request = Readonly<{
   /**
@@ -29,30 +27,27 @@ type Request = Readonly<{
   from: 'bot' | 'channel' | `user` | undefined;
 }>;
 
-type Props = EmptyObject;
+type Props = Readonly<{ children?: ReactNode | undefined }>;
 
-const template = templateMiddleware<typeof activityBorderDecoratorTypeName, Request, Props>(
-  'ActivityBorderDecoratorMiddleware'
-);
+const template = templateMiddleware<Request, Props>('ActivityBorderDecoratorMiddleware');
 
 const {
-  initMiddleware: initActivityBorderDecoratorMiddleware,
+  createMiddleware: createActivityBorderMiddleware,
+  extractMiddleware: extractActivityBorderDecoratorMiddleware,
   Provider: ActivityBorderDecoratorMiddlewareProvider,
-  Proxy: ActivityBorderDecoratorMiddlewareProxy,
-  '~types': _types
+  Proxy: ActivityBorderDecoratorMiddlewareProxy
 } = template;
 
 type ActivityBorderDecoratorMiddleware = InferMiddleware<typeof template>;
-type ActivityBorderDecoratorMiddlewareInit = InferInit<typeof template>;
 type ActivityBorderDecoratorMiddlewareProps = InferProps<typeof template>;
 type ActivityBorderDecoratorMiddlewareRequest = InferRequest<typeof template>;
 
 export {
   ActivityBorderDecoratorMiddlewareProvider,
   ActivityBorderDecoratorMiddlewareProxy,
-  initActivityBorderDecoratorMiddleware,
+  createActivityBorderMiddleware,
+  extractActivityBorderDecoratorMiddleware,
   type ActivityBorderDecoratorMiddleware,
-  type ActivityBorderDecoratorMiddlewareInit,
   type ActivityBorderDecoratorMiddlewareProps,
   type ActivityBorderDecoratorMiddlewareRequest
 };

--- a/packages/api/src/decorator/ActivityBorder/types.ts
+++ b/packages/api/src/decorator/ActivityBorder/types.ts
@@ -1,1 +1,0 @@
-export const activityBorderDecoratorTypeName = 'activity border' as const;

--- a/packages/api/src/decorator/ActivityGrouping/ActivityGroupingDecorator.tsx
+++ b/packages/api/src/decorator/ActivityGrouping/ActivityGroupingDecorator.tsx
@@ -4,6 +4,7 @@ import React, { memo, useMemo, type ReactNode } from 'react';
 import PassthroughFallback from '../private/PassthroughFallback';
 import {
   ActivityGroupingDecoratorMiddlewareProxy,
+  createActivityGroupingMiddleware,
   type ActivityGroupingDecoratorMiddlewareRequest
 } from './private/ActivityGroupingDecoratorMiddleware';
 
@@ -28,4 +29,4 @@ function ActivityGroupingDecorator({ activities, children, groupingName }: Activ
 }
 
 export default memo(ActivityGroupingDecorator);
-export { type ActivityGroupingDecoratorProps };
+export { createActivityGroupingMiddleware, type ActivityGroupingDecoratorProps };

--- a/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
@@ -1,5 +1,10 @@
 import { type WebChatActivity } from 'botframework-webchat-core';
-import templateMiddleware from '../../private/templateMiddleware';
+import templateMiddleware, {
+  type InferInit,
+  type InferMiddleware,
+  type InferProps,
+  type InferRequest
+} from '../../private/templateMiddleware';
 import { type activityGroupingDecoratorTypeName } from '../types';
 
 type Request = Readonly<{
@@ -13,19 +18,21 @@ type Props = Readonly<{
   activities: readonly WebChatActivity[];
 }>;
 
+const template = templateMiddleware<typeof activityGroupingDecoratorTypeName, Request, Props>(
+  'ActivityGroupingDecoratorMiddleware'
+);
+
 const {
   initMiddleware: initActivityGroupingDecoratorMiddleware,
   Provider: ActivityGroupingDecoratorMiddlewareProvider,
   Proxy: ActivityGroupingDecoratorMiddlewareProxy,
-  // False positive, `types` is used for its typing.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  types
-} = templateMiddleware<typeof activityGroupingDecoratorTypeName, Request, Props>('ActivityGroupingDecoratorMiddleware');
+  '~types': _types
+} = template;
 
-type ActivityGroupingDecoratorMiddleware = typeof types.middleware;
-type ActivityGroupingDecoratorMiddlewareInit = typeof types.init;
-type ActivityGroupingDecoratorMiddlewareProps = typeof types.props;
-type ActivityGroupingDecoratorMiddlewareRequest = typeof types.request;
+type ActivityGroupingDecoratorMiddleware = InferMiddleware<typeof template>;
+type ActivityGroupingDecoratorMiddlewareInit = InferInit<typeof template>;
+type ActivityGroupingDecoratorMiddlewareProps = InferProps<typeof template>;
+type ActivityGroupingDecoratorMiddlewareRequest = InferRequest<typeof template>;
 
 export {
   ActivityGroupingDecoratorMiddlewareProvider,

--- a/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
@@ -1,11 +1,9 @@
 import { type WebChatActivity } from 'botframework-webchat-core';
 import templateMiddleware, {
-  type InferInit,
   type InferMiddleware,
   type InferProps,
   type InferRequest
-} from '../../private/templateMiddleware';
-import { type activityGroupingDecoratorTypeName } from '../types';
+} from '../../../middleware/private/templateMiddleware';
 
 type Request = Readonly<{
   /**
@@ -18,28 +16,25 @@ type Props = Readonly<{
   activities: readonly WebChatActivity[];
 }>;
 
-const template = templateMiddleware<typeof activityGroupingDecoratorTypeName, Request, Props>(
-  'ActivityGroupingDecoratorMiddleware'
-);
+const template = templateMiddleware<Request, Props>('ActivityGroupingDecoratorMiddleware');
 
 const {
-  initMiddleware: initActivityGroupingDecoratorMiddleware,
+  createMiddleware: createActivityGroupingMiddleware,
+  extractMiddleware: extractActivityGroupingDecoratorMiddleware,
   Provider: ActivityGroupingDecoratorMiddlewareProvider,
-  Proxy: ActivityGroupingDecoratorMiddlewareProxy,
-  '~types': _types
+  Proxy: ActivityGroupingDecoratorMiddlewareProxy
 } = template;
 
 type ActivityGroupingDecoratorMiddleware = InferMiddleware<typeof template>;
-type ActivityGroupingDecoratorMiddlewareInit = InferInit<typeof template>;
 type ActivityGroupingDecoratorMiddlewareProps = InferProps<typeof template>;
 type ActivityGroupingDecoratorMiddlewareRequest = InferRequest<typeof template>;
 
 export {
   ActivityGroupingDecoratorMiddlewareProvider,
   ActivityGroupingDecoratorMiddlewareProxy,
-  initActivityGroupingDecoratorMiddleware,
+  createActivityGroupingMiddleware,
+  extractActivityGroupingDecoratorMiddleware,
   type ActivityGroupingDecoratorMiddleware,
-  type ActivityGroupingDecoratorMiddlewareInit,
   type ActivityGroupingDecoratorMiddlewareProps,
   type ActivityGroupingDecoratorMiddlewareRequest
 };

--- a/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
+++ b/packages/api/src/decorator/ActivityGrouping/private/ActivityGroupingDecoratorMiddleware.ts
@@ -16,7 +16,7 @@ type Props = Readonly<{
   activities: readonly WebChatActivity[];
 }>;
 
-const template = templateMiddleware<Request, Props>('ActivityGroupingDecoratorMiddleware');
+const template = templateMiddleware<Request, Props>('activity grouping');
 
 const {
   createMiddleware: createActivityGroupingMiddleware,

--- a/packages/api/src/decorator/ActivityGrouping/types.ts
+++ b/packages/api/src/decorator/ActivityGrouping/types.ts
@@ -1,1 +1,0 @@
-export const activityGroupingDecoratorTypeName = 'activity grouping' as const;

--- a/packages/api/src/decorator/DecoratorComposer.tsx
+++ b/packages/api/src/decorator/DecoratorComposer.tsx
@@ -1,6 +1,6 @@
 import { reactNode, validateProps } from 'botframework-webchat-react-valibot';
-import React, { Fragment, memo, useMemo, type ReactNode } from 'react';
-import { array, custom, object, optional, pipe, readonly, safeParse } from 'valibot';
+import React, { Fragment, memo, useMemo } from 'react';
+import { array, custom, object, optional, pipe, readonly, safeParse, type InferInput } from 'valibot';
 
 import { middlewareFactoryMarker } from '../middleware/private/templateMiddleware';
 import InternalDecoratorComposer from './internal/InternalDecoratorComposer';
@@ -18,12 +18,12 @@ const warnInvalidMiddlewarePropsSchema = optional(
   array(custom(value => value[middlewareFactoryMarker satisfies symbol] === middlewareFactoryMarker))
 );
 
-type DecoratorComposerProps = Readonly<{
-  children?: ReactNode | undefined;
-  // TODO: How could we mark `middleware` as readonly if we use InferInput<typeof decoratorComposerPropsSchema>?
-  //       Intersection doesn't work.
-  middleware?: readonly DecoratorMiddleware[] | undefined;
-}>;
+type DecoratorComposerProps = Omit<InferInput<typeof decoratorComposerPropsSchema>, 'middleware'> & {
+  // Mark "middleware" as read-only.
+  // Otherwise, passing a read-only middleware would fail because we prefer writable.
+  // eslint-disable-next-line react/require-default-props, react/no-unused-prop-types
+  readonly middleware?: readonly DecoratorMiddleware[] | undefined;
+};
 
 function DecoratorComposer(props: DecoratorComposerProps) {
   const { children, middleware } = validateProps(decoratorComposerPropsSchema, props);

--- a/packages/api/src/decorator/DecoratorComposer.tsx
+++ b/packages/api/src/decorator/DecoratorComposer.tsx
@@ -28,7 +28,6 @@ type DecoratorComposerProps = Readonly<{
 function DecoratorComposer(props: DecoratorComposerProps) {
   const { children, middleware } = validateProps(decoratorComposerPropsSchema, props);
 
-  // TODO: [P*] Checks if all middleware are created using `createXXXMiddleware`, warns if it's not.
   useMemo(() => {
     if (!safeParse(warnInvalidMiddlewarePropsSchema, middleware).success) {
       console.warn(

--- a/packages/api/src/decorator/DecoratorComposer.tsx
+++ b/packages/api/src/decorator/DecoratorComposer.tsx
@@ -8,6 +8,7 @@ type DecoratorComposerProps = Readonly<{
 }>;
 
 function DecoratorComposer({ children, middleware }: DecoratorComposerProps) {
+  // TODO: [P*] Checks if all middleware are created using `createXXXMiddleware`, warns if it's not.
   return middleware ? (
     <InternalDecoratorComposer middleware={middleware} priority="normal">
       {children}

--- a/packages/api/src/decorator/DecoratorComposer.tsx
+++ b/packages/api/src/decorator/DecoratorComposer.tsx
@@ -49,4 +49,4 @@ function DecoratorComposer(props: DecoratorComposerProps) {
 }
 
 export default memo(DecoratorComposer);
-export { type DecoratorComposerProps };
+export { decoratorComposerPropsSchema, type DecoratorComposerProps };

--- a/packages/api/src/decorator/internal/InternalDecoratorComposer.tsx
+++ b/packages/api/src/decorator/internal/InternalDecoratorComposer.tsx
@@ -1,14 +1,12 @@
 import React, { memo, useContext, useMemo, type ReactNode } from 'react';
 import {
   ActivityBorderDecoratorMiddlewareProvider,
-  initActivityBorderDecoratorMiddleware
+  extractActivityBorderDecoratorMiddleware
 } from '../ActivityBorder/private/ActivityBorderDecoratorMiddleware';
-import { activityBorderDecoratorTypeName } from '../ActivityBorder/types';
 import {
   ActivityGroupingDecoratorMiddlewareProvider,
-  initActivityGroupingDecoratorMiddleware
+  extractActivityGroupingDecoratorMiddleware
 } from '../ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
-import { activityGroupingDecoratorTypeName } from '../ActivityGrouping/types';
 import DecoratorComposerContext from '../private/DecoratorComposerContext';
 import { type DecoratorMiddleware } from '../types';
 
@@ -34,13 +32,10 @@ function InternalDecoratorComposer({
     [existingContext, middlewareFromProps, priority]
   );
 
-  const activityBorderMiddleware = useMemo(
-    () => initActivityBorderDecoratorMiddleware(middleware, activityBorderDecoratorTypeName),
-    [middleware]
-  );
+  const activityBorderMiddleware = useMemo(() => extractActivityBorderDecoratorMiddleware(middleware), [middleware]);
 
   const activityGroupingMiddleware = useMemo(
-    () => initActivityGroupingDecoratorMiddleware(middleware, activityGroupingDecoratorTypeName),
+    () => extractActivityGroupingDecoratorMiddleware(middleware),
     [middleware]
   );
 

--- a/packages/api/src/decorator/private/templateMiddleware.test.tsx
+++ b/packages/api/src/decorator/private/templateMiddleware.test.tsx
@@ -3,7 +3,7 @@
 import { render } from '@testing-library/react';
 import React, { Fragment, type ReactNode } from 'react';
 
-import templateMiddleware from './templateMiddleware';
+import templateMiddleware, { type InferMiddleware } from './templateMiddleware';
 
 type ButtonProps = Readonly<{ children?: ReactNode | undefined }>;
 type LinkProps = Readonly<{ children?: ReactNode | undefined; href: string }>;
@@ -20,27 +20,15 @@ const InternalLinkImpl = ({ children, href }: LinkProps) => <a href={href}>{chil
 
 // User story for using templateMiddleware as a building block for uber middleware.
 test('an uber middleware', () => {
-  const {
-    initMiddleware: initButtonMiddleware,
-    Provider: ButtonProvider,
-    Proxy: Button,
-    // False positive, `types` is used for its typing.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    types: buttonTypes
-  } = templateMiddleware<'button', void, ButtonProps>('Button');
+  const buttonTemplate = templateMiddleware<'button', void, ButtonProps>('Button');
+  const { initMiddleware: initButtonMiddleware, Provider: ButtonProvider, Proxy: Button } = buttonTemplate;
 
-  type ButtonMiddleware = typeof buttonTypes.middleware;
+  type ButtonMiddleware = InferMiddleware<typeof buttonTemplate>;
 
-  const {
-    initMiddleware: initLinkMiddleware,
-    Provider: LinkProvider,
-    Proxy: Link,
-    // False positive, `types` is used for its typing.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    types: linkTypes
-  } = templateMiddleware<'link', { external: boolean }, LinkProps>('Link');
+  const linkTemplate = templateMiddleware<'link', { external: boolean }, LinkProps>('Link');
+  const { initMiddleware: initLinkMiddleware, Provider: LinkProvider, Proxy: Link } = linkTemplate;
 
-  type LinkMiddleware = typeof linkTypes.middleware;
+  type LinkMiddleware = InferMiddleware<typeof linkTemplate>;
 
   const buttonMiddleware: ButtonMiddleware[] = [init => init === 'button' && (() => () => ButtonImpl)];
   const linkMiddleware: LinkMiddleware[] = [

--- a/packages/api/src/decorator/private/templateMiddleware.ts
+++ b/packages/api/src/decorator/private/templateMiddleware.ts
@@ -48,11 +48,11 @@ function templateMiddleware<Init extends string, Request = any, Props extends {}
     initMiddleware,
     Provider,
     Proxy,
-    '~types': {
-      init: undefined as Init,
-      middleware: undefined as Middleware,
-      props: undefined as Props,
-      request: undefined as Request
+    '~types': undefined as {
+      init: Init;
+      middleware: Middleware;
+      props: Props;
+      request: Request;
     }
   };
 }

--- a/packages/api/src/decorator/private/templateMiddleware.ts
+++ b/packages/api/src/decorator/private/templateMiddleware.ts
@@ -3,15 +3,13 @@ import { createChainOfResponsibility, type ComponentMiddleware } from 'react-cha
 import { type EmptyObject } from 'type-fest';
 import { any, array, function_, pipe, safeParse, type InferOutput } from 'valibot';
 
-export type MiddlewareWithInit<M extends ComponentMiddleware<any, any, any>, I> = (init: I) => ReturnType<M> | false;
+type MiddlewareWithInit<M extends ComponentMiddleware<any, any, any>, I> = (init: I) => ReturnType<M> | false;
 
 const EMPTY_ARRAY = Object.freeze([]);
 
 // Following @types/react to use {} for props.
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export default function templateMiddleware<Init extends string, Request = any, Props extends {} = EmptyObject>(
-  name: string
-) {
+function templateMiddleware<Init extends string, Request = any, Props extends {} = EmptyObject>(name: string) {
   type Middleware = ComponentMiddleware<Request, Props>;
 
   const middlewareSchema = array(pipe(any(), function_()));
@@ -22,8 +20,8 @@ export default function templateMiddleware<Init extends string, Request = any, P
   const warnInvalid = warnOnce(`"${name}" prop is invalid`);
 
   const initMiddleware = (
-    middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, Init>[],
-    init: Init
+    middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, unknown>[],
+    init: unknown
   ): readonly Middleware[] => {
     if (middleware) {
       if (isMiddleware(middleware)) {
@@ -50,7 +48,7 @@ export default function templateMiddleware<Init extends string, Request = any, P
     initMiddleware,
     Provider,
     Proxy,
-    types: {
+    '~types': {
       init: undefined as Init,
       middleware: undefined as Middleware,
       props: undefined as Props,
@@ -58,3 +56,11 @@ export default function templateMiddleware<Init extends string, Request = any, P
     }
   };
 }
+
+type InferMiddleware<T extends { '~types': { middleware } }> = T['~types']['middleware'];
+type InferInit<T extends { '~types': { init } }> = T['~types']['init'];
+type InferProps<T extends { '~types': { props } }> = T['~types']['props'];
+type InferRequest<T extends { '~types': { request } }> = T['~types']['request'];
+
+export default templateMiddleware;
+export { type InferInit, type InferMiddleware, type InferProps, type InferRequest, type MiddlewareWithInit };

--- a/packages/api/src/decorator/types.ts
+++ b/packages/api/src/decorator/types.ts
@@ -1,15 +1,20 @@
 import { type ActivityBorderDecoratorMiddleware } from './ActivityBorder/private/ActivityBorderDecoratorMiddleware';
-import { type activityBorderDecoratorTypeName } from './ActivityBorder/types';
+import { activityBorderDecoratorTypeName } from './ActivityBorder/types';
 import { type ActivityGroupingDecoratorMiddleware } from './ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
-import { type activityGroupingDecoratorTypeName } from './ActivityGrouping/types';
+import { activityGroupingDecoratorTypeName } from './ActivityGrouping/types';
 
-export type DecoratorMiddlewareTypes = {
-  [activityBorderDecoratorTypeName]: ReturnType<ActivityBorderDecoratorMiddleware>;
-  [activityGroupingDecoratorTypeName]: ReturnType<ActivityGroupingDecoratorMiddleware>;
-};
+export type DecoratorMiddleware =
+  | ((init: typeof activityBorderDecoratorTypeName) => ReturnType<ActivityBorderDecoratorMiddleware> | false)
+  | ((init: typeof activityGroupingDecoratorTypeName) => ReturnType<ActivityGroupingDecoratorMiddleware> | false);
 
-export type DecoratorMiddlewareInit = keyof DecoratorMiddlewareTypes;
+export function activityBorderMiddleware(
+  enhancer: ReturnType<ActivityBorderDecoratorMiddleware>
+): (init: string) => ReturnType<ActivityBorderDecoratorMiddleware> | false {
+  return init => init === activityBorderDecoratorTypeName && enhancer;
+}
 
-export interface DecoratorMiddleware {
-  (init: keyof DecoratorMiddlewareTypes): DecoratorMiddlewareTypes[typeof init] | false;
+export function activityGroupingMiddleware(
+  enhancer: ReturnType<ActivityGroupingDecoratorMiddleware>
+): (init: string) => ReturnType<ActivityGroupingDecoratorMiddleware> | false {
+  return init => init === activityGroupingDecoratorTypeName && enhancer;
 }

--- a/packages/api/src/decorator/types.ts
+++ b/packages/api/src/decorator/types.ts
@@ -1,6 +1,4 @@
-import { createActivityBorderMiddleware } from './ActivityBorder/private/ActivityBorderDecoratorMiddleware';
-import { createActivityGroupingMiddleware } from './ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
+import { ActivityBorderDecoratorMiddleware } from './ActivityBorder/private/ActivityBorderDecoratorMiddleware';
+import { ActivityGroupingDecoratorMiddleware } from './ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
 
-export type DecoratorMiddleware =
-  | ReturnType<typeof createActivityBorderMiddleware>
-  | ReturnType<typeof createActivityGroupingMiddleware>;
+export type DecoratorMiddleware = ActivityBorderDecoratorMiddleware | ActivityGroupingDecoratorMiddleware;

--- a/packages/api/src/decorator/types.ts
+++ b/packages/api/src/decorator/types.ts
@@ -1,20 +1,6 @@
-import { type ActivityBorderDecoratorMiddleware } from './ActivityBorder/private/ActivityBorderDecoratorMiddleware';
-import { activityBorderDecoratorTypeName } from './ActivityBorder/types';
-import { type ActivityGroupingDecoratorMiddleware } from './ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
-import { activityGroupingDecoratorTypeName } from './ActivityGrouping/types';
+import { createActivityBorderMiddleware } from './ActivityBorder/private/ActivityBorderDecoratorMiddleware';
+import { createActivityGroupingMiddleware } from './ActivityGrouping/private/ActivityGroupingDecoratorMiddleware';
 
 export type DecoratorMiddleware =
-  | ((init: typeof activityBorderDecoratorTypeName) => ReturnType<ActivityBorderDecoratorMiddleware> | false)
-  | ((init: typeof activityGroupingDecoratorTypeName) => ReturnType<ActivityGroupingDecoratorMiddleware> | false);
-
-export function activityBorderMiddleware(
-  enhancer: ReturnType<ActivityBorderDecoratorMiddleware>
-): (init: string) => ReturnType<ActivityBorderDecoratorMiddleware> | false {
-  return init => init === activityBorderDecoratorTypeName && enhancer;
-}
-
-export function activityGroupingMiddleware(
-  enhancer: ReturnType<ActivityGroupingDecoratorMiddleware>
-): (init: string) => ReturnType<ActivityGroupingDecoratorMiddleware> | false {
-  return init => init === activityGroupingDecoratorTypeName && enhancer;
-}
+  | ReturnType<typeof createActivityBorderMiddleware>
+  | ReturnType<typeof createActivityGroupingMiddleware>;

--- a/packages/api/src/hooks/Composer.tsx
+++ b/packages/api/src/hooks/Composer.tsx
@@ -40,6 +40,11 @@ import updateIn from 'simple-update-in';
 import StyleOptions from '../StyleOptions';
 import usePonyfill from '../hooks/usePonyfill';
 import getAllLocalizedStrings from '../localization/getAllLocalizedStrings';
+import { SendBoxMiddlewareProvider, type SendBoxMiddleware } from '../middleware/SendBoxMiddleware';
+import {
+  SendBoxToolbarMiddlewareProvider,
+  type SendBoxToolbarMiddleware
+} from '../middleware/SendBoxToolbarMiddleware';
 import normalizeStyleOptions from '../normalizeStyleOptions';
 import patchStyleOptionsFromDeprecatedProps from '../patchStyleOptionsFromDeprecatedProps';
 import ActivityAcknowledgementComposer from '../providers/ActivityAcknowledgement/ActivityAcknowledgementComposer';
@@ -67,8 +72,6 @@ import createCustomEvent from '../utils/createCustomEvent';
 import isObject from '../utils/isObject';
 import mapMap from '../utils/mapMap';
 import normalizeLanguage from '../utils/normalizeLanguage';
-import { SendBoxMiddlewareProvider, type SendBoxMiddleware } from './internal/SendBoxMiddleware';
-import { SendBoxToolbarMiddlewareProvider, type SendBoxToolbarMiddleware } from './internal/SendBoxToolbarMiddleware';
 import Tracker from './internal/Tracker';
 import WebChatAPIContext, { type WebChatAPIContextType } from './internal/WebChatAPIContext';
 import WebChatReduxContext, { useDispatch } from './internal/WebChatReduxContext';

--- a/packages/api/src/hooks/internal/SendBoxMiddleware.ts
+++ b/packages/api/src/hooks/internal/SendBoxMiddleware.ts
@@ -1,23 +1,30 @@
-import templateMiddleware from './private/templateMiddleware';
+import templateMiddleware, {
+  type InferInit,
+  type InferMiddleware,
+  type InferProps,
+  type InferRequest
+} from './private/templateMiddleware';
+
+const template = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxMiddleware');
 
 const {
   initMiddleware: initSendBoxMiddleware,
   Provider: SendBoxMiddlewareProvider,
   Proxy: SendBoxMiddlewareProxy,
-  // False positive, `types` is used for its typing.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  types
-} = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxMiddleware');
+  '~types': _types
+} = template;
 
-type SendBoxMiddleware = typeof types.middleware;
-type SendBoxMiddlewareProps = typeof types.props;
-type SendBoxMiddlewareRequest = typeof types.request;
+type SendBoxMiddleware = InferMiddleware<typeof template>;
+type SendBoxMiddlewareInit = InferInit<typeof template>;
+type SendBoxMiddlewareProps = InferProps<typeof template>;
+type SendBoxMiddlewareRequest = InferRequest<typeof template>;
 
 export {
+  initSendBoxMiddleware,
   SendBoxMiddlewareProvider,
   SendBoxMiddlewareProxy,
-  initSendBoxMiddleware,
   type SendBoxMiddleware,
+  type SendBoxMiddlewareInit,
   type SendBoxMiddlewareProps,
   type SendBoxMiddlewareRequest
 };

--- a/packages/api/src/hooks/internal/SendBoxToolbarMiddleware.ts
+++ b/packages/api/src/hooks/internal/SendBoxToolbarMiddleware.ts
@@ -1,23 +1,30 @@
-import templateMiddleware from './private/templateMiddleware';
+import templateMiddleware, {
+  type InferInit,
+  type InferMiddleware,
+  type InferProps,
+  type InferRequest
+} from './private/templateMiddleware';
+
+const template = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxToolbarMiddleware');
 
 const {
   initMiddleware: initSendBoxToolbarMiddleware,
   Provider: SendBoxToolbarMiddlewareProvider,
   Proxy: SendBoxToolbarMiddlewareProxy,
-  // False positive, `types` is used for its typing.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  types
-} = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxToolbarMiddleware');
+  '~types': _types
+} = template;
 
-type SendBoxToolbarMiddleware = typeof types.middleware;
-type SendBoxToolbarMiddlewareProps = typeof types.props;
-type SendBoxToolbarMiddlewareRequest = typeof types.request;
+type SendBoxToolbarMiddleware = InferMiddleware<typeof template>;
+type SendBoxToolbarMiddlewareInit = InferInit<typeof template>;
+type SendBoxToolbarMiddlewareProps = InferProps<typeof template>;
+type SendBoxToolbarMiddlewareRequest = InferRequest<typeof template>;
 
 export {
+  initSendBoxToolbarMiddleware,
   SendBoxToolbarMiddlewareProvider,
   SendBoxToolbarMiddlewareProxy,
-  initSendBoxToolbarMiddleware,
   type SendBoxToolbarMiddleware,
+  type SendBoxToolbarMiddlewareInit,
   type SendBoxToolbarMiddlewareProps,
   type SendBoxToolbarMiddlewareRequest
 };

--- a/packages/api/src/hooks/internal/private/templateMiddleware.ts
+++ b/packages/api/src/hooks/internal/private/templateMiddleware.ts
@@ -1,4 +1,8 @@
-import templateMiddleware from '../../../decorator/private/templateMiddleware';
-
 // TODO: We should move them to a common directory.
-export default templateMiddleware;
+export {
+  default,
+  type InferInit,
+  type InferMiddleware,
+  type InferProps,
+  type InferRequest
+} from '../../../decorator/private/templateMiddleware';

--- a/packages/api/src/hooks/internal/private/templateMiddleware.ts
+++ b/packages/api/src/hooks/internal/private/templateMiddleware.ts
@@ -1,8 +1,0 @@
-// TODO: We should move them to a common directory.
-export {
-  default,
-  type InferInit,
-  type InferMiddleware,
-  type InferProps,
-  type InferRequest
-} from '../../../decorator/private/templateMiddleware';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,21 +1,8 @@
+// TODO: Move the pattern to re-export.
 import StyleOptions, { StrictStyleOptions } from './StyleOptions';
 import defaultStyleOptions from './defaultStyleOptions';
 import Composer, { ComposerProps } from './hooks/Composer';
 import * as hooks from './hooks/index';
-import {
-  SendBoxMiddlewareProxy,
-  initSendBoxMiddleware,
-  type SendBoxMiddleware,
-  type SendBoxMiddlewareProps,
-  type SendBoxMiddlewareRequest
-} from './hooks/internal/SendBoxMiddleware';
-import {
-  SendBoxToolbarMiddlewareProxy,
-  initSendBoxToolbarMiddleware,
-  type SendBoxToolbarMiddleware,
-  type SendBoxToolbarMiddlewareProps,
-  type SendBoxToolbarMiddlewareRequest
-} from './hooks/internal/SendBoxToolbarMiddleware';
 import concatMiddleware from './hooks/middleware/concatMiddleware';
 import { type ActivityStatusRenderer } from './hooks/useCreateActivityStatusRenderer'; // TODO: [P1] This line should export the one from the version from "middleware rework" workstream.
 import { type DebouncedNotification, type DebouncedNotifications } from './hooks/useDebouncedNotifications';
@@ -43,26 +30,31 @@ import TypingIndicatorMiddleware, { type RenderTypingIndicator } from './types/T
 import { type WebSpeechPonyfill } from './types/WebSpeechPonyfill';
 import { type WebSpeechPonyfillFactory } from './types/WebSpeechPonyfillFactory';
 
+// #region Re-export
+export {
+  extractSendBoxMiddleware,
+  SendBoxMiddlewareProxy,
+  type SendBoxMiddleware,
+  type SendBoxMiddlewareProps,
+  type SendBoxMiddlewareRequest
+} from './middleware/SendBoxMiddleware';
+
+export {
+  extractSendBoxToolbarMiddleware,
+  SendBoxToolbarMiddlewareProxy,
+  type SendBoxToolbarMiddleware,
+  type SendBoxToolbarMiddlewareProps,
+  type SendBoxToolbarMiddlewareRequest
+} from './middleware/SendBoxToolbarMiddleware';
+// #endregion
+
 const buildTool = process.env.build_tool;
 const moduleFormat = process.env.module_format;
 const version = process.env.npm_package_version;
 
 const buildInfo = { buildTool, moduleFormat, version };
 
-export {
-  Composer,
-  SendBoxMiddlewareProxy,
-  SendBoxToolbarMiddlewareProxy,
-  buildInfo,
-  concatMiddleware,
-  defaultStyleOptions,
-  hooks,
-  initSendBoxMiddleware,
-  initSendBoxToolbarMiddleware,
-  localize,
-  normalizeStyleOptions,
-  version
-};
+export { buildInfo, Composer, concatMiddleware, defaultStyleOptions, hooks, localize, normalizeStyleOptions, version };
 
 export type {
   ActivityComponentFactory,
@@ -90,12 +82,6 @@ export type {
   RenderTypingIndicator,
   ScrollToEndButtonComponentFactory,
   ScrollToEndButtonMiddleware,
-  SendBoxMiddleware,
-  SendBoxMiddlewareProps,
-  SendBoxMiddlewareRequest,
-  SendBoxToolbarMiddleware,
-  SendBoxToolbarMiddlewareProps,
-  SendBoxToolbarMiddlewareRequest,
   SendStatus,
   StrictStyleOptions,
   StyleOptions,

--- a/packages/api/src/middleware/SendBoxMiddleware.ts
+++ b/packages/api/src/middleware/SendBoxMiddleware.ts
@@ -10,8 +10,7 @@ const {
   createMiddleware: createSendBoxMiddleware,
   extractMiddleware: extractSendBoxMiddleware,
   Provider: SendBoxMiddlewareProvider,
-  Proxy: SendBoxMiddlewareProxy,
-  '~types': _types
+  Proxy: SendBoxMiddlewareProxy
 } = template;
 
 type SendBoxMiddleware = InferMiddleware<typeof template>;

--- a/packages/api/src/middleware/SendBoxMiddleware.ts
+++ b/packages/api/src/middleware/SendBoxMiddleware.ts
@@ -1,30 +1,29 @@
 import templateMiddleware, {
-  type InferInit,
   type InferMiddleware,
   type InferProps,
   type InferRequest
 } from './private/templateMiddleware';
 
-const template = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxMiddleware');
+const template = templateMiddleware<void, { className?: string | undefined }>('sendBoxMiddleware');
 
 const {
-  initMiddleware: initSendBoxMiddleware,
+  createMiddleware: createSendBoxMiddleware,
+  extractMiddleware: extractSendBoxMiddleware,
   Provider: SendBoxMiddlewareProvider,
   Proxy: SendBoxMiddlewareProxy,
   '~types': _types
 } = template;
 
 type SendBoxMiddleware = InferMiddleware<typeof template>;
-type SendBoxMiddlewareInit = InferInit<typeof template>;
 type SendBoxMiddlewareProps = InferProps<typeof template>;
 type SendBoxMiddlewareRequest = InferRequest<typeof template>;
 
 export {
-  initSendBoxMiddleware,
+  createSendBoxMiddleware,
+  extractSendBoxMiddleware,
   SendBoxMiddlewareProvider,
   SendBoxMiddlewareProxy,
   type SendBoxMiddleware,
-  type SendBoxMiddlewareInit,
   type SendBoxMiddlewareProps,
   type SendBoxMiddlewareRequest
 };

--- a/packages/api/src/middleware/SendBoxToolbarMiddleware.ts
+++ b/packages/api/src/middleware/SendBoxToolbarMiddleware.ts
@@ -10,8 +10,7 @@ const {
   createMiddleware: createSendBoxToolbarMiddleware,
   extractMiddleware: extractSendBoxToolbarMiddleware,
   Provider: SendBoxToolbarMiddlewareProvider,
-  Proxy: SendBoxToolbarMiddlewareProxy,
-  '~types': _types
+  Proxy: SendBoxToolbarMiddlewareProxy
 } = template;
 
 type SendBoxToolbarMiddleware = InferMiddleware<typeof template>;

--- a/packages/api/src/middleware/SendBoxToolbarMiddleware.ts
+++ b/packages/api/src/middleware/SendBoxToolbarMiddleware.ts
@@ -1,30 +1,29 @@
 import templateMiddleware, {
-  type InferInit,
   type InferMiddleware,
   type InferProps,
   type InferRequest
 } from './private/templateMiddleware';
 
-const template = templateMiddleware<undefined, void, { className?: string | undefined }>('sendBoxToolbarMiddleware');
+const template = templateMiddleware<void, { className?: string | undefined }>('sendBoxToolbarMiddleware');
 
 const {
-  initMiddleware: initSendBoxToolbarMiddleware,
+  createMiddleware: createSendBoxToolbarMiddleware,
+  extractMiddleware: extractSendBoxToolbarMiddleware,
   Provider: SendBoxToolbarMiddlewareProvider,
   Proxy: SendBoxToolbarMiddlewareProxy,
   '~types': _types
 } = template;
 
 type SendBoxToolbarMiddleware = InferMiddleware<typeof template>;
-type SendBoxToolbarMiddlewareInit = InferInit<typeof template>;
 type SendBoxToolbarMiddlewareProps = InferProps<typeof template>;
 type SendBoxToolbarMiddlewareRequest = InferRequest<typeof template>;
 
 export {
-  initSendBoxToolbarMiddleware,
+  createSendBoxToolbarMiddleware,
+  extractSendBoxToolbarMiddleware,
   SendBoxToolbarMiddlewareProvider,
   SendBoxToolbarMiddlewareProxy,
   type SendBoxToolbarMiddleware,
-  type SendBoxToolbarMiddlewareInit,
   type SendBoxToolbarMiddlewareProps,
   type SendBoxToolbarMiddlewareRequest
 };

--- a/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
+++ b/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
@@ -11,3 +11,25 @@ test('should warn if middleware did not return function', () => {
   expect(warn).toHaveBeenCalledTimes(1);
   expect(warn).toHaveBeenNthCalledWith(1, expect.stringContaining('must return enhancer function'));
 });
+
+test('should not warn if middleware return false', () => {
+  const warn = jest.fn();
+  const template = templateMiddleware('Check');
+
+  jest.spyOn(console, 'warn').mockImplementation(warn);
+
+  template.extractMiddleware([() => false]);
+
+  expect(warn).toHaveBeenCalledTimes(0);
+});
+
+test('should not warn if middleware return function', () => {
+  const warn = jest.fn();
+  const template = templateMiddleware('Check');
+
+  jest.spyOn(console, 'warn').mockImplementation(warn);
+
+  template.extractMiddleware([() => () => 1 as any]);
+
+  expect(warn).toHaveBeenCalledTimes(0);
+});

--- a/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
+++ b/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
@@ -1,0 +1,13 @@
+import templateMiddleware from './templateMiddleware';
+
+test('should warn if middleware did not return function', () => {
+  const warn = jest.fn();
+  const template = templateMiddleware('Check');
+
+  jest.spyOn(console, 'warn').mockImplementation(warn);
+
+  template.extractMiddleware([() => 1 as any]);
+
+  expect(warn).toHaveBeenCalledTimes(1);
+  expect(warn).toHaveBeenNthCalledWith(1, expect.stringContaining('must return enhancer function'));
+});

--- a/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
+++ b/packages/api/src/middleware/private/templateMiddleware.check.test.tsx
@@ -1,5 +1,17 @@
 import templateMiddleware from './templateMiddleware';
 
+test('should warn if middleware is not an array of function', () => {
+  const warn = jest.fn();
+  const template = templateMiddleware('Check');
+
+  jest.spyOn(console, 'warn').mockImplementation(warn);
+
+  template.extractMiddleware(1 as any);
+
+  expect(warn).toHaveBeenCalledTimes(1);
+  expect(warn).toHaveBeenNthCalledWith(1, expect.stringContaining('must be an array of function'));
+});
+
 test('should warn if middleware did not return function', () => {
   const warn = jest.fn();
   const template = templateMiddleware('Check');

--- a/packages/api/src/middleware/private/templateMiddleware.test.tsx
+++ b/packages/api/src/middleware/private/templateMiddleware.test.tsx
@@ -21,19 +21,29 @@ const InternalLinkImpl = ({ children, href }: LinkProps) => <a href={href}>{chil
 // User story for using templateMiddleware as a building block for uber middleware.
 test('an uber middleware', () => {
   const buttonTemplate = templateMiddleware<void, ButtonProps>('Button');
-  const { extractMiddleware: extractButtonMiddleware, Provider: ButtonProvider, Proxy: Button } = buttonTemplate;
+  const {
+    createMiddleware: createButtonMiddleware,
+    extractMiddleware: extractButtonMiddleware,
+    Provider: ButtonProvider,
+    Proxy: Button
+  } = buttonTemplate;
 
   type ButtonMiddleware = InferMiddleware<typeof buttonTemplate>;
 
   const linkTemplate = templateMiddleware<{ external: boolean }, LinkProps>('Link');
-  const { extractMiddleware: extractLinkMiddleware, Provider: LinkProvider, Proxy: Link } = linkTemplate;
+  const {
+    createMiddleware: createLinkMiddleware,
+    extractMiddleware: extractLinkMiddleware,
+    Provider: LinkProvider,
+    Proxy: Link
+  } = linkTemplate;
 
   type LinkMiddleware = InferMiddleware<typeof linkTemplate>;
 
-  const buttonMiddleware: ButtonMiddleware[] = [init => init === 'button' && (() => () => ButtonImpl)];
+  const buttonMiddleware: ButtonMiddleware[] = [createButtonMiddleware(() => () => ButtonImpl)];
   const linkMiddleware: LinkMiddleware[] = [
-    init => init === 'link' && (next => request => (request.external ? ExternalLinkImpl : next(request))),
-    init => init === 'link' && (() => () => InternalLinkImpl)
+    createLinkMiddleware(next => request => (request.external ? ExternalLinkImpl : next(request))),
+    createLinkMiddleware(() => () => InternalLinkImpl)
   ];
 
   const App = ({

--- a/packages/api/src/middleware/private/templateMiddleware.test.tsx
+++ b/packages/api/src/middleware/private/templateMiddleware.test.tsx
@@ -20,13 +20,13 @@ const InternalLinkImpl = ({ children, href }: LinkProps) => <a href={href}>{chil
 
 // User story for using templateMiddleware as a building block for uber middleware.
 test('an uber middleware', () => {
-  const buttonTemplate = templateMiddleware<'button', void, ButtonProps>('Button');
-  const { initMiddleware: initButtonMiddleware, Provider: ButtonProvider, Proxy: Button } = buttonTemplate;
+  const buttonTemplate = templateMiddleware<void, ButtonProps>('Button');
+  const { extractMiddleware: extractButtonMiddleware, Provider: ButtonProvider, Proxy: Button } = buttonTemplate;
 
   type ButtonMiddleware = InferMiddleware<typeof buttonTemplate>;
 
-  const linkTemplate = templateMiddleware<'link', { external: boolean }, LinkProps>('Link');
-  const { initMiddleware: initLinkMiddleware, Provider: LinkProvider, Proxy: Link } = linkTemplate;
+  const linkTemplate = templateMiddleware<{ external: boolean }, LinkProps>('Link');
+  const { extractMiddleware: extractLinkMiddleware, Provider: LinkProvider, Proxy: Link } = linkTemplate;
 
   type LinkMiddleware = InferMiddleware<typeof linkTemplate>;
 
@@ -45,9 +45,9 @@ test('an uber middleware', () => {
   }>) => (
     <Fragment>
       {/* TODO: Should not case middleware to any */}
-      <ButtonProvider middleware={initButtonMiddleware(middleware as any, 'button')}>
+      <ButtonProvider middleware={extractButtonMiddleware(middleware as any)}>
         {/* TODO: Should not case middleware to any */}
-        <LinkProvider middleware={initLinkMiddleware(middleware as any, 'link')}>{children}</LinkProvider>
+        <LinkProvider middleware={extractLinkMiddleware(middleware as any)}>{children}</LinkProvider>
       </ButtonProvider>
     </Fragment>
   );

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -27,7 +27,7 @@ function templateMiddleware<Request, Props extends {}>(name: string) {
     return factory;
   };
 
-  const warnInvalid = warnOnce(`"${name}" middleware prop must be an array of function`);
+  const warnInvalidExtraction = warnOnce(`Middleware passed for extraction of "${name}" must be an array of function`);
 
   const extractMiddleware = (
     middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, string>[] | undefined
@@ -52,7 +52,7 @@ function templateMiddleware<Request, Props extends {}>(name: string) {
         );
       }
 
-      warnInvalid();
+      warnInvalidExtraction();
     }
 
     return EMPTY_ARRAY;

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -18,7 +18,7 @@ function templateMiddleware<Request, Props extends {}>(name: string) {
   type Middleware = ComponentMiddleware<Request, Props, string>;
 
   const createMiddleware = (enhancer: ReturnType<Middleware>): Middleware => {
-    const factory = init => init === name && enhancer;
+    const factory: Middleware = init => init === name && enhancer;
 
     // This is for checking if the middleware is created via factory function or not.
     // We recommend middleware to be created using factory function.

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -25,11 +25,19 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
   ): readonly Middleware[] => {
     if (middleware) {
       if (isArrayOfFunction(middleware)) {
-        // TODO: [P*] We assume middleware is Function[], we should do more checks.
         return Object.freeze(
           middleware
-            // TODO: [P*] Checks if the return value is of type function or false.
-            .map(middleware => middleware(name) as ReturnType<Middleware> | false)
+            .map(middleware => {
+              const result = middleware(name);
+
+              if (typeof result !== 'function') {
+                console.warn(`botframework-webchat: ${name}.middleware must return enhancer function`);
+
+                return false;
+              }
+
+              return result;
+            })
             .filter((enhancer): enhancer is ReturnType<Middleware> => !!enhancer)
             .map(enhancer => () => enhancer)
         );

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -30,8 +30,8 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
             .map(middleware => {
               const result = middleware(name);
 
-              if (typeof result !== 'function') {
-                console.warn(`botframework-webchat: ${name}.middleware must return enhancer function`);
+              if (typeof result !== 'function' && result !== false) {
+                console.warn(`botframework-webchat: ${name}.middleware must return enhancer function or false`);
 
                 return false;
               }

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -28,7 +28,7 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
     return factory;
   };
 
-  const warnInvalid = warnOnce(`"${name}" middleware prop is must be an array of function`);
+  const warnInvalid = warnOnce(`"${name}" middleware prop must be an array of function`);
 
   const extractMiddleware = (
     middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, unknown>[] | undefined

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -21,6 +21,8 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
   const createMiddleware = (enhancer: ReturnType<Middleware>): Middleware => {
     const factory = init => init === name && enhancer;
 
+    // This is for checking if the middleware is created via factory function or not.
+    // We recommend middleware to be created using factory function.
     factory[middlewareFactoryMarker satisfies symbol] = middlewareFactoryMarker;
 
     return factory;

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -1,6 +1,5 @@
 import { warnOnce } from 'botframework-webchat-core';
 import { createChainOfResponsibility, type ComponentMiddleware } from 'react-chain-of-responsibility';
-import { type EmptyObject } from 'type-fest';
 import { array, function_, safeParse, type InferOutput } from 'valibot';
 
 type MiddlewareWithInit<M extends ComponentMiddleware<any, any, any>, I> = (init: I) => ReturnType<M> | false;
@@ -15,8 +14,8 @@ const EMPTY_ARRAY = Object.freeze([]);
 
 // Following @types/react to use {} for props.
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name: string) {
-  type Middleware = ComponentMiddleware<Request, Props>;
+function templateMiddleware<Request, Props extends {}>(name: string) {
+  type Middleware = ComponentMiddleware<Request, Props, string>;
 
   const createMiddleware = (enhancer: ReturnType<Middleware>): Middleware => {
     const factory = init => init === name && enhancer;
@@ -31,7 +30,7 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
   const warnInvalid = warnOnce(`"${name}" middleware prop must be an array of function`);
 
   const extractMiddleware = (
-    middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, unknown>[] | undefined
+    middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, string>[] | undefined
   ): readonly Middleware[] => {
     if (middleware) {
       if (isArrayOfFunction(middleware)) {

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -18,6 +18,14 @@ const EMPTY_ARRAY = Object.freeze([]);
 function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name: string) {
   type Middleware = ComponentMiddleware<Request, Props>;
 
+  const createMiddleware = (enhancer: ReturnType<Middleware>): Middleware => {
+    const factory = init => init === name && enhancer;
+
+    factory[middlewareFactoryMarker satisfies symbol] = middlewareFactoryMarker;
+
+    return factory;
+  };
+
   const warnInvalid = warnOnce(`"${name}" prop is invalid`);
 
   const extractMiddleware = (
@@ -53,14 +61,6 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
 
   Provider.displayName = `${name}Provider`;
   Proxy.displayName = `${name}Proxy`;
-
-  const createMiddleware = (enhancer: ReturnType<Middleware>): Middleware => {
-    const factory = init => init === name && enhancer;
-
-    factory[middlewareFactoryMarker satisfies symbol] = middlewareFactoryMarker;
-
-    return factory;
-  };
 
   return {
     createMiddleware,

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -28,7 +28,7 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
     return factory;
   };
 
-  const warnInvalid = warnOnce(`"${name}" prop is invalid`);
+  const warnInvalid = warnOnce(`"${name}" middleware prop is must be an array of function`);
 
   const extractMiddleware = (
     middleware: readonly MiddlewareWithInit<ComponentMiddleware<unknown, unknown>, unknown>[] | undefined

--- a/packages/api/src/middleware/private/templateMiddleware.ts
+++ b/packages/api/src/middleware/private/templateMiddleware.ts
@@ -45,7 +45,7 @@ function templateMiddleware<Request = any, Props extends {} = EmptyObject>(name:
 
   return {
     createMiddleware:
-      (enhancer: ReturnType<Middleware>): ((init: string) => ReturnType<Middleware> | false) =>
+      (enhancer: ReturnType<Middleware>): Middleware =>
       init =>
         init === name && enhancer,
     extractMiddleware,

--- a/packages/component/src/Composer.tsx
+++ b/packages/component/src/Composer.tsx
@@ -5,9 +5,9 @@ import type {
 } from 'botframework-webchat-api';
 import {
   Composer as APIComposer,
+  extractSendBoxMiddleware,
+  extractSendBoxToolbarMiddleware,
   hooks,
-  initSendBoxMiddleware,
-  initSendBoxToolbarMiddleware,
   WebSpeechPonyfillFactory
 } from 'botframework-webchat-api';
 import { DecoratorComposer, type DecoratorMiddleware } from 'botframework-webchat-api/decorator';
@@ -51,8 +51,8 @@ import useTheme from './providers/Theme/useTheme';
 import createDefaultSendBoxMiddleware from './SendBox/createMiddleware';
 import createDefaultSendBoxToolbarMiddleware from './SendBoxToolbar/createMiddleware';
 import createStyleSet from './Styles/createStyleSet';
-import WebChatTheme from './Styles/WebChatTheme';
 import useCustomPropertiesClassName from './Styles/useCustomPropertiesClassName';
+import WebChatTheme from './Styles/WebChatTheme';
 import { type ContextOf } from './types/ContextOf';
 import { type FocusTranscriptInit } from './types/internal/FocusTranscriptInit';
 import addTargetBlankToHyperlinksMarkdown from './Utils/addTargetBlankToHyperlinksMarkdown';
@@ -424,8 +424,8 @@ const InternalComposer = ({
   const sendBoxMiddleware = useMemo<readonly SendBoxMiddleware[]>(
     () =>
       Object.freeze([
-        ...initSendBoxMiddleware(sendBoxMiddlewareFromProps, undefined),
-        ...initSendBoxMiddleware(theme.sendBoxMiddleware, undefined),
+        ...extractSendBoxMiddleware(sendBoxMiddlewareFromProps),
+        ...extractSendBoxMiddleware(theme.sendBoxMiddleware),
         ...createDefaultSendBoxMiddleware()
       ]),
     [sendBoxMiddlewareFromProps, theme.sendBoxMiddleware]
@@ -434,8 +434,8 @@ const InternalComposer = ({
   const sendBoxToolbarMiddleware = useMemo<readonly SendBoxToolbarMiddleware[]>(
     () =>
       Object.freeze([
-        ...initSendBoxToolbarMiddleware(sendBoxToolbarMiddlewareFromProps, undefined),
-        ...initSendBoxToolbarMiddleware(theme.sendBoxToolbarMiddleware, undefined),
+        ...extractSendBoxToolbarMiddleware(sendBoxToolbarMiddlewareFromProps),
+        ...extractSendBoxToolbarMiddleware(theme.sendBoxToolbarMiddleware),
         ...createDefaultSendBoxToolbarMiddleware()
       ]),
     [sendBoxToolbarMiddlewareFromProps, theme.sendBoxToolbarMiddleware]

--- a/packages/component/src/Middleware/ActivityGrouping/createDefaultActivityGroupingDecoratorMiddleware.tsx
+++ b/packages/component/src/Middleware/ActivityGrouping/createDefaultActivityGroupingDecoratorMiddleware.tsx
@@ -1,11 +1,11 @@
-import { activityGroupingMiddleware, type DecoratorMiddleware } from 'botframework-webchat-api/decorator';
+import { createActivityGroupingMiddleware, type DecoratorMiddleware } from 'botframework-webchat-api/decorator';
 import RenderActivityGrouping from './ui/RenderActivityGrouping';
 import SenderGrouping from './ui/SenderGrouping/SenderGrouping';
 import StatusGrouping from './ui/StatusGrouping/StatusGrouping';
 
 export default function createDefaultActivityGroupingDecoratorMiddleware(): readonly DecoratorMiddleware[] {
   return Object.freeze([
-    activityGroupingMiddleware(
+    createActivityGroupingMiddleware(
       () =>
         ({ groupingName }) =>
           groupingName === 'sender'

--- a/packages/component/src/Middleware/ActivityGrouping/createDefaultActivityGroupingDecoratorMiddleware.tsx
+++ b/packages/component/src/Middleware/ActivityGrouping/createDefaultActivityGroupingDecoratorMiddleware.tsx
@@ -1,22 +1,18 @@
-import {
-  type DecoratorMiddleware,
-  type DecoratorMiddlewareInit,
-  type DecoratorMiddlewareTypes
-} from 'botframework-webchat-api/decorator';
+import { activityGroupingMiddleware, type DecoratorMiddleware } from 'botframework-webchat-api/decorator';
 import RenderActivityGrouping from './ui/RenderActivityGrouping';
 import SenderGrouping from './ui/SenderGrouping/SenderGrouping';
 import StatusGrouping from './ui/StatusGrouping/StatusGrouping';
 
 export default function createDefaultActivityGroupingDecoratorMiddleware(): readonly DecoratorMiddleware[] {
   return Object.freeze([
-    (init: DecoratorMiddlewareInit) =>
-      init === 'activity grouping' &&
-      ((() =>
+    activityGroupingMiddleware(
+      () =>
         ({ groupingName }) =>
           groupingName === 'sender'
             ? SenderGrouping
             : groupingName === 'status'
               ? StatusGrouping
-              : RenderActivityGrouping) satisfies DecoratorMiddlewareTypes['activity grouping'])
+              : RenderActivityGrouping
+    )
   ]);
 }

--- a/packages/component/src/decorator/private/WebChatDecorator.tsx
+++ b/packages/component/src/decorator/private/WebChatDecorator.tsx
@@ -3,8 +3,10 @@ import {
   DecoratorComposer,
   type DecoratorMiddleware
 } from 'botframework-webchat-api/decorator';
-import React, { memo, type ReactNode } from 'react';
+import React, { memo } from 'react';
+import { object, optional, pipe, readonly, type InferInput } from 'valibot';
 
+import { reactNode, validateProps } from 'botframework-webchat-react-valibot';
 import BorderFlair from './BorderFlair';
 import BorderLoader from './BorderLoader';
 import WebChatTheme from './WebChatTheme';
@@ -18,11 +20,18 @@ const middleware: readonly DecoratorMiddleware[] = Object.freeze([
   )
 ]);
 
-type WebChatDecoratorProps = Readonly<{
-  readonly children?: ReactNode | undefined;
-}>;
+const webChatDecoratorPropsSchema = pipe(
+  object({
+    children: optional(reactNode())
+  }),
+  readonly()
+);
 
-function WebChatDecorator({ children }: WebChatDecoratorProps) {
+type WebChatDecoratorProps = InferInput<typeof webChatDecoratorPropsSchema>;
+
+function WebChatDecorator(props: WebChatDecoratorProps) {
+  const { children } = validateProps(webChatDecoratorPropsSchema, props);
+
   return (
     <WebChatTheme>
       <DecoratorComposer middleware={middleware}>{children}</DecoratorComposer>
@@ -31,4 +40,4 @@ function WebChatDecorator({ children }: WebChatDecoratorProps) {
 }
 
 export default memo(WebChatDecorator);
-export { type WebChatDecoratorProps };
+export { webChatDecoratorPropsSchema, type WebChatDecoratorProps };

--- a/packages/component/src/decorator/private/WebChatDecorator.tsx
+++ b/packages/component/src/decorator/private/WebChatDecorator.tsx
@@ -1,4 +1,8 @@
-import { DecoratorComposer, type DecoratorMiddleware } from 'botframework-webchat-api/decorator';
+import {
+  createActivityBorderMiddleware,
+  DecoratorComposer,
+  type DecoratorMiddleware
+} from 'botframework-webchat-api/decorator';
 import React, { memo, type ReactNode } from 'react';
 
 import BorderFlair from './BorderFlair';
@@ -6,12 +10,12 @@ import BorderLoader from './BorderLoader';
 import WebChatTheme from './WebChatTheme';
 
 const middleware: readonly DecoratorMiddleware[] = Object.freeze([
-  init =>
-    init === 'activity border' &&
-    (next => request => (request.livestreamingState === 'completing' ? BorderFlair : next(request))),
-  init =>
-    init === 'activity border' &&
-    (next => request => (request.livestreamingState === 'preparing' ? BorderLoader : next(request)))
+  createActivityBorderMiddleware(
+    next => request => (request.livestreamingState === 'completing' ? BorderFlair : next(request))
+  ),
+  createActivityBorderMiddleware(
+    next => request => (request.livestreamingState === 'preparing' ? BorderLoader : next(request))
+  )
 ]);
 
 type WebChatDecoratorProps = Readonly<{

--- a/packages/component/src/decorator/private/WebChatDecorator.tsx
+++ b/packages/component/src/decorator/private/WebChatDecorator.tsx
@@ -3,10 +3,10 @@ import {
   DecoratorComposer,
   type DecoratorMiddleware
 } from 'botframework-webchat-api/decorator';
+import { reactNode, validateProps } from 'botframework-webchat-react-valibot';
 import React, { memo } from 'react';
 import { object, optional, pipe, readonly, type InferInput } from 'valibot';
 
-import { reactNode, validateProps } from 'botframework-webchat-react-valibot';
 import BorderFlair from './BorderFlair';
 import BorderLoader from './BorderLoader';
 import WebChatTheme from './WebChatTheme';

--- a/packages/fluent-theme/src/private/FluentThemeProvider.tsx
+++ b/packages/fluent-theme/src/private/FluentThemeProvider.tsx
@@ -1,9 +1,8 @@
 import { type ActivityMiddleware, type StyleOptions, type TypingIndicatorMiddleware } from 'botframework-webchat-api';
 import {
+  activityBorderMiddleware,
   DecoratorComposer,
-  DecoratorMiddleware,
-  type DecoratorMiddlewareInit,
-  type DecoratorMiddlewareTypes
+  type DecoratorMiddleware
 } from 'botframework-webchat-api/decorator';
 import { Components } from 'botframework-webchat-component';
 import { WebChatDecorator } from 'botframework-webchat-component/decorator';
@@ -54,12 +53,9 @@ const activityMiddleware: readonly ActivityMiddleware[] = Object.freeze([
 const sendBoxMiddleware = [() => () => () => PrimarySendBox];
 
 const decoratorMiddleware: readonly DecoratorMiddleware[] = Object.freeze([
-  (init: DecoratorMiddlewareInit) =>
-    init === 'activity border' &&
-    ((next => request =>
-      request.livestreamingState === 'preparing'
-        ? ActivityLoader
-        : next(request)) satisfies DecoratorMiddlewareTypes['activity border'])
+  activityBorderMiddleware(
+    next => request => (request.livestreamingState === 'preparing' ? ActivityLoader : next(request))
+  )
 ]);
 
 const styles = createStyles('fluent-theme');

--- a/packages/fluent-theme/src/private/FluentThemeProvider.tsx
+++ b/packages/fluent-theme/src/private/FluentThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { type ActivityMiddleware, type StyleOptions, type TypingIndicatorMiddleware } from 'botframework-webchat-api';
 import {
-  activityBorderMiddleware,
+  createActivityBorderMiddleware,
   DecoratorComposer,
   type DecoratorMiddleware
 } from 'botframework-webchat-api/decorator';
@@ -53,7 +53,7 @@ const activityMiddleware: readonly ActivityMiddleware[] = Object.freeze([
 const sendBoxMiddleware = [() => () => () => PrimarySendBox];
 
 const decoratorMiddleware: readonly DecoratorMiddleware[] = Object.freeze([
-  activityBorderMiddleware(
+  createActivityBorderMiddleware(
     next => request => (request.livestreamingState === 'preparing' ? ActivityLoader : next(request))
   )
 ]);


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog Entry

### Breaking changes

- The following middleware should be created using their respective factory functions:
   - `activityBorderDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
   - `activityGroupingDecoratorMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
   - `sendBoxMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
   - `sendBoxToolbarMiddleware`, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)

### Added

- Added `sendBoxMiddleware` and `sendBoxToolbarMiddleware`, by [@compulim](https://github.com/compulim), in PR [#5120](https://github.com/microsoft/BotFramework-WebChat/pull/5120) and [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)
   - Instead of passing barebone middleware, use the `createSendBoxMiddleware` and `createSendBoxToolbarMiddleware` correspondingly, related to PR [#5504](https://github.com/microsoft/BotFramework-WebChat/pull/5504)

## Description

Clean up middleware signature to prepare for poly-middleware.

Eventually, we will unite all middleware signature to the following format.

```ts
const someMiddleware: Middleware<Request, Props> = 
  (init: string) => 
    (next: Enhancer<Request>) => 
      (request: Request) =>
        next(request) satisfies ComponentType<Props>;
```

## Design

### Introduction of `createXXXMiddleware`

Narrowing and guarding function overloading is still weak in TypeScript. Until they improve it, we need a "wrapping function" to make middleware typed properly.

We cannot do use first argument to differentiate the type of return value.

```ts
interface SomeFunction {
  (type: 'n'): number;
  (type: 's'): string;
}
```

We will also leverage the `createXXXMiddleware` for backward/forward compatibility.

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- Cleaned up decorator middleware typing
   - Removed unnecessary typing and their exports
   - `init` will always be a string, only `Request` and `Props` are customizable
   - Added new `createActivityBorderMiddleware()`, `createActivityGroupingMiddleware()`, `createSendBoxMiddleware()` and `createSendBoxToolbarMiddleware()` helper functions to wrap their decorator middleware correspondingly
- Updated `templateMiddleware`
   - New typing helper `Infer*<typeof template>` to infer from `template['~types']`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
