### PR TITLE
Fix npm start

### DIFF
--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -67,7 +67,7 @@
     "precommit:eslint": "../../node_modules/.bin/eslint --report-unused-disable-directives --max-warnings 0",
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
-    "start": "npm run build -- --watch"
+    "start": "npm run build:tsup -- --watch"
   },
   "localDependencies": {
     "@msinternal/botframework-webchat-base": "development",

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -50,7 +50,7 @@
     "precommit:eslint": "../../node_modules/.bin/eslint --report-unused-disable-directives --max-warnings 0",
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
-    "start": "npm run build -- --watch"
+    "start": "npm run build:tsup -- --watch"
   },
   "localDependencies": {
     "@msinternal/botframework-webchat-tsconfig": "development",


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description

`npm start` is broken after PR #5584. This PR is fixing it.

If `npm run build:validate` exited, it will exit everything in `npm start`, causing `npm start` to stop.

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- `npm start` runs `npm run build:tsup` only

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] ~I have added tests and executed them locally~
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] `package.json` and `package-lock.json` reviewed
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] ~Tests reviewed (coverage, legitimacy)~
