### PR TITLE
fix: make streaming parser more stable and add a fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ Breaking changes in this release:
 - Added Speech-to-Speech (S2S) support for real-time voice conversations, in PR [#5654](https://github.com/microsoft/BotFramework-WebChat/pull/5654), by [@pranavjoshi](https://github.com/pranavjoshi001)
 - Added core mute/unmute functionality for speech-to-speech via `useRecorder` hook (silent chunks keep server connection alive), in PR [#5688](https://github.com/microsoft/BotFramework-WebChat/pull/5688), by [@pranavjoshi](https://github.com/pranavjoshi001)
 - 🧪 Added incremental streaming Markdown renderer for livestreaming, in PR [#5799](https://github.com/microsoft/BotFramework-WebChat/pull/5799), by [@OEvgeny](https://github.com/OEvgeny)
+   - Fixed streaming Markdown renderer to preserve link reference definitions during incremental rendering and recover on error, in PR [#5808](https://github.com/microsoft/BotFramework-WebChat/pull/5808), by [@OEvgeny](https://github.com/OEvgeny)
 
 ### Changed
 

--- a/packages/bundle/src/markdown/createStreamingRenderer.spec.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.spec.ts
@@ -1,7 +1,7 @@
 /** @jest-environment @happy-dom/jest-environment */
 /// <reference types="jest" />
 
-import createStreamingRenderer from './createStreamingRenderer';
+import createStreamingRenderer, { STREAMING_ERROR } from './createStreamingRenderer';
 
 const OPTIONS: Parameters<typeof createStreamingRenderer>[0] = {
   markdownRespectCRLF: false
@@ -11,12 +11,16 @@ const INIT: Parameters<typeof createStreamingRenderer>[1] = {
   externalLinkAlt: 'Opens in a new window'
 };
 
+let currentContainer: HTMLElement | null = null;
+
 function setup() {
   const container = document.createElement('div');
 
   document.body.appendChild(container);
 
   const renderer = createStreamingRenderer(OPTIONS, INIT);
+
+  currentContainer = container;
 
   const nextOptions = () => ({ container });
 
@@ -77,6 +81,25 @@ function splitBySentinel(container: HTMLElement): [string, string] | null {
 }
 
 describe('createStreamingRenderer', () => {
+  afterEach(() => {
+    if (!currentContainer) {
+      return;
+    }
+
+    const wrapper = currentContainer.firstElementChild as HTMLElement | null;
+
+    // eslint-disable-next-line security/detect-object-injection
+    if (wrapper[STREAMING_ERROR]) {
+      // eslint-disable-next-line security/detect-object-injection
+      console.warn('Streaming renderer error gonna fail the test:', wrapper[STREAMING_ERROR]);
+    }
+
+    expect(wrapper?.dataset.renderError).toBeUndefined();
+    expect(wrapper?.dataset.renderErrorCount).toBeUndefined();
+
+    currentContainer = null;
+  });
+
   describe('single block', () => {
     test('should render a paragraph without sentinel', () => {
       const { container, nextOptions, renderer } = setup();
@@ -110,6 +133,21 @@ describe('createStreamingRenderer', () => {
       expect(split).not.toBeNull();
       expect(split![0]).toBe('<p>First paragraph</p>');
       expect(split![1]).toBe('<p>Second paragraph</p>');
+    });
+
+    test('should extract link definitions during full reparse path', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('See [link][1]\n\n[1]: https://example.com "Example"', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+      expect(container.querySelector('a[href="https://example.com"]')?.textContent).toBe('link');
+
+      const { definitions } = renderer.finalize(nextOptions());
+
+      expect(definitions).toEqual([
+        expect.objectContaining({ identifier: '1', url: 'https://example.com', title: 'Example' })
+      ]);
     });
 
     test('should preserve newline between paragraphs in textContent', () => {
@@ -222,6 +260,21 @@ describe('createStreamingRenderer', () => {
       expect(split2![1]).toBe('<p>Partial more text</p>');
     });
 
+    test('should resolve active references using committed definitions during active growth', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('First paragraph\n\n[1]: https://example.com "Example"\n\nSecond [link', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+      expect(container.querySelector('a[href="https://example.com"]')).toBeNull();
+
+      renderer.next('][1]', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+
+      expect(container.querySelector('a[href="https://example.com"]')?.textContent).toBe('link');
+    });
+
     test('should commit additional blocks during incremental streaming', () => {
       const { container, nextOptions, renderer } = setup();
 
@@ -241,6 +294,126 @@ describe('createStreamingRenderer', () => {
       expect(split2![0]).toContain('Block A');
       expect(split2![0]).toContain('Block B');
       expect(split2![1]).toBe('<p>Block C</p>');
+    });
+
+    test('should keep incremental split when committed block references a later definition', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('First paragraph [first][1]\n\nSecond paragraph [first][1]', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+      expect(container.querySelector('a[href="https://example.com"]')).toBeNull();
+
+      renderer.next('\n\n[1]: https://example.com "Example"', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+      expect(container.querySelectorAll('a[href="https://example.com"]').length).toBe(1);
+      expect(container.querySelector('a[href="https://example.com"]')?.textContent).toBe('first');
+    });
+
+    test('should extract link definitions when active tail grows', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('See [link][1]\n\n', nextOptions());
+      renderer.next('[1]: https://example.com "Example"', nextOptions());
+
+      expect(getSentinel(container)).not.toBeNull();
+      expect(container.querySelector('a[href="https://example.com"]')?.textContent).toBe('link');
+
+      const { definitions } = renderer.finalize(nextOptions());
+
+      expect(definitions).toEqual([
+        expect.objectContaining({ identifier: '1', url: 'https://example.com', title: 'Example' })
+      ]);
+    });
+
+    test('should extract link definitions when definition block becomes committed', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('See [link][1]\n\n', nextOptions());
+      renderer.next('[1]: https://example.com "Example"\n\nTrailing', nextOptions());
+
+      const split = splitBySentinel(container);
+
+      expect(split).not.toBeNull();
+      expect(split![1]).toBe('<p>Trailing</p>');
+      expect(container.querySelector('a[href="https://example.com"]')?.textContent).toBe('link');
+
+      const { definitions } = renderer.finalize(nextOptions());
+
+      expect(definitions).toEqual([
+        expect.objectContaining({ identifier: '1', url: 'https://example.com', title: 'Example' })
+      ]);
+    });
+
+    test('should extract definitions across committed and active paragraphs with shared link definitions', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next(
+        'First paragraph [first][1]\n\n[1]: https://example.com "Example"\n\n' +
+          'Second paragraph [first][1] [second][2]\n\n',
+        nextOptions()
+      );
+
+      expect(getWrapperHTML(container)).toContain('First paragraph');
+      expect(getWrapperHTML(container)).toContain('Second paragraph');
+
+      expect(container.querySelectorAll('a[href="https://example.com"]').length).toBe(2);
+      expect(container.querySelector('a[href="https://example.org"]')).toBeNull();
+
+      renderer.next('[2]: https://example.org "Other"', nextOptions());
+
+      expect(container.querySelector('a[href="https://example.org"]')?.textContent).toBe('second');
+
+      const { definitions } = renderer.finalize(nextOptions());
+
+      expect(definitions).toEqual([
+        expect.objectContaining({ identifier: '1', url: 'https://example.com', title: 'Example' }),
+        expect.objectContaining({ identifier: '2', url: 'https://example.org', title: 'Other' })
+      ]);
+    });
+
+    test('should preserve definitions for later blocks committed through incremental boundary', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next(
+        ['First [first][1]\n\n[1]: https://example.com "Example"\n\n', 'Second [first][1]\n\n'].join(''),
+        nextOptions()
+      );
+
+      expect(container.querySelectorAll('a[href="https://example.com"]').length).toBe(2);
+      expect(getSentinel(container)).not.toBeNull();
+
+      renderer.next('Third [first][1]', nextOptions());
+
+      expect(container.querySelectorAll('a[href="https://example.com"]').length).toBe(3);
+
+      const split = splitBySentinel(container);
+
+      expect(split).not.toBeNull();
+      expect(split![0]).toContain('First');
+      expect(split![0]).toContain('Second');
+      expect(split![1]).toContain('Third');
+      expect(container.querySelectorAll('a[href="https://example.com"]').length).toBe(3);
+      expect(container.querySelectorAll('a[href="https://example.com"]').item(0)?.textContent).toBe('first');
+    });
+
+    test('should extract link definitions after streaming content', () => {
+      const { container, nextOptions, renderer } = setup();
+
+      renderer.next('See [link][1]\n\n', nextOptions());
+      renderer.next('[1]: https://example.com "Example"', nextOptions());
+
+      const { definitions } = renderer.finalize(nextOptions());
+
+      expect(definitions).toEqual([
+        expect.objectContaining({ identifier: '1', url: 'https://example.com', title: 'Example' })
+      ]);
+
+      const linkElement = container.querySelector('a[href="https://example.com"]');
+
+      expect(linkElement).not.toBeNull();
+      expect(linkElement?.textContent).toBe('link');
     });
   });
 

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -173,6 +173,7 @@ export default function createStreamingRenderer(
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
 
+    // Ensure definitions are resolved during parse phase
     if (knownDefinitions.size) {
       for (const definition of knownDefinitions) {
         doc.write(prep(definition, undefined, false));
@@ -196,20 +197,27 @@ export default function createStreamingRenderer(
   function commit(block: BlockBoundary): string {
     const compiler = compile(micromarkOptions);
 
-    // Rather than dealing with state restore, parse and fed definitions to compiler before actual markdown
+    // Extract all available definitions to prevent compiler crashes
+    // on definitions appearing after the block boundary.
     extractDefinitions(stepEvents);
-    const doc = parse(micromarkOptions).document();
-    const prep = preprocess();
 
-    for (const definition of knownDefinitions) {
-      doc.write(prep(definition, undefined, false));
+    // Rather than trying to restore compiler state, we parse and fed the definitions
+    // back to the compiler as if they appear in the markdown.
+    if (knownDefinitions.size) {
+      const doc = parse(micromarkOptions).document();
+      const prep = preprocess();
+      for (const definition of knownDefinitions) {
+        doc.write(prep(definition, undefined, false));
+      }
+
+      compiler(postprocess(doc.write(prep('', undefined, true))));
     }
-
-    compiler(postprocess(doc.write(prep('', undefined, true))));
 
     const newCommittedOffset = block.startOffset;
     const newCommittedEvents = stepEvents.filter(([, token]) => token.start.offset < newCommittedOffset);
 
+    // Offset the committed block by the provided boundary start
+    // excluding the offset of definitions upserted during the step.
     lastCommittedBlockEndOffset += newCommittedOffset - lastStepDefinitionOffset;
 
     return compiler(newCommittedEvents);

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -171,23 +171,24 @@ export default function createStreamingRenderer(
 
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
-    const events = [];
 
     if (knownDefinitions.size) {
       for (const definition of knownDefinitions) {
-        events.push(...doc.write(prep(definition, undefined, false)));
+        doc.write(prep(definition, undefined, false));
       }
+
       const lastDefinitionTokenOffset = doc.events.at(-1)?.[1].end.offset;
       if (typeof lastDefinitionTokenOffset !== 'number') {
         throw new Error('Failed to extract definition token offset');
       }
+
       lastStepDefinitionOffset = lastDefinitionTokenOffset;
     } else {
       lastStepDefinitionOffset = 0;
     }
 
     const tailEvents = doc.write(prep(markdownTail, undefined, true));
-    return postprocess(events.concat(tailEvents));
+    return postprocess(tailEvents);
   }
 
   function commit(chunkEvents: Event[], lastBlock: BlockBoundary): string {
@@ -197,14 +198,12 @@ export default function createStreamingRenderer(
     extractDefinitions(chunkEvents);
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
-    const events = [];
 
     for (const definition of knownDefinitions) {
-      events.push(...doc.write(prep(definition, undefined, false)));
+      doc.write(prep(definition, undefined, false));
     }
-    // Compiler wants eof token
-    events.push(...doc.write(prep('', undefined, true)));
-    compiler(postprocess(events));
+
+    compiler(postprocess(doc.write(prep('', undefined, true))));
 
     const newCommittedOffset = lastBlock.startOffset;
     const newCommittedEvents = chunkEvents.filter(([, token]) => token.start.offset < newCommittedOffset);
@@ -219,6 +218,7 @@ export default function createStreamingRenderer(
   }
 
   function cleanup() {
+    revert();
     activeSentinel = null;
     lastCommittedBlockEndOffset = 0;
     knownDefinitions.clear();

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -198,6 +198,7 @@ export default function createStreamingRenderer(
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
     const events = [];
+
     for (const definition of knownDefinitions) {
       events.push(...doc.write(prep(definition, undefined, false)));
     }

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -172,6 +172,7 @@ export default function createStreamingRenderer(
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
     const events = [];
+
     if (knownDefinitions.size) {
       for (const definition of knownDefinitions) {
         events.push(...doc.write(prep(definition, undefined, false)));

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -177,7 +177,7 @@ export default function createStreamingRenderer(
     }
 
     const lastDefinitionTokenOffset = doc.events.at(-1)?.[1].end.offset;
-    lastStepDefinitionOffset = lastDefinitionTokenOffset ? lastDefinitionTokenOffset + 1 : 0;
+    lastStepDefinitionOffset = lastDefinitionTokenOffset || 0;
 
     const tailEvents = doc.write(prep(markdownTail, undefined, true));
     return postprocess(events.concat(tailEvents));

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -235,6 +235,7 @@ export default function createStreamingRenderer(
       cleanup();
 
       const wrapper = ensureWrapper(options.container, options.containerClassName);
+
       wrapper.replaceChildren();
 
       return;
@@ -318,6 +319,7 @@ export default function createStreamingRenderer(
     cleanup();
     const fullEvents = step(processedMarkdown);
     const blocks = findTopLevelBlocks(fullEvents);
+    const wrapper = ensureWrapper(options.container, options.containerClassName);
     const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
 
     try {
@@ -336,8 +338,6 @@ export default function createStreamingRenderer(
 
         activeFragment.append(...Array.from(activeDoc.body.childNodes));
         betterLinkDocumentMod(activeFragment, decorate);
-
-        const wrapper = ensureWrapper(options.container, options.containerClassName);
 
         activeSentinel = document.createComment('');
 
@@ -363,10 +363,7 @@ export default function createStreamingRenderer(
     const fragment = parsedDocument.createDocumentFragment();
 
     fragment.append(...Array.from(parsedDocument.body.childNodes));
-
     betterLinkDocumentMod(fragment, decorate);
-
-    const wrapper = ensureWrapper(options.container, options.containerClassName);
 
     wrapper.replaceChildren(applyTransform(fragment, options.transformFragment));
   }
@@ -391,21 +388,17 @@ export default function createStreamingRenderer(
       const rawHTML = compile(micromarkOptions)(fullEvents);
       const parsedDocument = domParser.parseFromString(rawHTML.trim(), 'text/html');
       const fragment = parsedDocument.createDocumentFragment();
-
-      fragment.append(...Array.from(parsedDocument.body.childNodes));
-
       const definitions = extractDefinitionsFromEvents(fullEvents);
+      const wrapper = ensureWrapper(options.container, options.containerClassName);
       const decorate = createDecorate(definitions, externalLinkAlt);
 
+      fragment.append(...Array.from(parsedDocument.body.childNodes));
       betterLinkDocumentMod(fragment, decorate);
 
       activeSentinel = null;
 
       // Full replace on finalize — no incremental path needed.
-      const wrapper = ensureWrapper(options.container, options.containerClassName);
-      const transformedFragment = applyTransform(fragment, options.transformFragment);
-
-      wrapper.replaceChildren(transformedFragment);
+      wrapper.replaceChildren(applyTransform(fragment, options.transformFragment));
 
       return Object.freeze({ definitions });
     },

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -386,13 +386,14 @@ export default function createStreamingRenderer(
 
       const fullEvents = parseEvents(processedMarkdown);
       const rawHTML = compile(micromarkOptions)(fullEvents);
-      const parsedDocument = domParser.parseFromString(rawHTML.trim(), 'text/html');
-      const fragment = parsedDocument.createDocumentFragment();
+      const finalDoc = domParser.parseFromString(rawHTML.trim(), 'text/html');
+      const fragment = finalDoc.createDocumentFragment();
+
       const definitions = extractDefinitionsFromEvents(fullEvents);
       const wrapper = ensureWrapper(options.container, options.containerClassName);
       const decorate = createDecorate(definitions, externalLinkAlt);
 
-      fragment.append(...Array.from(parsedDocument.body.childNodes));
+      fragment.append(...Array.from(finalDoc.body.childNodes));
       betterLinkDocumentMod(fragment, decorate);
 
       activeSentinel = null;

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -35,6 +35,8 @@ type StreamingRenderer = Readonly<{
   reset: () => void;
 }>;
 
+export const STREAMING_ERROR = Symbol('markdown streaming error');
+
 // Top-level block token types emitted by micromark.
 // An exit event at depth 0 for one of these types marks a committed block boundary.
 const TOP_LEVEL_BLOCK_TYPES: ReadonlySet<string> = new Set([
@@ -77,7 +79,7 @@ function findTopLevelBlocks(events: ReadonlyArray<Event>): readonly BlockBoundar
       depth--;
 
       if (!depth && blocks.length) {
-        blocks[blocks.length - 1].endOffset = token.end.offset;
+        blocks.at(-1).endOffset = token.end.offset;
       }
     }
   }
@@ -108,7 +110,6 @@ export default function createStreamingRenderer(
   const domParser = new DOMParser();
 
   // Parser state.
-  let activeBlockStartOffset = 0;
   let previousMarkdown = '';
   const emptyDefinitions: readonly MarkdownLinkDefinition[] = Object.freeze([]);
 
@@ -149,15 +150,80 @@ export default function createStreamingRenderer(
     return wrapper;
   }
 
+  function setError(error: unknown, wrapper: HTMLElement) {
+    wrapper.dataset.renderError = String(error instanceof Error ? error.message : error);
+    wrapper.dataset.renderErrorCount = String(Number(wrapper.dataset.renderErrorCount || '0') + 1);
+    // eslint-disable-next-line security/detect-object-injection
+    (wrapper as any)[STREAMING_ERROR] = error;
+  }
+
+  const knownDefinitions: Set<string> = new Set();
+  function extractDefinitions(events: ReadonlyArray<Event>) {
+    for (const [action, token, ctx] of events) {
+      token.type === 'definition' && action === 'exit' && knownDefinitions.add(ctx.sliceSerialize(token) + '\n');
+    }
+  }
+
+  let lastStepDefinitionOffset = 0;
+  let lastCommittedBlockEndOffset = 0;
+  function step(markdown: string): Event[] {
+    const markdownTail = markdown.slice(lastCommittedBlockEndOffset);
+
+    const doc = parse(micromarkOptions).document();
+    const prep = preprocess();
+    const events = [];
+    for (const definition of knownDefinitions) {
+      events.push(...doc.write(prep(definition, undefined, false)));
+    }
+
+    const lastDefinitionTokenOffset = doc.events.at(-1)?.[1].end.offset;
+    lastStepDefinitionOffset = lastDefinitionTokenOffset ? lastDefinitionTokenOffset + 1 : 0;
+
+    const tailEvents = doc.write(prep(markdownTail, undefined, true));
+    return postprocess(events.concat(tailEvents));
+  }
+
+  function commit(chunkEvents: Event[], lastBlock: BlockBoundary): string {
+    const compiler = compile(micromarkOptions);
+
+    // Rather than dealing with state restore, parse and fed definitions to compiler before actual markdown
+    extractDefinitions(chunkEvents);
+    const doc = parse(micromarkOptions).document();
+    const prep = preprocess();
+    const events = [];
+    for (const definition of knownDefinitions) {
+      events.push(...doc.write(prep(definition, undefined, false)));
+    }
+    // Compiler wants eof token
+    events.push(...doc.write(prep('', undefined, true)));
+    compiler(postprocess(events));
+
+    const newCommittedOffset = lastBlock.startOffset;
+    const newCommittedEvents = chunkEvents.filter(([, token]) => token.start.offset < newCommittedOffset);
+
+    lastCommittedBlockEndOffset += newCommittedOffset - lastStepDefinitionOffset;
+
+    return compiler(newCommittedEvents);
+  }
+
+  function revert() {
+    lastStepDefinitionOffset = 0;
+  }
+
+  function cleanup() {
+    activeSentinel = null;
+    lastCommittedBlockEndOffset = 0;
+    knownDefinitions.clear();
+  }
+
   function renderNext(chunk: string, options: StreamingNextOptions): void {
+    const isAppend = !!previousMarkdown;
     previousMarkdown += chunk;
 
     if (!previousMarkdown) {
-      activeBlockStartOffset = 0;
-      activeSentinel = null;
+      cleanup();
 
       const wrapper = ensureWrapper(options.container, options.containerClassName);
-
       wrapper.replaceChildren();
 
       return;
@@ -169,129 +235,124 @@ export default function createStreamingRenderer(
       processedMarkdown = respectCRLFPre(processedMarkdown);
     }
 
-    // Incremental path: re-parse only from the last committed block boundary.
-    // Guard: if sentinel was lost (e.g. container changed), fall back to full reparse.
-    if (activeBlockStartOffset > 0) {
-      const wrapper = ensureWrapper(options.container, options.containerClassName);
+    try {
+      // Incremental path: re-parse only from the last committed block boundary.
+      if (isAppend) {
+        const wrapper = ensureWrapper(options.container, options.containerClassName);
 
-      if (activeSentinel && wrapper.contains(activeSentinel)) {
-        const tailEvents = parseEvents(processedMarkdown.slice(activeBlockStartOffset));
-        const tailBlocks = findTopLevelBlocks(tailEvents);
-        const tailHTML = compile(micromarkOptions)(tailEvents);
+        if (activeSentinel && wrapper.contains(activeSentinel)) {
+          const tailEvents = step(processedMarkdown);
+          const tailBlocks = findTopLevelBlocks(tailEvents);
+          const tailHTML = compile(micromarkOptions)(tailEvents);
 
-        if (tailBlocks.length <= 1) {
-          // Fast path: active block grew, no new committed blocks.
-          // Replace only the active zone (after sentinel).
-          const activeDoc = domParser.parseFromString(tailHTML.trim(), 'text/html');
-          const activeFragment = activeDoc.createDocumentFragment();
+          if (tailBlocks.length <= 1) {
+            // Fast path: active block grew, no new committed blocks.
+            // Replace only the active zone (after sentinel).
+            const activeDoc = domParser.parseFromString(tailHTML.trim(), 'text/html');
+            const activeFragment = activeDoc.createDocumentFragment();
 
-          activeFragment.append(...Array.from(activeDoc.body.childNodes));
-          betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
+            activeFragment.append(...Array.from(activeDoc.body.childNodes));
+            betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
 
-          const activeRange = document.createRange();
+            const activeRange = document.createRange();
 
-          activeRange.setStartAfter(activeSentinel);
-          activeRange.setEndAfter(wrapper.lastChild!);
-          activeRange.deleteContents();
+            activeRange.setStartAfter(activeSentinel);
+            activeRange.setEndAfter(wrapper.lastChild!);
+            activeRange.deleteContents();
 
-          wrapper.append(applyTransform(activeFragment, options.transformFragment));
-        } else {
-          // New block boundary in tail: commit newly-finished blocks, replace active.
-          const newActiveOffsetInTail = tailBlocks[tailBlocks.length - 1].startOffset;
-          const committedTailEvents = tailEvents.filter(([, token]) => token.start.offset < newActiveOffsetInTail);
-          const committedTailHTML = compile(micromarkOptions)(committedTailEvents);
+            wrapper.append(applyTransform(activeFragment, options.transformFragment));
+          } else {
+            // New block boundary in tail: commit newly-finished blocks, replace active.
+            const committedTailHTML = commit(tailEvents, tailBlocks.at(-1));
 
-          activeBlockStartOffset += newActiveOffsetInTail;
+            const committedDoc = domParser.parseFromString(committedTailHTML, 'text/html');
+            const committedFragment = committedDoc.createDocumentFragment();
 
-          const committedDoc = domParser.parseFromString(committedTailHTML, 'text/html');
-          const committedFragment = committedDoc.createDocumentFragment();
+            committedFragment.append(...Array.from(committedDoc.body.childNodes));
+            betterLinkDocumentMod(committedFragment, createDecorate(emptyDefinitions, externalLinkAlt));
 
-          committedFragment.append(...Array.from(committedDoc.body.childNodes));
-          betterLinkDocumentMod(committedFragment, createDecorate(emptyDefinitions, externalLinkAlt));
+            const remainingHTML = tailHTML.slice(committedTailHTML.length);
+            const activeDoc = domParser.parseFromString(remainingHTML.trim(), 'text/html');
+            const activeFragment = activeDoc.createDocumentFragment();
 
-          const remainingHTML = tailHTML.slice(committedTailHTML.length);
-          const activeDoc = domParser.parseFromString(remainingHTML.trim(), 'text/html');
-          const activeFragment = activeDoc.createDocumentFragment();
+            activeFragment.append(...Array.from(activeDoc.body.childNodes));
+            betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
 
-          activeFragment.append(...Array.from(activeDoc.body.childNodes));
-          betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
+            // Remove old sentinel and active zone.
+            const tailRange = document.createRange();
 
-          // Remove old sentinel and active zone.
-          const tailRange = document.createRange();
+            tailRange.setStartBefore(activeSentinel);
+            tailRange.setEndAfter(wrapper.lastChild!);
+            tailRange.deleteContents();
 
-          tailRange.setStartBefore(activeSentinel);
-          tailRange.setEndAfter(wrapper.lastChild!);
-          tailRange.deleteContents();
+            // Append newly committed, new sentinel, active.
+            activeSentinel = document.createComment('');
 
-          // Append newly committed, new sentinel, active.
-          activeSentinel = document.createComment('');
+            wrapper.append(
+              applyTransform(committedFragment, options.transformFragment),
+              activeSentinel,
+              applyTransform(activeFragment, options.transformFragment)
+            );
+          }
 
-          wrapper.append(
-            applyTransform(committedFragment, options.transformFragment),
-            activeSentinel,
-            applyTransform(activeFragment, options.transformFragment)
-          );
+          return;
         }
 
-        return;
+        // Sentinel lost — reset and fall through to full reparse.
+        cleanup();
       }
-
-      // Sentinel lost — reset and fall through to full reparse.
-      activeBlockStartOffset = 0;
-      activeSentinel = null;
+    } catch (error) {
+      setError(error, ensureWrapper(options.container, options.containerClassName));
     }
 
     // Full reparse path.
-    const fullEvents = parseEvents(processedMarkdown);
-    const rawHTML = compile(micromarkOptions)(fullEvents);
+    const fullEvents = step(processedMarkdown);
     const blocks = findTopLevelBlocks(fullEvents);
 
-    if (blocks.length >= 2) {
-      const lastBlock = blocks[blocks.length - 1];
+    try {
+      if (blocks.length >= 2) {
+        const lastBlock = blocks.at(-1);
+        const committedHTML = commit(fullEvents, lastBlock);
+        const activeEvents = step(processedMarkdown);
+        const activeHTML = compile(micromarkOptions)(activeEvents);
 
-      activeBlockStartOffset = lastBlock.startOffset;
+        const committedDoc = domParser.parseFromString(committedHTML, 'text/html');
+        const committedFragment = committedDoc.createDocumentFragment();
 
-      // Compile the active (last block) portion first — it is always a single
-      // block and therefore cheap.  Then derive the committed HTML by slicing
-      // the already-compiled full output so that inter-block whitespace
-      // (produced by lineEnding events the compiler only flushes mid-stream)
-      // is preserved in the committed fragment.
-      const activeEvents = fullEvents.filter(([, token]) => token.start.offset >= lastBlock.startOffset);
-      const activeHTML = compile(micromarkOptions)(activeEvents);
-      const committedHTML = rawHTML.slice(0, rawHTML.length - activeHTML.length);
+        committedFragment.append(...Array.from(committedDoc.body.childNodes));
 
-      const committedDoc = domParser.parseFromString(committedHTML, 'text/html');
-      const committedFragment = committedDoc.createDocumentFragment();
+        const activeDoc = domParser.parseFromString(activeHTML.trim(), 'text/html');
+        const activeFragment = activeDoc.createDocumentFragment();
 
-      committedFragment.append(...Array.from(committedDoc.body.childNodes));
+        activeFragment.append(...Array.from(activeDoc.body.childNodes));
 
-      const activeDoc = domParser.parseFromString(activeHTML.trim(), 'text/html');
-      const activeFragment = activeDoc.createDocumentFragment();
+        const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
 
-      activeFragment.append(...Array.from(activeDoc.body.childNodes));
+        betterLinkDocumentMod(committedFragment, decorate);
+        betterLinkDocumentMod(activeFragment, decorate);
 
-      const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
+        const wrapper = ensureWrapper(options.container, options.containerClassName);
 
-      betterLinkDocumentMod(committedFragment, decorate);
-      betterLinkDocumentMod(activeFragment, decorate);
+        activeSentinel = document.createComment('');
 
-      const wrapper = ensureWrapper(options.container, options.containerClassName);
+        wrapper.replaceChildren(
+          applyTransform(committedFragment, options.transformFragment),
+          activeSentinel,
+          applyTransform(activeFragment, options.transformFragment)
+        );
 
-      activeSentinel = document.createComment('');
+        return;
+      }
+    } catch (error) {
+      setError(error, ensureWrapper(options.container, options.containerClassName));
 
-      wrapper.replaceChildren(
-        applyTransform(committedFragment, options.transformFragment),
-        activeSentinel,
-        applyTransform(activeFragment, options.transformFragment)
-      );
-
-      return;
+      cleanup();
     }
 
     // Single block — full replace, no sentinel.
-    activeBlockStartOffset = 0;
     activeSentinel = null;
 
+    const rawHTML = compile(micromarkOptions)(fullEvents);
     const parsedDocument = domParser.parseFromString(rawHTML.trim(), 'text/html');
     const fragment = parsedDocument.createDocumentFragment();
 
@@ -331,7 +392,6 @@ export default function createStreamingRenderer(
 
       betterLinkDocumentMod(fragment, createDecorate(definitions, externalLinkAlt));
 
-      activeBlockStartOffset = 0;
       activeSentinel = null;
 
       // Full replace on finalize — no incremental path needed.
@@ -344,14 +404,16 @@ export default function createStreamingRenderer(
     },
 
     next(chunk: string, options: StreamingNextOptions): void {
-      renderNext(chunk, options);
+      try {
+        renderNext(chunk, options);
+      } finally {
+        revert();
+      }
     },
 
     reset(): void {
       previousMarkdown = '';
-      activeBlockStartOffset = 0;
-      activeSentinel = null;
-      wrapperDiv = null;
+      cleanup();
     }
   });
 }

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -166,6 +166,7 @@ export default function createStreamingRenderer(
 
   let lastStepDefinitionOffset = 0;
   let lastCommittedBlockEndOffset = 0;
+  let stepEvents: Event[] = [];
   function step(markdown: string): Event[] {
     const markdownTail = markdown.slice(lastCommittedBlockEndOffset);
 
@@ -188,14 +189,15 @@ export default function createStreamingRenderer(
     }
 
     const tailEvents = doc.write(prep(markdownTail, undefined, true));
-    return postprocess(tailEvents);
+    stepEvents = postprocess(tailEvents);
+    return stepEvents;
   }
 
-  function commit(chunkEvents: Event[], lastBlock: BlockBoundary): string {
+  function commit(block: BlockBoundary): string {
     const compiler = compile(micromarkOptions);
 
     // Rather than dealing with state restore, parse and fed definitions to compiler before actual markdown
-    extractDefinitions(chunkEvents);
+    extractDefinitions(stepEvents);
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
 
@@ -205,8 +207,8 @@ export default function createStreamingRenderer(
 
     compiler(postprocess(doc.write(prep('', undefined, true))));
 
-    const newCommittedOffset = lastBlock.startOffset;
-    const newCommittedEvents = chunkEvents.filter(([, token]) => token.start.offset < newCommittedOffset);
+    const newCommittedOffset = block.startOffset;
+    const newCommittedEvents = stepEvents.filter(([, token]) => token.start.offset < newCommittedOffset);
 
     lastCommittedBlockEndOffset += newCommittedOffset - lastStepDefinitionOffset;
 
@@ -215,6 +217,7 @@ export default function createStreamingRenderer(
 
   function revert() {
     lastStepDefinitionOffset = 0;
+    stepEvents = [];
   }
 
   function cleanup() {
@@ -251,16 +254,17 @@ export default function createStreamingRenderer(
         if (activeSentinel && wrapper.contains(activeSentinel)) {
           const tailEvents = step(processedMarkdown);
           const tailBlocks = findTopLevelBlocks(tailEvents);
-          const tailHTML = compile(micromarkOptions)(tailEvents);
+          const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
 
           if (tailBlocks.length <= 1) {
             // Fast path: active block grew, no new committed blocks.
             // Replace only the active zone (after sentinel).
+            const tailHTML = compile(micromarkOptions)(tailEvents);
             const activeDoc = domParser.parseFromString(tailHTML.trim(), 'text/html');
             const activeFragment = activeDoc.createDocumentFragment();
 
             activeFragment.append(...Array.from(activeDoc.body.childNodes));
-            betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
+            betterLinkDocumentMod(activeFragment, decorate);
 
             const activeRange = document.createRange();
 
@@ -271,20 +275,20 @@ export default function createStreamingRenderer(
             wrapper.append(applyTransform(activeFragment, options.transformFragment));
           } else {
             // New block boundary in tail: commit newly-finished blocks, replace active.
-            const committedTailHTML = commit(tailEvents, tailBlocks.at(-1));
-
+            const committedTailHTML = commit(tailBlocks.at(-1));
             const committedDoc = domParser.parseFromString(committedTailHTML, 'text/html');
             const committedFragment = committedDoc.createDocumentFragment();
 
-            committedFragment.append(...Array.from(committedDoc.body.childNodes));
-            betterLinkDocumentMod(committedFragment, createDecorate(emptyDefinitions, externalLinkAlt));
-
-            const remainingHTML = tailHTML.slice(committedTailHTML.length);
-            const activeDoc = domParser.parseFromString(remainingHTML.trim(), 'text/html');
+            const activeEvents = step(processedMarkdown);
+            const activeHTML = compile(micromarkOptions)(activeEvents);
+            const activeDoc = domParser.parseFromString(activeHTML.trim(), 'text/html');
             const activeFragment = activeDoc.createDocumentFragment();
 
+            committedFragment.append(...Array.from(committedDoc.body.childNodes));
+            betterLinkDocumentMod(committedFragment, decorate);
+
             activeFragment.append(...Array.from(activeDoc.body.childNodes));
-            betterLinkDocumentMod(activeFragment, createDecorate(emptyDefinitions, externalLinkAlt));
+            betterLinkDocumentMod(activeFragment, decorate);
 
             // Remove old sentinel and active zone.
             const tailRange = document.createRange();
@@ -314,27 +318,23 @@ export default function createStreamingRenderer(
     cleanup();
     const fullEvents = step(processedMarkdown);
     const blocks = findTopLevelBlocks(fullEvents);
+    const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
 
     try {
       if (blocks.length >= 2) {
-        const lastBlock = blocks.at(-1);
-        const committedHTML = commit(fullEvents, lastBlock);
-        const activeEvents = step(processedMarkdown);
-        const activeHTML = compile(micromarkOptions)(activeEvents);
-
+        const committedHTML = commit(blocks.at(-1));
         const committedDoc = domParser.parseFromString(committedHTML, 'text/html');
         const committedFragment = committedDoc.createDocumentFragment();
 
-        committedFragment.append(...Array.from(committedDoc.body.childNodes));
-
+        const activeEvents = step(processedMarkdown);
+        const activeHTML = compile(micromarkOptions)(activeEvents);
         const activeDoc = domParser.parseFromString(activeHTML.trim(), 'text/html');
         const activeFragment = activeDoc.createDocumentFragment();
 
-        activeFragment.append(...Array.from(activeDoc.body.childNodes));
-
-        const decorate = createDecorate(emptyDefinitions, externalLinkAlt);
-
+        committedFragment.append(...Array.from(committedDoc.body.childNodes));
         betterLinkDocumentMod(committedFragment, decorate);
+
+        activeFragment.append(...Array.from(activeDoc.body.childNodes));
         betterLinkDocumentMod(activeFragment, decorate);
 
         const wrapper = ensureWrapper(options.container, options.containerClassName);
@@ -364,7 +364,7 @@ export default function createStreamingRenderer(
 
     fragment.append(...Array.from(parsedDocument.body.childNodes));
 
-    betterLinkDocumentMod(fragment, createDecorate(emptyDefinitions, externalLinkAlt));
+    betterLinkDocumentMod(fragment, decorate);
 
     const wrapper = ensureWrapper(options.container, options.containerClassName);
 
@@ -395,8 +395,9 @@ export default function createStreamingRenderer(
       fragment.append(...Array.from(parsedDocument.body.childNodes));
 
       const definitions = extractDefinitionsFromEvents(fullEvents);
+      const decorate = createDecorate(definitions, externalLinkAlt);
 
-      betterLinkDocumentMod(fragment, createDecorate(definitions, externalLinkAlt));
+      betterLinkDocumentMod(fragment, decorate);
 
       activeSentinel = null;
 

--- a/packages/bundle/src/markdown/createStreamingRenderer.ts
+++ b/packages/bundle/src/markdown/createStreamingRenderer.ts
@@ -172,12 +172,18 @@ export default function createStreamingRenderer(
     const doc = parse(micromarkOptions).document();
     const prep = preprocess();
     const events = [];
-    for (const definition of knownDefinitions) {
-      events.push(...doc.write(prep(definition, undefined, false)));
+    if (knownDefinitions.size) {
+      for (const definition of knownDefinitions) {
+        events.push(...doc.write(prep(definition, undefined, false)));
+      }
+      const lastDefinitionTokenOffset = doc.events.at(-1)?.[1].end.offset;
+      if (typeof lastDefinitionTokenOffset !== 'number') {
+        throw new Error('Failed to extract definition token offset');
+      }
+      lastStepDefinitionOffset = lastDefinitionTokenOffset;
+    } else {
+      lastStepDefinitionOffset = 0;
     }
-
-    const lastDefinitionTokenOffset = doc.events.at(-1)?.[1].end.offset;
-    lastStepDefinitionOffset = lastDefinitionTokenOffset || 0;
 
     const tailEvents = doc.write(prep(markdownTail, undefined, true));
     return postprocess(events.concat(tailEvents));
@@ -297,15 +303,13 @@ export default function createStreamingRenderer(
 
           return;
         }
-
-        // Sentinel lost — reset and fall through to full reparse.
-        cleanup();
       }
     } catch (error) {
       setError(error, ensureWrapper(options.container, options.containerClassName));
     }
 
     // Full reparse path.
+    cleanup();
     const fullEvents = step(processedMarkdown);
     const blocks = findTopLevelBlocks(fullEvents);
 


### PR DESCRIPTION
**Fixes #**

**Changelog Entry**


- 🧪 Added incremental streaming Markdown renderer for livestreaming, in PR [#5799](https://github.com/microsoft/BotFramework-WebChat/pull/5799), by [@OEvgeny](https://github.com/OEvgeny)
   - Fixed streaming Markdown renderer to preserve link reference definitions during incremental rendering and recover on error, in PR [#5808](https://github.com/microsoft/BotFramework-WebChat/pull/5808), by [@OEvgeny](https://github.com/OEvgeny)
 
**Description**

This change stabilizes `createStreamingRenderer` by improving incremental Markdown parsing and adding a fallback on error. It also preserves link reference definitions across streaming commits so links continue to resolve correctly as streamed content grows.

**Design**

The main idea is to fed known definitions back to the parser instead of trying to resume the parser state which is hidden in the closure.

**Specific Changes**

- createStreamingRenderer.ts
  - Added `STREAMING_ERROR` symbol and wrapper error metadata.
  - Added `extractDefinitions`, `step`, `commit`, `cleanup`, and `revert` helper logic.
  - Improved incremental rendering path to preserve definitions and commit newly finished blocks.

- createStreamingRenderer.spec.ts
  - Added coverage for:
    - definition extraction during full reparse,
    - active reference resolution while tail grows,
    - incremental commits with later definitions,
    - shared link definitions across committed and active blocks,
    - definition preservation when blocks become committed.

**Checklist**

- [x] I have added tests and executed them locally
- [x] I have updated CHANGELOG.md
- [x] ~I have updated documentation~

## Review Checklist

> This section is for contributors to review your work.

- [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
- [ ] Browser and platform compatibilities reviewed
- [ ] CSS styles reviewed (minimal rules, no `z-index`)
- [ ] Documents reviewed (docs, samples, live demo)
- [ ] Internationalization reviewed (strings, unit formatting)
- [ ] `package.json` and `package-lock.json` reviewed
- [ ] Security reviewed (no data URIs, check for nonce leak)
- [ ] Tests reviewed (coverage, legitimacy)
