### PR TITLE
Fix: core internal import in CJS legacy envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 
 - Deprecating `disabled` props and `useDisabled` hook in favor of new `uiState` props and `useUIState` hook, in PR [#5276](https://github.com/microsoft/BotFramework-WebChat/pull/5276), by [@compulim](https://github.com/compulim)
 - `useSuggestedActions()` hook is being deprecated in favor of the `useSuggestedActionsHooks().useSuggestedActions()` hook, in PR [#5489](https://github.com/microsoft/BotFramework-WebChat/pull/5489), by [@compulim](https://github.com/compulim)
+- Fixed core internal import in legacy CommonJS environments, in [5509](https://github.com/microsoft/BotFramework-WebChat/pull/5509), by [@OEvgeny](https://github.com/OEvgeny)
 
 ## [4.18.0] - 2024-07-10
 

--- a/packages/core/internal.js
+++ b/packages/core/internal.js
@@ -1,0 +1,3 @@
+// This is required for Webpack 4 which does not support named exports.
+// eslint-disable-next-line no-undef
+module.exports = require('./dist/botframework-webchat-core.internal.js');


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

-  Fixed core internal import in legacy CommonJS environments, in [5509](https://github.com/microsoft/BotFramework-WebChat/pull/5509), by [@OEvgeny](https://github.com/OEvgeny)

## Description

This adds missing files to the `core` npm package, so the `internal` module can be properly located in environments lacking `exports` field support.


## Specific Changes

- Fixed files field to include top level js files

## -

-

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [x] Browser and platform compatibilities reviewed
-  [x] CSS styles reviewed (minimal rules, no `z-index`)
-  [x] Documents reviewed (docs, samples, live demo)
-  [x] Internationalization reviewed (strings, unit formatting)
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] Security reviewed (no data URIs, check for nonce leak)
-  [x] Tests reviewed (coverage, legitimacy)
