### PR TITLE
Add feedback form override component and host sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ Breaking changes in this release:
       - `import { hooks } from 'botframework-webchat'` should be replaced by `import * as hooks from 'botframework-webchat/hook'`
    - Added target to Chrome 100 and re-enable Lightning CSS for ESM builds, by [@compulim](https://github.com/compulim) in PR [#5602](https://github.com/microsoft/BotFramework-WebChat/pull/5602)
 - Relaxed `role` prop to allow any string instead of ARIA landmark roles, in PR [#5561](https://github.com/microsoft/BotFramework-WebChat/pull/5561), by [@compulim](https://github.com/compulim)
+- Added `renderFeedbackFormOverrideComponent` style option to allow host applications to provide custom feedback form components, in PR [#5818](https://github.com/microsoft/BotFramework-WebChat/pull/5818)
+   - Enables hosts to replace the native feedback form with their own UI via `styleOptions.renderFeedbackFormOverrideComponent`
+   - Feedback buttons remain controlled by Web Chat while form rendering is delegated to the host application
+   - Added sample and integration tests demonstrating custom feedback form implementation
 - Cleaned up `<ThemeProvider>` and various CSS related code, in PR [#5611](https://github.com/microsoft/BotFramework-WebChat/pull/5611), by [@compulim](https://github.com/compulim)
 - (Experimental) Reworked the copilot variant to align with the modern Copilot UX, in PR [#5630](https://github.com/microsoft/BotFramework-WebChat/pull/5630), by [@OEvgeny](https://github.com/OEvgeny), in PR [#5634](https://github.com/microsoft/BotFramework-WebChat/pull/5634), by [@OEvgeny](https://github.com/OEvgeny), in PR [#5656](https://github.com/microsoft/BotFramework-WebChat/pull/5656), by [@OEvgeny](https://github.com/OEvgeny)
    - Added loading animation for `copilot`, and `fluent` variants

--- a/__tests__/html2/feedbackForm/feedback.form.middleware.inline.changeMind.html
+++ b/__tests__/html2/feedbackForm/feedback.form.middleware.inline.changeMind.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <style>
+      dialog {
+        backdrop-filter: blur(2px);
+        border: 2px solid #0078d4;
+        border-radius: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+        padding: 20px;
+        min-width: 300px;
+      }
+
+      dialog::backdrop {
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+    </style>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.production.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js"></script>
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <main id="webchat"></main>
+    <script type="importmap">
+      {
+        "imports": {
+          "@testduet/wait-for": "https://esm.sh/@testduet/wait-for"
+        }
+      }
+    </script>
+    <script type="module">
+      import { waitFor } from '@testduet/wait-for';
+
+      run(async function () {
+        const {
+          React: { createElement, useEffect, useRef },
+          ReactDOM: { render, createPortal },
+          WebChat: { ReactWebChat, testIds }
+        } = window;
+
+        const { directLine, store } = testHelpers.createDirectLineEmulator();
+
+        window.__feedbackOverrideLaunches = [];
+
+        function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
+          const hasLaunchedRef = useRef(false);
+          const dialogRef = useRef(null);
+          const textareaRef = useRef(null);
+
+          const isLike = selectedAction['@type'] === 'LikeAction';
+
+          useEffect(() => {
+            if (!hasLaunchedRef.current) {
+              hasLaunchedRef.current = true;
+              window.__feedbackOverrideLaunches.push(selectedAction['@type']);
+            }
+          }, [selectedAction]);
+
+          useEffect(() => {
+            dialogRef.current?.showModal();
+            setTimeout(() => textareaRef.current?.focus(), 0);
+          }, []);
+
+          const handleDismiss = () => {
+            dialogRef.current?.close();
+            onDismiss();
+          };
+
+          const handleSubmit = () => {
+            dialogRef.current?.close();
+            onSubmit();
+          };
+
+          const dialogElement = createElement(
+            'dialog',
+            { 'data-testid': 'inline feedback override host', ref: dialogRef },
+            createElement(
+              'form',
+              { style: { width: '400px' }, onSubmit: (e) => { e.preventDefault(); handleSubmit(); } },
+              createElement('h2', { style: { margin: '0 0 16px 0', fontSize: '18px' } }, 'Send Feedback'),
+              createElement(
+                'div',
+                { style: { marginBottom: '16px', padding: '12px', backgroundColor: isLike ? '#d4edda' : '#f8d7da', borderRadius: '4px', textAlign: 'center' } },
+                createElement('div', { style: { fontSize: '24px', marginBottom: '8px' } }, isLike ? '👍' : '👎'),
+                createElement('div', { style: { fontWeight: 'bold' } }, isLike ? 'Helpful' : 'Not Helpful')
+              ),
+              createElement(
+                'div',
+                { style: { marginBottom: '16px' } },
+                createElement('label', { style: { display: 'block', marginBottom: '8px', fontWeight: 'bold' } }, 'Tell us more (optional):'),
+                createElement('textarea', {
+                  ref: textareaRef,
+                  'data-testid': 'feedback textarea',
+                  placeholder: 'Please share your thoughts...',
+                  style: {
+                    width: '100%',
+                    height: '100px',
+                    padding: '8px',
+                    fontFamily: 'system-ui, -apple-system, sans-serif',
+                    fontSize: '14px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    boxSizing: 'border-box',
+                    resize: 'none'
+                  }
+                })
+              ),
+              createElement(
+                'div',
+                { style: { display: 'flex', gap: '8px', justifyContent: 'flex-end' } },
+                createElement('button', {
+                  'data-testid': 'inline feedback override cancel',
+                  onClick: handleDismiss,
+                  type: 'button',
+                  style: {
+                    padding: '8px 16px',
+                    backgroundColor: '#f0f0f0',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px'
+                  }
+                }, 'Cancel'),
+                createElement('button', {
+                  'data-testid': 'inline feedback override submit',
+                  type: 'submit',
+                  style: {
+                    padding: '8px 16px',
+                    backgroundColor: '#0078d4',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px'
+                  }
+                }, 'Submit')
+              )
+            )
+          );
+
+          // Render dialog as a portal to the body
+          return createPortal(dialogElement, document.body);
+        }
+
+        render(
+          createElement(ReactWebChat, {
+            directLine,
+            store,
+            styleOptions: {
+              feedbackActionsPlacement: 'activity-actions',
+              renderFeedbackFormOverrideComponent: ({ onDismiss, onSubmit, selectedAction }) =>
+                createElement(InlineFeedbackHost, { onDismiss, onSubmit, selectedAction })
+            }
+          }),
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+
+        await directLine.emulateIncomingActivity({
+          type: 'message',
+          id: 'a-00002',
+          timestamp: 0,
+          text: 'This is a change-mind middleware test message',
+          from: {
+            role: 'bot'
+          },
+          locale: 'en-US',
+          entities: [],
+          channelData: {
+            feedbackLoop: {
+              type: 'default',
+              disclaimer: 'This disclaimer should not be shown by the native form.'
+            }
+          }
+        });
+
+        await pageConditions.numActivitiesShown(1);
+
+        await host.click(pageElements.allByTestId(testIds.feedbackButton)[0]);
+
+        await waitFor(() => expect(document.querySelector('[data-testid="inline feedback override host"]')).toBeTruthy());
+
+        expect(window.__feedbackOverrideLaunches).toEqual(['LikeAction']);
+
+        await host.click(document.querySelector('[data-testid="inline feedback override cancel"]'));
+
+        await waitFor(() => expect(document.querySelector('[data-testid="inline feedback override host"]')).toBeFalsy());
+
+        expect(document.activeElement).toBe(pageElements.allByTestId(testIds.feedbackButton)[0]);
+        expect(Array.from(pageElements.allByTestId(testIds.feedbackButton)).map(element => element.checked)).toEqual([
+          false,
+          false
+        ]);
+
+        await host.click(pageElements.allByTestId(testIds.feedbackButton)[1]);
+
+        await waitFor(() => expect(document.querySelector('[data-testid="inline feedback override host"]')).toBeTruthy());
+
+        expect(window.__feedbackOverrideLaunches).toEqual(['LikeAction', 'DislikeAction']);
+
+        const { activity } = await directLine.actPostActivity(async () => {
+          await host.click(document.querySelector('[data-testid="inline feedback override submit"]'));
+        });
+
+        expect(activity).toEqual(
+          expect.objectContaining({
+            type: 'invoke',
+            name: 'message/submitAction',
+            value: expect.objectContaining({
+              actionName: 'feedback',
+              actionValue: expect.objectContaining({ reaction: 'dislike' })
+            })
+          })
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/__tests__/html2/feedbackForm/feedback.form.middleware.inline.html
+++ b/__tests__/html2/feedbackForm/feedback.form.middleware.inline.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <style>
+      dialog {
+        backdrop-filter: blur(2px);
+        border: 2px solid #0078d4;
+        border-radius: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+        padding: 20px;
+        min-width: 300px;
+      }
+
+      dialog::backdrop {
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+    </style>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.production.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js"></script>
+    <script crossorigin="anonymous" src="/test-harness.js"></script>
+    <script crossorigin="anonymous" src="/test-page-object.js"></script>
+    <script crossorigin="anonymous" src="/__dist__/webchat-es5.js"></script>
+  </head>
+  <body>
+    <main id="webchat"></main>
+    <script type="importmap">
+      {
+        "imports": {
+          "@testduet/wait-for": "https://esm.sh/@testduet/wait-for"
+        }
+      }
+    </script>
+    <script type="module">
+      import { waitFor } from '@testduet/wait-for';
+
+      run(async function () {
+        const {
+          React: { createElement, useEffect, useRef },
+          ReactDOM: { render, createPortal },
+          WebChat: { ReactWebChat, testIds }
+        } = window;
+
+        const { directLine, store } = testHelpers.createDirectLineEmulator();
+
+        window.__feedbackOverrideLaunches = [];
+
+        function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
+          const hasLaunchedRef = useRef(false);
+          const dialogRef = useRef(null);
+          const textareaRef = useRef(null);
+
+          const isLike = selectedAction['@type'] === 'LikeAction';
+
+          useEffect(() => {
+            if (!hasLaunchedRef.current) {
+              hasLaunchedRef.current = true;
+              window.__feedbackOverrideLaunches.push(selectedAction['@type']);
+            }
+          }, [selectedAction]);
+
+          useEffect(() => {
+            dialogRef.current?.showModal();
+            setTimeout(() => textareaRef.current?.focus(), 0);
+          }, []);
+
+          const handleDismiss = () => {
+            dialogRef.current?.close();
+            onDismiss();
+          };
+
+          const handleSubmit = () => {
+            dialogRef.current?.close();
+            onSubmit();
+          };
+
+          const dialogElement = createElement(
+            'dialog',
+            { 'data-testid': 'inline feedback override host', ref: dialogRef },
+            createElement(
+              'form',
+              { style: { width: '400px' }, onSubmit: (e) => { e.preventDefault(); handleSubmit(); } },
+              createElement('h2', { style: { margin: '0 0 16px 0', fontSize: '18px' } }, 'Send Feedback'),
+              createElement(
+                'div',
+                { style: { marginBottom: '16px', padding: '12px', backgroundColor: isLike ? '#d4edda' : '#f8d7da', borderRadius: '4px', textAlign: 'center' } },
+                createElement('div', { style: { fontSize: '24px', marginBottom: '8px' } }, isLike ? '👍' : '👎'),
+                createElement('div', { style: { fontWeight: 'bold' } }, isLike ? 'Helpful' : 'Not Helpful')
+              ),
+              createElement(
+                'div',
+                { style: { marginBottom: '16px' } },
+                createElement('label', { style: { display: 'block', marginBottom: '8px', fontWeight: 'bold' } }, 'Tell us more (optional):'),
+                createElement('textarea', {
+                  ref: textareaRef,
+                  'data-testid': 'feedback textarea',
+                  placeholder: 'Please share your thoughts...',
+                  style: {
+                    width: '100%',
+                    height: '100px',
+                    padding: '8px',
+                    fontFamily: 'system-ui, -apple-system, sans-serif',
+                    fontSize: '14px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    boxSizing: 'border-box',
+                    resize: 'none'
+                  }
+                })
+              ),
+              createElement(
+                'div',
+                { style: { display: 'flex', gap: '8px', justifyContent: 'flex-end' } },
+                createElement('button', {
+                  'data-testid': 'inline feedback override cancel',
+                  onClick: handleDismiss,
+                  type: 'button',
+                  style: {
+                    padding: '8px 16px',
+                    backgroundColor: '#f0f0f0',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px'
+                  }
+                }, 'Cancel'),
+                createElement('button', {
+                  'data-testid': 'inline feedback override submit',
+                  type: 'submit',
+                  style: {
+                    padding: '8px 16px',
+                    backgroundColor: '#0078d4',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px'
+                  }
+                }, 'Submit')
+              )
+            )
+          );
+
+          // Render dialog as a portal to the body
+          return createPortal(dialogElement, document.body);
+        }
+
+        render(
+          createElement(ReactWebChat, {
+            directLine,
+            store,
+            styleOptions: {
+              feedbackActionsPlacement: 'activity-actions',
+              renderFeedbackFormOverrideComponent: ({ onDismiss, onSubmit, selectedAction }) =>
+                createElement(InlineFeedbackHost, { onDismiss, onSubmit, selectedAction })
+            }
+          }),
+          document.getElementById('webchat')
+        );
+
+        await pageConditions.uiConnected();
+
+        await directLine.emulateIncomingActivity({
+          type: 'message',
+          id: 'a-00001',
+          timestamp: 0,
+          text: 'This is a custom feedback middleware test message',
+          from: {
+            role: 'bot'
+          },
+          locale: 'en-US',
+          entities: [],
+          channelData: {
+            feedbackLoop: {
+              type: 'default',
+              disclaimer: 'This disclaimer should not be shown by the native form.'
+            }
+          }
+        });
+
+        await pageConditions.numActivitiesShown(1);
+
+        await host.click(pageElements.allByTestId(testIds.feedbackButton)[0]);
+
+        await waitFor(() => expect(document.querySelector('[data-testid="inline feedback override host"]')).toBeTruthy());
+
+        expect(pageElements.byTestId(testIds.feedbackSendBox)).toBeFalsy();
+        expect(window.__feedbackOverrideLaunches).toEqual(['LikeAction']);
+
+        const { activity } = await directLine.actPostActivity(async () => {
+          await host.click(document.querySelector('[data-testid="inline feedback override submit"]'));
+        });
+
+        expect(activity).toEqual(
+          expect.objectContaining({
+            type: 'invoke',
+            name: 'message/submitAction',
+            value: expect.objectContaining({
+              actionName: 'feedback',
+              actionValue: expect.objectContaining({ reaction: 'like' })
+            })
+          })
+        );
+
+        await host.snapshot('local');
+      });
+    </script>
+  </body>
+</html>

--- a/packages/api/src/StyleOptions.ts
+++ b/packages/api/src/StyleOptions.ts
@@ -1,4 +1,19 @@
-import type { WebChatActivity } from 'botframework-webchat-core';
+import type { ReactNode } from 'react';
+import type { OrgSchemaAction, WebChatActivity } from 'botframework-webchat-core';
+
+/**
+ * Context passed to a host-provided feedback form override component.
+ *
+ * @see StyleOptions.renderFeedbackFormOverrideComponent
+ */
+export type RenderFeedbackFormOverrideComponentContext = {
+  /** The currently selected vote action (e.g., LikeAction or DislikeAction). */
+  selectedAction: OrgSchemaAction;
+  /** Call to submit the currently selected vote. */
+  onSubmit: () => void;
+  /** Call to dismiss/cancel the feedback form. Resets the vote selection. */
+  onDismiss: () => void;
+};
 
 type StyleOptions = {
   /**
@@ -955,6 +970,49 @@ type StyleOptions = {
    * New in 4.19.0.
    */
   feedbackActionsPlacement?: 'activity-actions' | 'activity-status';
+
+  /**
+   * (EXPERIMENTAL) Host-provided feedback form override component.
+   *
+   * When set, replaces the native feedback text form with a host-provided React component.
+   * The native vote buttons (thumbs up/down) still render and manage selection state.
+   * Only the feedback form (text area + submit/cancel) is replaced.
+   *
+   * Useful when the host wants to render an external/imperative feedback surface
+   * (e.g., a portal-mounted dialog or modal owned by the host application). In that
+   * case the host can perform side effects in a hook and return `null` to render
+   * nothing inline within Web Chat.
+   *
+   * The renderer receives an object with the current feedback state and callbacks:
+   * - `selectedAction` — the currently selected vote action
+   * - `onSubmit` — call to submit the currently selected vote. Web Chat will post
+   *   the invoke activity to the bot and mark feedback as submitted.
+   * - `onDismiss` — call to cancel/dismiss the feedback form. Web Chat will clear
+   *   the vote selection so the user can vote again.
+   *
+   * Hosts SHOULD call exactly one of `onSubmit` or `onDismiss` when their external
+   * surface is closed. If neither is called, the bot will not receive the vote and
+   * the thumb will remain selected, preventing the user from re-voting.
+   *
+   * Return a React node to render in place of the native form, or `null` to render nothing.
+   *
+   * @example
+   * // Side-effect-only renderer: launch external dialog, wire its callbacks.
+   * renderFeedbackFormOverrideComponent: ({ selectedAction, onSubmit, onDismiss }) => {
+   *   useEffect(() => {
+   *     openExternalFeedbackDialog({
+   *       onSuccess: () => onSubmit(),
+   *       onCancel:  () => onDismiss(), // clear thumb selection
+   *     });
+   *   }, []);
+   *   return null;
+   * }
+   *
+   * @default undefined (uses native feedback form)
+   *
+   * New in 4.19.0.
+   */
+  renderFeedbackFormOverrideComponent?: (context: RenderFeedbackFormOverrideComponentContext) => ReactNode | null;
 
   /**
    * Use continuous mode for speech recognition. Default to `false`.

--- a/packages/api/src/defaultStyleOptions.ts
+++ b/packages/api/src/defaultStyleOptions.ts
@@ -309,6 +309,7 @@ const DEFAULT_OPTIONS: Required<StyleOptions> = {
   codeBlockTheme: 'github-light-default' as const,
 
   feedbackActionsPlacement: 'activity-status' as const,
+  renderFeedbackFormOverrideComponent: undefined,
 
   // Speech recognition
   speechRecognitionContinuous: false,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -31,7 +31,11 @@ export {
   type SendBoxToolbarMiddlewareRequest
 } from './middleware/SendBoxToolbarMiddleware';
 export { default as normalizeStyleOptions } from './normalizeStyleOptions';
-export { type StrictStyleOptions, type default as StyleOptions } from './StyleOptions';
+export {
+  type RenderFeedbackFormOverrideComponentContext,
+  type StrictStyleOptions,
+  type default as StyleOptions
+} from './StyleOptions';
 export { type ActivityStatusMiddleware, type RenderActivityStatus } from './types/ActivityStatusMiddleware';
 export {
   type AttachmentForScreenReaderComponentFactory,

--- a/packages/component/src/ActivityFeedback/ActivityFeedback.tsx
+++ b/packages/component/src/ActivityFeedback/ActivityFeedback.tsx
@@ -1,5 +1,15 @@
+import { hooks } from 'botframework-webchat-api';
+import type { OrgSchemaAction } from 'botframework-webchat-core';
 import { useStyles } from '@msinternal/botframework-webchat-styles/react';
-import React, { memo, useCallback, useMemo, type FormEventHandler, type KeyboardEventHandler } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useMemo,
+  type Dispatch,
+  type FormEventHandler,
+  type KeyboardEventHandler,
+  type SetStateAction
+} from 'react';
 import { Extract, wrapWith } from 'react-wrap-with';
 import { useRefFrom } from 'use-ref-from';
 
@@ -11,24 +21,41 @@ import useActivityFeedbackHooks from './providers/useActivityFeedbackHooks';
 
 import styles from './private/FeedbackForm.module.css';
 
+const { useStyleOptions } = hooks;
+
+type FeedbackFormOverrideRenderer = (context: {
+  selectedAction: OrgSchemaAction;
+  onSubmit: () => void;
+  onDismiss: () => void;
+}) => React.ReactNode | null;
+
+type FeedbackTextState = readonly [string | undefined, Dispatch<SetStateAction<string | undefined>>];
+type SelectedActionState = readonly [OrgSchemaAction | undefined, (action: OrgSchemaAction | undefined) => void];
+type StyleOptionsWithFeedbackFormOverrideComponent = Readonly<{
+  renderFeedbackFormOverrideComponent?: FeedbackFormOverrideRenderer | undefined;
+}>;
+
 function InternalActivityFeedback() {
   const classNames = useStyles(styles);
 
   const { useActions, useFeedbackText, useFocusFeedbackButton, useHasSubmitted, useSelectedAction, useSubmit } =
     useActivityFeedbackHooks();
 
-  const [_, setFeedbackText] = useFeedbackText();
+  const [_, setFeedbackText] = useFeedbackText() as FeedbackTextState;
   const [actions] = useActions();
   const [hasSubmitted] = useHasSubmitted();
-  const [selectedAction, setSelectedAction] = useSelectedAction();
+  const [selectedAction, setSelectedAction] = useSelectedAction() as SelectedActionState;
   const focusFeedbackButton = useFocusFeedbackButton();
   const submit = useSubmit();
+  const [{ renderFeedbackFormOverrideComponent }] = useStyleOptions() as readonly [
+    StyleOptionsWithFeedbackFormOverrideComponent
+  ];
 
   const firstActionRequireReview = useMemo(() => actions.find(isActionRequireReview), [actions]);
   const selectedActionRef = useRefFrom(selectedAction);
 
   const handleReset = useCallback<FormEventHandler<HTMLFormElement>>(() => {
-    focusFeedbackButton(selectedActionRef.current);
+    selectedActionRef.current && focusFeedbackButton(selectedActionRef.current);
 
     setFeedbackText(undefined);
     setSelectedAction(undefined);
@@ -38,7 +65,7 @@ function InternalActivityFeedback() {
     event => {
       event.preventDefault();
 
-      submit(selectedActionRef.current);
+      selectedActionRef.current && submit(selectedActionRef.current);
     },
     [selectedActionRef, submit]
   );
@@ -61,22 +88,50 @@ function InternalActivityFeedback() {
     [hasSubmitted, selectedAction]
   );
 
+  // Callbacks for custom feedback form renderer.
+  const handleCustomSubmit = useCallback(() => {
+    selectedActionRef.current && submit(selectedActionRef.current);
+  }, [selectedActionRef, submit]);
+
+  const handleCustomDismiss = useCallback(() => {
+    selectedActionRef.current && focusFeedbackButton(selectedActionRef.current);
+
+    setFeedbackText(undefined);
+    setSelectedAction(undefined);
+  }, [focusFeedbackButton, selectedActionRef, setFeedbackText, setSelectedAction]);
+
+  const customFormElement = useMemo(() => {
+    if (!renderFeedbackFormOverrideComponent || !isExpanded || !selectedAction) {
+      return null;
+    }
+
+    return renderFeedbackFormOverrideComponent({
+      selectedAction,
+      onSubmit: handleCustomSubmit,
+      onDismiss: handleCustomDismiss
+    });
+  }, [renderFeedbackFormOverrideComponent, isExpanded, selectedAction, handleCustomSubmit, handleCustomDismiss]);
+
+  if (!actions.length) {
+    return null;
+  }
+
   return (
-    !!actions.length && (
-      <form
-        className={classNames['feedback-form']}
-        onKeyDown={handleKeyDown}
-        onReset={handleReset}
-        onSubmit={handleSubmit}
-      >
-        <FeedbackVoteButtonBar
-          // If one of the action requires review, use radio button for all.
-          buttonAs={firstActionRequireReview ? 'radio' : 'button'}
-        />
-        {/* We put the form outside of the container to let it wrap to next line instead of keeping it the same line as the like/dislike buttons. */}
-        {isExpanded && <FeedbackForm />}
-      </form>
-    )
+    <form
+      className={classNames['feedback-form']}
+      onKeyDown={handleKeyDown}
+      onReset={handleReset}
+      onSubmit={handleSubmit}
+    >
+      <FeedbackVoteButtonBar
+        // If one of the action requires review, use radio button for all.
+        buttonAs={firstActionRequireReview ? 'radio' : 'button'}
+      />
+      {/* We put the form outside of the container to let it wrap to next line instead of keeping it the same line as the like/dislike buttons. */}
+      {isExpanded && !renderFeedbackFormOverrideComponent && <FeedbackForm />}
+      {/* When a host renderFeedbackFormOverrideComponent is provided, skip the native form. */}
+      {isExpanded && renderFeedbackFormOverrideComponent ? customFormElement : null}
+    </form>
   );
 }
 

--- a/packages/component/src/ActivityFeedback/providers/ActivityFeedbackComposer.tsx
+++ b/packages/component/src/ActivityFeedback/providers/ActivityFeedbackComposer.tsx
@@ -163,15 +163,18 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
   useMemo(() => {
     const activeOrCompletedAction = rawActions.find(
       (action): action is OrgSchemaAction & { actionStatus: 'ActiveActionStatus' | 'CompletedActionStatus' } =>
-        action.actionStatus === 'ActiveActionStatus' || action.actionStatus === 'CompletedActionStatus'
+        !!action['@id'] &&
+        (action.actionStatus === 'ActiveActionStatus' || action.actionStatus === 'CompletedActionStatus')
     );
+    const activeOrCompletedActionId = activeOrCompletedAction?.['@id'];
 
-    actionStateRef.current = activeOrCompletedAction
-      ? {
-          actionId: activeOrCompletedAction['@id'],
-          actionStatus: activeOrCompletedAction.actionStatus
-        }
-      : undefined;
+    actionStateRef.current =
+      activeOrCompletedAction && activeOrCompletedActionId
+        ? {
+            actionId: activeOrCompletedActionId,
+            actionStatus: activeOrCompletedAction.actionStatus
+          }
+        : undefined;
   }, [rawActions]);
 
   // Workaround ESLint on saying actionStateRef.current is redundant when using it directly.
@@ -204,6 +207,10 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
 
   const submit = useCallback(
     (action: OrgSchemaAction) => {
+      if (!action['@id']) {
+        return console.warn('botframework-webchat internal: Cannot submit an action without id, ignoring the call.');
+      }
+
       if (actionStateRef.current?.actionStatus === 'CompletedActionStatus') {
         return console.warn(
           'botframework-webchat internal: useFeedbackActions().submitCallback() must not be called after feedback is completed, ignoring the call.'
@@ -257,6 +264,10 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
 
   const setSelectedAction = useCallback(
     (action: OrgSchemaAction | undefined) => {
+      if (action && !action['@id']) {
+        return console.warn('botframework-webchat internal: Cannot select an action without id, ignoring the call.');
+      }
+
       // If the action require a UserReview, do not allow resubmit.
       const shouldAllowResubmit = canActionResubmit(action);
 
@@ -270,10 +281,12 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
         );
       }
 
+      const selectedActionId = action?.['@id'];
+
       setActionStateWithRefresh(
-        action
+        selectedActionId
           ? Object.freeze({
-              actionId: action['@id'],
+              actionId: selectedActionId,
               actionStatus: 'ActiveActionStatus'
             })
           : undefined
@@ -283,10 +296,11 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
         clearTimeout(autoSubmitTimeoutRef.current);
 
         if (action?.['@id']) {
-          autoSubmitTimeoutRef.current = setTimeout(
-            () => submit(actionsRef.current.find(({ '@id': id }) => id === action['@id'])),
-            DEBOUNCE_TIMEOUT
-          );
+          autoSubmitTimeoutRef.current = setTimeout(() => {
+            const actionToSubmit = actionsRef.current.find(({ '@id': id }) => id === action['@id']);
+
+            actionToSubmit && submit(actionToSubmit);
+          }, DEBOUNCE_TIMEOUT);
         }
       }
     },
@@ -294,7 +308,11 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
   );
 
   const selectedActionState = useMemo<readonly [OrgSchemaAction, (action: OrgSchemaAction) => void]>(
-    () => Object.freeze([selectedAction, setSelectedAction]),
+    () =>
+      Object.freeze([selectedAction, setSelectedAction]) as readonly [
+        OrgSchemaAction,
+        (action: OrgSchemaAction) => void
+      ],
     [selectedAction, setSelectedAction]
   );
 
@@ -304,7 +322,7 @@ function ActivityFeedbackComposer(props: ActivityFeedbackComposerProps) {
   );
 
   const feedbackTextState = useMemo<readonly [string, Dispatch<SetStateAction<string>>]>(
-    () => Object.freeze([feedbackText, setFeedbackText]),
+    () => Object.freeze([feedbackText, setFeedbackText]) as readonly [string, Dispatch<SetStateAction<string>>],
     [feedbackText, setFeedbackText]
   );
 

--- a/samples/05.custom-components/h.feedback-form/README.md
+++ b/samples/05.custom-components/h.feedback-form/README.md
@@ -1,0 +1,281 @@
+# Sample - Replace the native feedback form with an inline host component
+
+This sample shows how to keep Web Chat's native thumbs up/down behavior while replacing the native feedback form with a host-provided inline component mounted through `styleOptions.renderFeedbackFormOverrideComponent`.
+
+The inline component simulates a third-party feedback library that only mounts when the user clicks a feedback button. The host component receives Web Chat callbacks and imperatively mounts the third-party UI when the component appears.
+
+# Test out the hosted sample
+
+-  [Try out MockBot](https://microsoft.github.io/BotFramework-WebChat/05.custom-components/h.feedback-form)
+
+# How to run locally
+
+-  Fork this repository
+-  Navigate to `/Your-Local-WebChat/samples/05.custom-components/h.feedback-form` in command line
+-  Run `npx serve`
+-  Browse to [http://localhost:5000/](http://localhost:5000/)
+
+# Things to try out
+
+-  Type `help`
+   -  Click thumbs up or thumbs down on the bot reply
+   -  Observe the inline feedback host replacing the native textarea form
+-  Submit feedback from the simulated third-party widget
+  -  Observe Web Chat still submit the existing feedback invoke payload for the selected vote
+
+# Code
+
+> Jump to [completed code](#completed-code) to see the end-result `index.html`.
+
+## Overview
+
+First, define a simulated third-party library API that mounts into a DOM node imperatively.
+
+```js
+function handleFeedbackSubmitClick({ container, onCancel, onSubmit, reaction }) {
+  function ThirdPartyFeedback() {
+    return (
+      <div className="thirdPartyFeedback">
+        <h2 className="thirdPartyFeedback__header">Third-party feedback</h2>
+        <p className="thirdPartyFeedback__body">You selected {reaction}.</p>
+        <div className="thirdPartyFeedback__buttonBar">
+          <button className="thirdPartyFeedback__button" onClick={onSubmit} type="button">
+            Submit feedback
+          </button>
+          <button className="thirdPartyFeedback__button thirdPartyFeedback__button--secondary" onClick={onCancel} type="button">
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  ReactDOM.render(<ThirdPartyFeedback />, container);
+
+  return () => ReactDOM.unmountComponentAtNode(container);
+}
+```
+
+Next, build an inline host component that receives the override context from `styleOptions.renderFeedbackFormOverrideComponent`. When it mounts, it calls the third-party API once and maps Web Chat helpers to the third-party callbacks.
+
+```js
+function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
+  const containerRef = React.useRef(null);
+  const hasMountedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!containerRef.current || hasMountedRef.current) {
+      return;
+    }
+
+    hasMountedRef.current = true;
+
+    const dispose = handleFeedbackSubmitClick({
+      container: containerRef.current,
+      onCancel: onDismiss,
+      onSubmit,
+      reaction: selectedAction['@type'] === 'LikeAction' ? 'like' : 'dislike'
+    });
+
+    return dispose;
+  }, [onDismiss, onSubmit, selectedAction]);
+
+  return <div className="thirdPartyFeedbackHost" ref={containerRef} />;
+}
+```
+
+Then, pass the override renderer into `ReactWebChat`. Web Chat will still own the thumbs buttons and selected-action state. The override only replaces the expanded form area.
+
+```js
+ReactDOM.render(
+  <ReactWebChat
+    directLine={window.WebChat.createDirectLine({ token })}
+    styleOptions={{
+      feedbackActionsPlacement: 'activity-actions',
+      renderFeedbackFormOverrideComponent: ({ onDismiss, onSubmit, selectedAction }) => (
+        <InlineFeedbackHost
+          onDismiss={onDismiss}
+          onSubmit={onSubmit}
+          selectedAction={selectedAction}
+        />
+      )
+    }}
+  />,
+  document.getElementById('webchat')
+);
+```
+
+## Completed code
+
+<!-- prettier-ignore-start -->
+```html
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <title>Web Chat: Replace the native feedback form with an inline host component</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone@7.8.7/babel.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js"></script>
+    <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+    <style>
+      html,
+      body {
+        height: 100%;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      #webchat {
+        height: 100%;
+        width: 100%;
+      }
+
+      .thirdPartyFeedbackHost {
+        margin-top: 8px;
+      }
+
+      .thirdPartyFeedback {
+        background: #f5f8ff;
+        border: solid 1px #c7d2fe;
+        border-radius: 8px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px;
+      }
+
+      .thirdPartyFeedback__header {
+        font: 600 14px/1.4 'Segoe UI', Arial, sans-serif;
+        margin: 0;
+      }
+
+      .thirdPartyFeedback__textarea {
+        border: solid 1px #93a4ff;
+        border-radius: 4px;
+        font: 14px/1.4 'Segoe UI', Arial, sans-serif;
+        min-height: 84px;
+        padding: 8px;
+        resize: vertical;
+      }
+
+      .thirdPartyFeedback__buttonBar {
+        display: flex;
+        gap: 8px;
+      }
+
+      .thirdPartyFeedback__button {
+        background: #2946d1;
+        border: 0;
+        border-radius: 4px;
+        color: White;
+        cursor: pointer;
+        font: 600 13px/1 'Segoe UI', Arial, sans-serif;
+        padding: 10px 12px;
+      }
+
+      .thirdPartyFeedback__button--secondary {
+        background: #dbe3ff;
+        color: #1f2a5c;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="webchat" role="main"></div>
+    <script type="text/babel" data-presets="es2015,react,stage-3">
+      (async function () {
+        const { ReactWebChat } = window.WebChat;
+        const { useEffect, useRef, useState } = window.React;
+
+        function handleFeedbackSubmitClick({ container, onCancel, onSubmit, reaction }) {
+          function ThirdPartyFeedback() {
+            return (
+              <div className="thirdPartyFeedback">
+                <h2 className="thirdPartyFeedback__header">Third-party feedback</h2>
+                <p className="thirdPartyFeedback__body">You selected {reaction}.</p>
+                <div className="thirdPartyFeedback__buttonBar">
+                  <button className="thirdPartyFeedback__button" onClick={onSubmit} type="button">
+                    Submit feedback
+                  </button>
+                  <button
+                    className="thirdPartyFeedback__button thirdPartyFeedback__button--secondary"
+                    onClick={onCancel}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            );
+          }
+
+          window.ReactDOM.render(<ThirdPartyFeedback />, container);
+
+          return () => window.ReactDOM.unmountComponentAtNode(container);
+        }
+
+        function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
+          const containerRef = useRef(null);
+          const hasMountedRef = useRef(false);
+
+          useEffect(() => {
+            if (!containerRef.current || hasMountedRef.current) {
+              return;
+            }
+
+            hasMountedRef.current = true;
+
+            const dispose = handleFeedbackSubmitClick({
+              container: containerRef.current,
+              onCancel: onDismiss,
+              onSubmit,
+              reaction: selectedAction['@type'] === 'LikeAction' ? 'like' : 'dislike'
+            });
+
+            return dispose;
+          }, [onDismiss, onSubmit, selectedAction]);
+
+          return <div className="thirdPartyFeedbackHost" ref={containerRef} />;
+        }
+
+        const res = await fetch(
+          'https://hawo-mockbot4-token-app.ambitiousflower-67725bfd.westus.azurecontainerapps.io/api/token/directline',
+          { method: 'POST' }
+        );
+        const { token } = await res.json();
+
+        window.ReactDOM.render(
+          <ReactWebChat
+            directLine={window.WebChat.createDirectLine({ token })}
+            styleOptions={{
+              feedbackActionsPlacement: 'activity-actions',
+              renderFeedbackFormOverrideComponent: ({ onDismiss, onSubmit, selectedAction }) => (
+                <InlineFeedbackHost
+                  onDismiss={onDismiss}
+                  onSubmit={onSubmit}
+                  selectedAction={selectedAction}
+                />
+              )
+            }}
+          />,
+          document.getElementById('webchat')
+        );
+
+        document.querySelector('#webchat > *').focus();
+      })().catch(err => console.error(err));
+    </script>
+  </body>
+</html>
+```
+<!-- prettier-ignore-end -->
+
+# Further reading
+
+-  [Activity status middleware sample](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples/05.custom-components/g.activity-status)
+
+## Full list of Web Chat hosted samples
+
+View the list of [available Web Chat samples](https://github.com/microsoft/BotFramework-WebChat/tree/main/samples)

--- a/samples/05.custom-components/h.feedback-form/README.md
+++ b/samples/05.custom-components/h.feedback-form/README.md
@@ -21,7 +21,7 @@ The inline component simulates a third-party feedback library that only mounts w
    -  Click thumbs up or thumbs down on the bot reply
    -  Observe the inline feedback host replacing the native textarea form
 -  Submit feedback from the simulated third-party widget
-  -  Observe Web Chat still submit the existing feedback invoke payload for the selected vote
+  -  Observe Web Chat still submits the existing feedback invoke payload for the selected vote
 
 # Code
 
@@ -188,7 +188,7 @@ ReactDOM.render(
     <script type="text/babel" data-presets="es2015,react,stage-3">
       (async function () {
         const { ReactWebChat } = window.WebChat;
-        const { useEffect, useRef, useState } = window.React;
+        const { useEffect, useRef } = window.React;
 
         function handleFeedbackSubmitClick({ container, onCancel, onSubmit, reaction }) {
           function ThirdPartyFeedback() {

--- a/samples/05.custom-components/h.feedback-form/index.html
+++ b/samples/05.custom-components/h.feedback-form/index.html
@@ -117,14 +117,11 @@
 
         function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
           const containerRef = useRef(null);
-          const hasMountedRef = useRef(false);
 
           useEffect(() => {
-            if (!containerRef.current || hasMountedRef.current) {
+            if (!containerRef.current) {
               return;
             }
-
-            hasMountedRef.current = true;
 
             const dispose = handleFeedbackSubmitClick({
               container: containerRef.current,

--- a/samples/05.custom-components/h.feedback-form/index.html
+++ b/samples/05.custom-components/h.feedback-form/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <title>Web Chat: Replace the native feedback form with an inline host component</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      For simplicity and code clarity, we are using Babel and React from unpkg.com.
+    -->
+    <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone@7.8.7/babel.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js"></script>
+    <!--
+      This CDN points to the latest official release of Web Chat. If you need to test against Web Chat's latest bits, please refer to using Web Chat's latest bits:
+      https://github.com/microsoft/BotFramework-WebChat#how-to-test-with-web-chats-latest-bits
+    -->
+    <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+    <style>
+      html,
+      body {
+        height: 100%;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      #webchat {
+        height: 100%;
+        width: 100%;
+      }
+
+      .thirdPartyFeedbackHost {
+        margin-top: 8px;
+      }
+
+      .thirdPartyFeedback {
+        background: #f5f8ff;
+        border: solid 1px #c7d2fe;
+        border-radius: 8px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px;
+      }
+
+      .thirdPartyFeedback__header {
+        font: 600 14px/1.4 'Segoe UI', Arial, sans-serif;
+        margin: 0;
+      }
+
+      .thirdPartyFeedback__body {
+        color: #1f2a5c;
+        font: 14px/1.4 'Segoe UI', Arial, sans-serif;
+        margin: 0;
+      }
+
+      .thirdPartyFeedback__buttonBar {
+        display: flex;
+        gap: 8px;
+      }
+
+      .thirdPartyFeedback__button {
+        background: #2946d1;
+        border: 0;
+        border-radius: 4px;
+        color: White;
+        cursor: pointer;
+        font: 600 13px/1 'Segoe UI', Arial, sans-serif;
+        padding: 10px 12px;
+      }
+
+      .thirdPartyFeedback__button--secondary {
+        background: #dbe3ff;
+        color: #1f2a5c;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="webchat" role="main"></div>
+    <script type="text/babel" data-presets="es2015,react,stage-3">
+      (async function () {
+        // In this demo, we are using Direct Line token from MockBot.
+        // Your client code must provide either a secret or a token to talk to your bot.
+        // Tokens are more secure. To learn about the differences between secrets and tokens
+        // and to understand the risks associated with using secrets, visit https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication?view=azure-bot-service-4.0
+
+        const { ReactWebChat } = window.WebChat;
+        const { useEffect, useRef } = window.React;
+
+        function handleFeedbackSubmitClick({ container, onCancel, onSubmit, reaction }) {
+          function ThirdPartyFeedback() {
+            return (
+              <div className="thirdPartyFeedback">
+                <h2 className="thirdPartyFeedback__header">Third-party feedback</h2>
+                <p className="thirdPartyFeedback__body">You selected {reaction}.</p>
+                <div className="thirdPartyFeedback__buttonBar">
+                  <button className="thirdPartyFeedback__button" onClick={onSubmit} type="button">
+                    Submit feedback
+                  </button>
+                  <button
+                    className="thirdPartyFeedback__button thirdPartyFeedback__button--secondary"
+                    onClick={onCancel}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            );
+          }
+
+          window.ReactDOM.render(<ThirdPartyFeedback />, container);
+
+          return () => window.ReactDOM.unmountComponentAtNode(container);
+        }
+
+        function InlineFeedbackHost({ onDismiss, onSubmit, selectedAction }) {
+          const containerRef = useRef(null);
+          const hasMountedRef = useRef(false);
+
+          useEffect(() => {
+            if (!containerRef.current || hasMountedRef.current) {
+              return;
+            }
+
+            hasMountedRef.current = true;
+
+            const dispose = handleFeedbackSubmitClick({
+              container: containerRef.current,
+              onCancel: onDismiss,
+              onSubmit,
+              reaction: selectedAction['@type'] === 'LikeAction' ? 'like' : 'dislike'
+            });
+
+            return dispose;
+          }, [onDismiss, onSubmit, selectedAction]);
+
+          return <div className="thirdPartyFeedbackHost" ref={containerRef} />;
+        }
+
+        const res = await fetch(
+          'https://hawo-mockbot4-token-app.ambitiousflower-67725bfd.westus.azurecontainerapps.io/api/token/directline',
+          { method: 'POST' }
+        );
+        const { token } = await res.json();
+
+        window.ReactDOM.render(
+          <ReactWebChat
+            directLine={window.WebChat.createDirectLine({ token })}
+            styleOptions={{
+              feedbackActionsPlacement: 'activity-actions',
+              renderFeedbackFormOverrideComponent: ({ onDismiss, onSubmit, selectedAction }) => (
+                <InlineFeedbackHost
+                  onDismiss={onDismiss}
+                  onSubmit={onSubmit}
+                  selectedAction={selectedAction}
+                />
+              )
+            }}
+          />,
+          document.getElementById('webchat')
+        );
+
+        document.querySelector('#webchat > *').focus();
+      })().catch(err => console.error(err));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Please provide the issue number here if any -->

> Fixes #

## Changelog Entry

- Added `renderFeedbackFormOverrideComponent` style option to allow host applications to provide custom feedback form components, in PR [#5818](https://github.com/microsoft/BotFramework-WebChat/pull/5818)
   - Enables hosts to replace the native feedback form with their own UI via `styleOptions.renderFeedbackFormOverrideComponent`
   - Feedback buttons remain controlled by Web Chat while form rendering is delegated to the host application
   - Added sample and integration tests demonstrating custom feedback form implementation

## Description

Adds simple conditional mount native or mount custom feedback form.

Allows the host to override feedback form and replace it with a host provided custom feedback form. 

Host will continue using the existing thumbs up/down voting buttons per activity to trigger feedback form mount.

Prime example is shown below. In this example, the host is forced to use a 3rd party library that emits a Dialog that collects feedback. The E2E test has been slowed down so that we can see the dialog taking effect.

<img width="503" height="1080" alt="WebChat_feedbackFormOverride" src="https://github.com/user-attachments/assets/841b05a6-49f6-4ad7-8674-faf07c95f109" />

## Design

NA

## Specific Changes

NA

- 

<!-- For bugs, add the bug repro as a test. Otherwise, add tests to futureproof your work. -->

- [X] I have added tests and executed them locally
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated documentation

## Review Checklist

> This section is for contributors to review your work.

- [ ] Accessibility reviewed (tab order, content readability, alt text, color contrast)
- [ ] Browser and platform compatibilities reviewed
- [ ] CSS styles reviewed (minimal rules, no `z-index`)
- [ ] Documents reviewed (docs, samples, live demo)
- [ ] Internationalization reviewed (strings, unit formatting)
- [ ] `package.json` and `package-lock.json` reviewed
- [ ] Security reviewed (no data URIs, check for nonce leak)
- [ ] Tests reviewed (coverage, legitimacy)
