### PR TITLE
Remove `@tsconfig/strictest` from unnecessary packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20669,7 +20669,6 @@
         "@msinternal/botframework-webchat-base": "0.0.0-0",
         "@msinternal/botframework-webchat-react-hooks": "^0.0.0-0",
         "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^22.13.4",
         "cross-env": "^7.0.3",
         "type-fest": "^4.34.1",
@@ -20979,7 +20978,6 @@
       "license": "MIT",
       "devDependencies": {
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^24.1.0",
         "core-js-pure": "^3.44.0",
         "cross-env": "^10.0.0",
@@ -21915,7 +21913,6 @@
         "@msinternal/botframework-webchat-base": "0.0.0-0",
         "@msinternal/botframework-webchat-styles": "0.0.0-0",
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/math-random": "^1.0.2",
         "@types/node": "^24.1.0",
         "@types/react": "^16.14.65",
@@ -21996,7 +21993,6 @@
       },
       "devDependencies": {
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/jest": "^30.0.0",
         "@types/react": "^16.14.65",
         "tsup": "^8.5.0",
@@ -22241,7 +22237,6 @@
       "devDependencies": {
         "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/react": "^16.14.65",
         "tsup": "^8.5.0",
         "typescript": "~5.8.3"
@@ -22258,7 +22253,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.4",
         "@msinternal/botframework-webchat-base": "0.0.0-0",
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^24.1.0",
         "cross-env": "^10.0.0",
         "esbuild": "^0.25.8",

--- a/packages/api-middleware/package.json
+++ b/packages/api-middleware/package.json
@@ -79,7 +79,6 @@
     "@msinternal/botframework-webchat-base": "0.0.0-0",
     "@msinternal/botframework-webchat-react-hooks": "^0.0.0-0",
     "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.13.4",
     "cross-env": "^7.0.3",
     "type-fest": "^4.34.1",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -66,7 +66,6 @@
   },
   "devDependencies": {
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^24.1.0",
     "core-js-pure": "^3.44.0",
     "cross-env": "^10.0.0",

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -72,7 +72,6 @@
     "@msinternal/botframework-webchat-base": "0.0.0-0",
     "@msinternal/botframework-webchat-styles": "0.0.0-0",
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/math-random": "^1.0.2",
     "@types/node": "^24.1.0",
     "@types/react": "^16.14.65",

--- a/packages/react-valibot/package.json
+++ b/packages/react-valibot/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/jest": "^30.0.0",
     "@types/react": "^16.14.65",
     "tsup": "^8.5.0",

--- a/packages/redux-store/package.json
+++ b/packages/redux-store/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/react": "^16.14.65",
     "tsup": "^8.5.0",
     "typescript": "~5.8.3"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -82,7 +82,6 @@
     "@jridgewell/sourcemap-codec": "^1.5.4",
     "@msinternal/botframework-webchat-base": "0.0.0-0",
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^24.1.0",
     "cross-env": "^10.0.0",
     "esbuild": "^0.25.8",


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

(No changelog for non-production-impacting changes.)

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

As we introduced `@msinternal/botframework-webchat-tsconfig` package, we no longer need `@tsconfig/strictest` in individual packages. We will configure it through the new package.

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- Remove `@tsconfig/strictest` dependencies from all packages except `@msinternal/botframework-webchat-tsconfig`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
