### PR TITLE
fix(component/ErrorBox): correct 'occured' -> 'occurred' fallback message

### DIFF
--- a/packages/component/src/ErrorBox.tsx
+++ b/packages/component/src/ErrorBox.tsx
@@ -42,7 +42,7 @@ function ErrorBox(props: ErrorBoxProps) {
     if (error instanceof Error) {
       rectifiedError = error;
     } else {
-      rectifiedError = new Error('Unknown error occured');
+      rectifiedError = new Error('Unknown error occurred');
       rectifiedError.cause = error;
     }
 


### PR DESCRIPTION
The fallback `Error` rectifier in `packages/component/src/ErrorBox.tsx:45` constructed `new Error('Unknown error occured')` when the source error was a non-Error value. The message ends up rendered to end users in the WebChat error box. String-literal-only change.