### PR TITLE
Set VRT per-pixel tolerance to 0.06

### DIFF
--- a/__tests__/constants.json
+++ b/__tests__/constants.json
@@ -2,7 +2,7 @@
   "browserName": "chrome-docker",
   "imageSnapshotOptions": {
     "customDiffConfig": {
-      "threshold": 0.05
+      "threshold": 0.06
     },
     "noColors": true
   },

--- a/packages/test/harness/src/host/jest/setupToMatchImageSnapshot.js
+++ b/packages/test/harness/src/host/jest/setupToMatchImageSnapshot.js
@@ -4,7 +4,7 @@ global.expect &&
   global.expect.extend({
     toMatchImageSnapshot: configureToMatchImageSnapshot({
       customDiffConfig: {
-        threshold: 0.05
+        threshold: 0.06
       },
       noColors: true
     })


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

## Changelog Entry

<!-- Please paste your new entry from CHANGELOG.MD here. Entry is not required for work only related to development purposes. -->

(No changelog for test infrastructure change.)

## Description

<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

We recycle Chrome tab during visual regression test for performance reason. However, it seems the recycle would also affect how Chrome render SVGs.

We are increasing tolerance from `0.05` to `0.06` for a pixel change inside the file attach icon.

## Specific Changes

<!-- Please list the changes in a concise manner. -->

- Update per-pixel tolerance to `0.06` from `0.05`

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

-  [x] I have added tests and executed them locally
-  [x] ~I have updated `CHANGELOG.md`~
-  [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

-  [x] ~Accessibility reviewed (tab order, content readability, alt text, color contrast)~
-  [x] ~Browser and platform compatibilities reviewed~
-  [x] ~CSS styles reviewed (minimal rules, no `z-index`)~
-  [x] ~Documents reviewed (docs, samples, live demo)~
-  [x] ~Internationalization reviewed (strings, unit formatting)~
-  [x] ~`package.json` and `package-lock.json` reviewed~
-  [x] ~Security reviewed (no data URIs, check for nonce leak)~
-  [x] Tests reviewed (coverage, legitimacy)
