### PR TITLE
feat: Add ref API to Composer for programmatic send box focus

### DIFF
--- a/packages/bundle/src/FullComposer.tsx
+++ b/packages/bundle/src/FullComposer.tsx
@@ -1,28 +1,27 @@
 import { Components } from 'botframework-webchat-component';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import AddFullBundle from './AddFullBundle';
 
 import type { AddFullBundleProps } from './AddFullBundle';
-import type { ComposerProps } from 'botframework-webchat-component';
-import type { FC } from 'react';
+import type { ComposerProps, ComposerRef } from 'botframework-webchat-component';
 
 const { Composer } = Components;
 
 type FullComposerProps = ComposerProps & AddFullBundleProps;
 
-const FullComposer: FC<FullComposerProps> = props => (
+const FullComposer = forwardRef<ComposerRef, FullComposerProps>((props, ref) => (
   <AddFullBundle {...props}>
     {extraProps => (
-      <Composer {...props} {...extraProps}>
-        {/* We need to spread, thus, we cannot we destructuring assignment. */}
-        {/* eslint-disable-next-line react/destructuring-assignment */}
+      <Composer ref={ref} {...props} {...extraProps}>
         {props.children}
       </Composer>
     )}
   </AddFullBundle>
-);
+));
+
+FullComposer.displayName = 'FullComposer';
 
 FullComposer.defaultProps = {
   ...Composer.defaultProps,
@@ -40,4 +39,4 @@ FullComposer.propTypes = {
 
 export default FullComposer;
 
-export type { FullComposerProps };
+export type { FullComposerProps, ComposerRef };

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -98,6 +98,7 @@ export {
 };
 
 export type { StyleOptions, StrictStyleOptions };
+export type { ComposerRef } from './FullComposer';
 
 window['WebChat'] = {
   ...window['WebChat'],

--- a/packages/component/src/index.ts
+++ b/packages/component/src/index.ts
@@ -2,7 +2,7 @@ import { concatMiddleware, hooks as apiHooks, localize } from 'botframework-webc
 
 import ReactWebChat, { ReactWebChatProps } from './ReactWebChat';
 
-import Composer, { ComposerProps } from './Composer';
+import Composer, { ComposerProps, ComposerRef } from './Composer';
 
 import AccessKeySinkSurface from './Utils/AccessKeySink/Surface';
 
@@ -118,4 +118,4 @@ export {
   withEmoji
 };
 
-export type { BasicWebChatProps, ComposerProps, ReactWebChatProps };
+export type { BasicWebChatProps, ComposerProps, ComposerRef, ReactWebChatProps };


### PR DESCRIPTION
- Add forwardRef wrapper to Composer component
- Expose focusSendBoxInput() method via ComposerRef
- Export ComposerRef type for TypeScript consumers
- Forward ref through FullComposer in bundle package
- Leverages existing useFocus('sendBox') infrastructure
- Returns Promise<void> for async focus handling

<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Design

<!-- If this feature is complicated in nature, please provide additional clarifications. -->

## Specific Changes

<!-- Please list the changes in a concise manner. -->

## -

-

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [ ] I have added tests and executed them locally
-  [ ] I have updated `CHANGELOG.md`
-  [ ] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
