### PR TITLE
feat: bundle internal packages types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "cross-env": "^10.0.0",
         "diff": "^8.0.2",
         "dotenv": "^17.2.1",
+        "dtsroll": "^1.4.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -3332,6 +3333,67 @@
       "version": "1.2.1",
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.2.tgz",
+      "integrity": "sha512-tCtHJ2BlhSoK4cCs25NMXfV7EALKr0jyasmqVCq3y9cBrKdmJhtsy1iTz36Xhk/O+pDJbzawxF4K6ZblqCnITQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.46.2",
       "cpu": [
@@ -3817,6 +3879,13 @@
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
@@ -5442,6 +5511,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/byte-size": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-9.0.1.tgz",
+      "integrity": "sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "dev": true,
@@ -5834,6 +5921,20 @@
     },
     "node_modules/cldrjs": {
       "version": "0.5.5"
+    },
+    "node_modules/cleye": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/cleye/-/cleye-1.3.4.tgz",
+      "integrity": "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "terminal-columns": "^1.4.1",
+        "type-flag": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/cleye?sponsor=1"
+      }
     },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
@@ -6794,6 +6895,38 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dtsroll": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dtsroll/-/dtsroll-1.4.1.tgz",
+      "integrity": "sha512-Ih6dWLx/6DGpPMIODGzaeGYYW/L/A4bAk0/5j+XPKYQ9D2vHKyDZt86GaKCAjd2uhLDwHrr4HwGzoBzdl0EQ2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "byte-size": "^9.0.1",
+        "cleye": "^1.3.2",
+        "rollup": "^4.29.1",
+        "rollup-plugin-dts": "6.1.1"
+      },
+      "bin": {
+        "dtsroll": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/dtsroll?sponsor=1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.5 || ^5.0",
+        "vite": "5 || 6"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/dunder-proto": {
@@ -7931,6 +8064,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -9671,6 +9811,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -15178,6 +15325,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+      "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "magic-string": "^0.30.10"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.24.2"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "dev": true,
@@ -16584,6 +16754,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/terminal-columns": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/terminal-columns/-/terminal-columns-1.4.1.tgz",
+      "integrity": "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/terminal-columns?sponsor=1"
+      }
+    },
     "node_modules/terser": {
       "version": "5.39.0",
       "dev": true,
@@ -17149,6 +17329,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
+      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/type-flag?sponsor=1"
       }
     },
     "node_modules/type-is": {
@@ -18428,7 +18618,6 @@
         "@types/dom-speech-recognition": "^0.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.1.0",
-        "@types/react": "^16.14.65",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "core-js": "^3.44.0",
@@ -18440,6 +18629,7 @@
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
+        "@types/react": "^16.14.65",
         "react": ">= 16.8.6",
         "react-dom": ">= 16.8.6"
       }
@@ -18450,7 +18640,6 @@
       "license": "MIT",
       "dependencies": {
         "handler-chain": "^0.1.0",
-        "react-chain-of-responsibility": "0.4.0-main.c2f17da",
         "react-wrap-with": "0.1.0",
         "valibot": "1.1.0"
       },
@@ -18465,7 +18654,8 @@
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "react": ">= 16.8.6"
+        "react": ">= 16.8.6",
+        "react-chain-of-responsibility": "0.4.0-main.c2f17da"
       }
     },
     "packages/api-middleware/node_modules/@types/node": {
@@ -18901,6 +19091,7 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.6",
+        "react-chain-of-responsibility": "0.4.0-main.c2f17da",
         "react-dom": ">= 16.8.6"
       }
     },
@@ -19049,7 +19240,6 @@
         "@types/jest": "^30.0.0",
         "@types/mdast": "^4.0.4",
         "@types/node": "^24.1.0",
-        "@types/react": "^16.14.65",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "core-js": "^3.44.0",
@@ -19058,6 +19248,7 @@
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
+        "@types/react": "^16.14.65",
         "react": ">= 16.8.6",
         "react-dom": ">= 16.8.6"
       }
@@ -19750,11 +19941,11 @@
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
         "@types/math-random": "^1.0.2",
         "@types/node": "^24.1.0",
-        "@types/react": "^16.14.65",
         "tsup": "^8.5.0",
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
+        "@types/react": "^16.14.65",
         "react": ">= 16.8.6"
       }
     },
@@ -19806,18 +19997,16 @@
       "name": "@msinternal/botframework-webchat-react-valibot",
       "version": "0.0.0-0",
       "license": "MIT",
-      "dependencies": {
-        "valibot": "1.1.0"
-      },
       "devDependencies": {
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
         "@types/jest": "^30.0.0",
-        "@types/react": "^16.14.65",
         "tsup": "^8.5.0",
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
-        "react": ">= 16.8.6"
+        "@types/react": "^16.14.65",
+        "react": ">= 16.8.6",
+        "valibot": "1.1.0"
       }
     },
     "packages/react-valibot/node_modules/@jest/expect-utils": {
@@ -20090,11 +20279,11 @@
       "devDependencies": {
         "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
         "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-        "@types/react": "^16.14.65",
         "tsup": "^8.5.0",
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
+        "@types/react": "^16.14.65",
         "react": ">= 16.8.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
     "cross-env": "^10.0.0",
     "diff": "^8.0.2",
     "dotenv": "^17.2.1",
+    "dtsroll": "^1.4.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/packages/api-middleware/legacy.js
+++ b/packages/api-middleware/legacy.js
@@ -1,3 +1,0 @@
-// This is required for Webpack 4 which does not support named exports.
-// eslint-disable-next-line no-undef
-module.exports = require('./dist/botframework-webchat-api-middleware.legacy.js');

--- a/packages/api-middleware/package.json
+++ b/packages/api-middleware/package.json
@@ -85,11 +85,11 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
+    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react": ">= 16.8.6"
   },
   "dependencies": {
     "handler-chain": "^0.1.0",
-    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react-wrap-with": "0.1.0",
     "valibot": "1.1.0"
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,9 +75,12 @@
   ],
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/component#readme",
   "scripts": {
-    "build": "npm run build:globalize && npm run build:tsup",
+    "build": "npm run build:globalize && npm run build:tsup && npm run build:dtsroll && npm run build:validate",
     "build:globalize": "node scripts/createPrecompiledGlobalize.mjs",
     "build:tsup": "tsup",
+    "build:dtsroll": "dtsroll ./dist/*.d.*",
+    "build:validate": "npm run build:validate:dts",
+    "build:validate:dts": "if grep -q -P '@msinternal\\/' dist/*.d.* 2>/dev/null; then echo \"Error: dist/*.d.* is not compiled by dtsroll\" >&2; exit 1; fi",
     "bump": "npm run bump:prod && npm run bump:dev && (npm audit fix || exit 0)",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install --save-exact $PACKAGES_TO_BUMP || true",
@@ -128,7 +131,6 @@
     "@types/dom-speech-recognition": "^0.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.1.0",
-    "@types/react": "^16.14.65",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "core-js": "^3.44.0",
@@ -153,6 +155,7 @@
     "valibot": "1.1.0"
   },
   "peerDependencies": {
+    "@types/react": "^16.14.65",
     "react": ">= 16.8.6",
     "react-dom": ">= 16.8.6"
   }

--- a/packages/base/utils.js
+++ b/packages/base/utils.js
@@ -1,3 +1,0 @@
-// This is required for Webpack 4 which does not support named exports.
-// eslint-disable-next-line no-undef
-module.exports = require('./dist/botframework-webchat-base.utils.js');

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -97,9 +97,12 @@
     }
   },
   "scripts": {
-    "build": "npm run build:static && npm run build:tsup",
+    "build": "npm run build:static && npm run build:tsup && npm run build:dtsroll && npm run build:validate",
     "build:static": "node ./esbuild.static.mjs",
     "build:tsup": "tsup",
+    "build:dtsroll": "dtsroll ./dist/*.d.*",
+    "build:validate": "npm run build:validate:dts",
+    "build:validate:dts": "if grep -q -P '@msinternal\\/' dist/*.d.* 2>/dev/null; then echo \"Error: dist/*.d.* is not compiled by dtsroll\" >&2; exit 1; fi",
     "bump": "npm run bump:prod && npm run bump:dev && (npm audit fix || exit 0)",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install --save-exact $PACKAGES_TO_BUMP || true",
@@ -236,6 +239,7 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
+    "react-chain-of-responsibility": "0.4.0-main.c2f17da",
     "react": ">= 16.8.6",
     "react-dom": ">= 16.8.6"
   }

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -75,9 +75,12 @@
   ],
   "homepage": "https://github.com/microsoft/BotFramework-WebChat/tree/main/packages/component#readme",
   "scripts": {
-    "build": "npm run build:tsup && npm run build:validate",
+    "build": "npm run build:tsup && build:dtsroll && npm run build:validate",
     "build:tsup": "tsup",
-    "build:validate": "grep -q -P '\\.webchat \\.w([a-zA-Z-]){6}_' dist/*.css 2>/dev/null || { echo \"Error: dist/*.css is not compiled by Lightning CSS\" >&2; exit 1; }",
+    "build:dtsroll": "dtsroll ./dist/*.d.*",
+    "build:validate": "npm run build:validate:css && npm run build:validate:dts",
+    "build:validate:css": "grep -q -P '\\.webchat \\.w([a-zA-Z-]){6}_' dist/*.css 2>/dev/null || { echo \"Error: dist/*.css is not compiled by Lightning CSS\" >&2; exit 1; }",
+    "build:validate:dts": "if grep -q -P '@msinternal\\/' dist/*.d.* 2>/dev/null; then echo \"Error: dist/*.d.* is not compiled by dtsroll\" >&2; exit 1; fi",
     "bump": "npm run bump:prod && npm run bump:dev && (npm audit fix || exit 0)",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install --save-exact $PACKAGES_TO_BUMP || true",
@@ -136,7 +139,6 @@
     "@types/jest": "^30.0.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.1.0",
-    "@types/react": "^16.14.65",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "core-js": "^3.44.0",
@@ -175,6 +177,7 @@
     "valibot": "1.1.0"
   },
   "peerDependencies": {
+    "@types/react": "^16.14.65",
     "react": ">= 16.8.6",
     "react-dom": ">= 16.8.6"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,11 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "npm run build:tsup && npm run build:dtsroll && npm run build:validate",
+    "build:tsup": "tsup",
+    "build:dtsroll": "dtsroll ./dist/*.d.*",
+    "build:validate": "npm run build:validate:dts",
+    "build:validate:dts": "if grep -q -P '@msinternal\\/' dist/*.d.* 2>/dev/null; then echo \"Error: dist/*.d.* is not compiled by dtsroll\" >&2; exit 1; fi",
     "bump": "npm run bump:prod && npm run bump:dev && (npm audit fix || exit 0)",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install --save-exact $PACKAGES_TO_BUMP || true",
@@ -66,7 +70,7 @@
     "precommit:eslint": "../../node_modules/.bin/eslint --report-unused-disable-directives --max-warnings 0",
     "precommit:typecheck": "tsc --project ./src --emitDeclarationOnly false --esModuleInterop true --noEmit --pretty false",
     "preversion": "cat package.json | jq '(.localDependencies // {} | to_entries | map([if .value == \"production\" then \"dependencies\" else \"devDependencies\" end, .key])) as $P | delpaths($P)' > package-temp.json && mv package-temp.json package.json",
-    "start": "npm run build -- --watch 200"
+    "start": "npm run build:tsup -- --watch 200"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -40,10 +40,13 @@
     "static/**/*"
   ],
   "scripts": {
-    "build": "npm run build:static && npm run build:tsup && npm run build:validate",
+    "build": "npm run build:static && npm run build:tsup && npm run build:dtsroll && npm run build:validate",
     "build:static": "node ./esbuild.static.mjs",
     "build:tsup": "tsup",
-    "build:validate": "grep -q -P '\\.webchat-fluent \\.w([a-zA-Z-]){6}_' dist/*.css 2>/dev/null || { echo \"Error: dist/*.css is not compiled by Lightning CSS\" >&2; exit 1; }",
+    "build:dtsroll": "dtsroll ./dist/*.d.*",
+    "build:validate": "npm run build:validate:css && npm run build:validate:dts",
+    "build:validate:css": "grep -q -P '\\.webchat-fluent \\.w([a-zA-Z-]){6}_' dist/*.css 2>/dev/null || { echo \"Error: dist/*.css is not compiled by Lightning CSS\" >&2; exit 1; }",
+    "build:validate:dts": "if grep -q -P '@msinternal\\/' dist/*.d.* 2>/dev/null; then echo \"Error: dist/*.d.* is not compiled by dtsroll\" >&2; exit 1; fi",
     "bump": "npm run bump:prod && npm run bump:dev && (npm audit fix || exit 0)",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localDependencies // {} | keys) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | contains([$K]) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install --save-exact $PACKAGES_TO_BUMP || true",
@@ -75,7 +78,6 @@
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
     "@types/math-random": "^1.0.2",
     "@types/node": "^24.1.0",
-    "@types/react": "^16.14.65",
     "tsup": "^8.5.0",
     "typescript": "~5.8.3"
   },
@@ -88,6 +90,7 @@
     "valibot": "1.1.0"
   },
   "peerDependencies": {
+    "@types/react": "^16.14.65",
     "react": ">= 16.8.6"
   }
 }

--- a/packages/react-valibot/package.json
+++ b/packages/react-valibot/package.json
@@ -2,6 +2,7 @@
   "name": "@msinternal/botframework-webchat-react-valibot",
   "version": "0.0.0-0",
   "description": "The botframework-webchat react-valibot package",
+  "main": "./dist/botframework-webchat-react-valibot.js",
   "types": "./dist/botframework-webchat-react-valibot.d.ts",
   "exports": {
     ".": {
@@ -58,15 +59,12 @@
   "devDependencies": {
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
     "@types/jest": "^30.0.0",
-    "@types/react": "^16.14.65",
     "tsup": "^8.5.0",
     "typescript": "~5.8.3"
   },
-  "dependencies": {
-    "valibot": "1.1.0"
-  },
   "peerDependencies": {
-    "react": ">= 16.8.6"
-  },
-  "main": "index.js"
+    "@types/react": "^16.14.65",
+    "react": ">= 16.8.6",
+    "valibot": "1.1.0"
+  }
 }

--- a/packages/redux-store/package.json
+++ b/packages/redux-store/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@msinternal/botframework-webchat-react-valibot": "^0.0.0-0",
     "@msinternal/botframework-webchat-tsconfig": "^0.0.0-0",
-    "@types/react": "^16.14.65",
     "tsup": "^8.5.0",
     "typescript": "~5.8.3"
   },
@@ -69,6 +68,7 @@
     "valibot": "1.1.0"
   },
   "peerDependencies": {
+    "@types/react": "^16.14.65",
     "react": ">= 16.8.6"
   }
 }


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

- Fix published package types containing internal package references

## Description

This PR adds a layer of bundling for our types as well as an extra validation layer to ensure we do not leak `@msinternal/*` packages type references to the outside.

## Design

As to the date `tsup` does not resolve external package types which is stated in their [docs](https://tsup.egoist.dev/#generate-declaration-file):
> Note that --dts does not resolve external (aka in node_modules) types used in the .d.ts file, if that's somehow a requirement, try the experimental --dts-resolve flag instead.

I've tried the above mentioned experimental `--dts-resolve` flag without any luck. So the only option seems to shop around for the solutions available.
 
The `dtsroll` package is designed to modify generated definition files in place according to the `package.json` definitions.

I shuffled a bit dependencies in the `package.json` files we have, but overall dependencies changes are not needed except for the `bundle` package.

I also removed Webpack 4 legacy entries for internal packages as these packages should be bundled and such entries trip `dtsroll` for some reason.

## Specific Changes

- updated public `package.json` files to include `dtsroll` transform step
- updated public `package.json` files to include validation step

## -

-

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] I have updated `CHANGELOG.md`
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
-  [ ] Browser and platform compatibilities reviewed
-  [ ] CSS styles reviewed (minimal rules, no `z-index`)
-  [ ] Documents reviewed (docs, samples, live demo)
-  [ ] Internationalization reviewed (strings, unit formatting)
-  [ ] `package.json` and `package-lock.json` reviewed
-  [ ] Security reviewed (no data URIs, check for nonce leak)
-  [ ] Tests reviewed (coverage, legitimacy)
