### PR TITLE
Use exact version for `react-chain-of-responsibility`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 - Fixed [#5520](https://github.com/microsoft/BotFramework-WebChat/issues/5520). Version information should be injected when installed via npm, in PR [#5521](https://github.com/microsoft/BotFramework-WebChat/pull/5521), by [@compulim](https://github.com/compulim)
 - Fixed aria-label only announcing placeholder in feedback form, in PR [#5567](https://github.com/microsoft/BotFramework-WebChat/pull/5567)
 - Fixed placing focus on the code block content, so it is possible to scroll code via keyboard, in PR [#5575](https://github.com/microsoft/BotFramework-WebChat/pull/5575), by [@OEvgeny](https://github.com/OEvgeny)
+- Fixed [#5581](https://github.com/microsoft/BotFramework-WebChat/issues/5581). Activities should be displayed after upgrading via `npm install`, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX), by [@compulim](https://github.com/compulim)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,7 +301,7 @@ Notes: web developers are advised to use [`~` (tilde range)](https://github.com/
 - Fixed [#5520](https://github.com/microsoft/BotFramework-WebChat/issues/5520). Version information should be injected when installed via npm, in PR [#5521](https://github.com/microsoft/BotFramework-WebChat/pull/5521), by [@compulim](https://github.com/compulim)
 - Fixed aria-label only announcing placeholder in feedback form, in PR [#5567](https://github.com/microsoft/BotFramework-WebChat/pull/5567)
 - Fixed placing focus on the code block content, so it is possible to scroll code via keyboard, in PR [#5575](https://github.com/microsoft/BotFramework-WebChat/pull/5575), by [@OEvgeny](https://github.com/OEvgeny)
-- Fixed [#5581](https://github.com/microsoft/BotFramework-WebChat/issues/5581). Activities should be displayed after upgrading via `npm install`, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX), by [@compulim](https://github.com/compulim)
+- Fixed [#5581](https://github.com/microsoft/BotFramework-WebChat/issues/5581). Activities should be displayed after upgrading via `npm install`, in PR [#5582](https://github.com/microsoft/BotFramework-WebChat/pull/5582), by [@compulim](https://github.com/compulim)
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20616,7 +20616,7 @@
         "iter-fest": "0.3.0",
         "math-random": "2.0.1",
         "prop-types": "15.8.1",
-        "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+        "react-chain-of-responsibility": "0.4.0-main.c2f17da",
         "react-redux": "7.2.9",
         "redux": "5.0.1",
         "simple-update-in": "2.2.0",
@@ -20660,7 +20660,7 @@
       "license": "MIT",
       "dependencies": {
         "handler-chain": "^0.1.0",
-        "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+        "react-chain-of-responsibility": "0.4.0-main.c2f17da",
         "react-wrap-with": "0.1.0",
         "valibot": "1.1.0"
       },
@@ -21246,7 +21246,7 @@
         "merge-refs": "2.0.0",
         "prop-types": "15.8.1",
         "punycode": "2.3.1",
-        "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+        "react-chain-of-responsibility": "0.4.0-main.c2f17da",
         "react-dictate-button": "4.0.0",
         "react-film": "4.0.0",
         "react-redux": "7.2.9",

--- a/packages/api-middleware/package.json
+++ b/packages/api-middleware/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "handler-chain": "^0.1.0",
-    "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react-wrap-with": "0.1.0",
     "valibot": "1.1.0"
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -135,7 +135,7 @@
     "iter-fest": "0.3.0",
     "math-random": "2.0.1",
     "prop-types": "15.8.1",
-    "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react-redux": "7.2.9",
     "redux": "5.0.1",
     "simple-update-in": "2.2.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -137,7 +137,7 @@
     "merge-refs": "2.0.0",
     "prop-types": "15.8.1",
     "punycode": "2.3.1",
-    "react-chain-of-responsibility": "^0.4.0-main.c2f17da",
+    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react-dictate-button": "4.0.0",
     "react-film": "4.0.0",
     "react-redux": "7.2.9",


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #5581.

## Changelog Entry

### Fixed

- Fixed [#5581](https://github.com/microsoft/BotFramework-WebChat/issues/5581). Activities should be displayed after upgrading via `npm install`, in PR [#XXX](https://github.com/microsoft/BotFramework-WebChat/pull/XXX), by [@compulim](https://github.com/compulim)

## Description

Newer version of `react-chain-of-responsibility` introduced support of wrapper component.

However, due to caret versioning, when upgrading via `npm install`, the latest version of `react-chain-of-responsibility` is not installed. Thus, wrapper component support is missing, cause `<ErrorBoundary>` not to be rendered.

Tests did not catch the problem because pipeline always run with fresh install.

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- `npm install react-chain-of-responsibility@main --save-exact`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
